### PR TITLE
feat(health-check): auto-derive LATEST_TAG from latest GitHub release (#39)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -145,7 +145,7 @@ A separate CI gate, `.github/workflows/manifest-check.yml`, runs `build-manifest
 
 ### Continuous health monitoring
 
-`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the latest tag, validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. Update the `LATEST_TAG` env var in that workflow whenever a new release is tagged so the lock-file probe stays current.
+`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the **latest published GitHub release** (auto-derived via `gh api repos/.../releases/latest --jq .tag_name`; see Issue #39), validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. No manual `LATEST_TAG` bump is required after a release; see `DEPLOYMENT-GUIDE.md` "Post-Release Operations" for the full checklist.
 
 **Critical:** `site-docs/solutions/*/` is **gitignored** and regenerated on every build. Manual edits to those files are discarded. Never edit under `site-docs/solutions/{slug}/` directly.
 

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -17,10 +17,29 @@ jobs:
   ping:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve latest release tag
+        id: tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Auto-derive LATEST_TAG from the GitHub Releases API so the
+          # health probe always targets the most recently published release
+          # without requiring a manual workflow edit after every tag.
+          # Issue #39: replaces the previous hardcoded `LATEST_TAG: v1.4.x`.
+          tag=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name 2>/dev/null || echo "")
+          if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+            echo "::error::No published release found for ${{ github.repository }}. The health probe requires at least one release; tag the first release before this workflow can run."
+            exit 1
+          fi
+          echo "Resolved LATEST_TAG=$tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
       - name: Probe published surfaces
         id: probe
         env:
-          LATEST_TAG: v1.4.1
+          LATEST_TAG: ${{ steps.tag.outputs.tag }}
         shell: bash
         run: |
           set -u

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,7 @@ A separate CI gate, `.github/workflows/manifest-check.yml`, runs `build-manifest
 
 ### Continuous health monitoring
 
-`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the latest tag (currently `v1.4.1`), validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. Update the `LATEST_TAG` env var in that workflow whenever a new release is tagged so the lock-file probe stays current.
+`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the **latest published GitHub release** (auto-derived via `gh api repos/.../releases/latest --jq .tag_name`; see Issue #39), validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. No manual `LATEST_TAG` bump is required after a release; see `DEPLOYMENT-GUIDE.md` "Post-Release Operations" for the full checklist.
 
 ### To change overview / catalog content
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **`conditional-access-automation` v1.2.2 → v2.0.0** — CAA Dataverse schema renamed from underscored snake_case SchemaNames to single-word PascalCase (Issue #36). Customers must drop and recreate the three CAA tables before upgrading. See `conditional-access-automation/CHANGELOG.md` for migration steps. The OData lint workflow (`.github/workflows/odata-lint.yml`) is now `--strict` and the soft-gate is removed.
 - **`cross-solution-integration` v2.0.0 → v2.0.1** — adapts CAA history-table reader to the renamed columns. Now requires CAA v2.0.0+.
 
+### Changed — CI / release ops
+- **`.github/workflows/health-check.yml`** — `LATEST_TAG` is now auto-derived via `gh api repos/.../releases/latest --jq .tag_name` (Issue #39). The previous hardcoded `LATEST_TAG: v1.4.1` env value has been replaced by a "Resolve latest release tag" step. Maintainers no longer need to bump the workflow manually after each release. Fails loudly if no release exists.
+- **`DEPLOYMENT-GUIDE.md`** — added "Post-Release Operations" section documenting the auto-derive mechanism + recommended post-release checklist.
+- Doc references in `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md` updated to reflect the auto-derive behavior.
+
 ### Removed
 - The `# legacy: dev-only` exception in `conditional-access-automation/.ralph-config.json` claiming that underscored SchemaNames were "correct and intentional" has been removed; that statement was incorrect.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ A separate CI gate, `.github/workflows/manifest-check.yml`, runs `build-manifest
 
 ### Continuous health monitoring
 
-`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the latest tag, validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. Update the `LATEST_TAG` env var in that workflow whenever a new release is tagged so the lock-file probe stays current.
+`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the **latest published GitHub release** (auto-derived via `gh api repos/.../releases/latest --jq .tag_name`; see Issue #39), validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. No manual `LATEST_TAG` bump is required after a release; see `DEPLOYMENT-GUIDE.md` "Post-Release Operations" for the full checklist.
 
 **Critical:** `site-docs/solutions/*/` is **gitignored** and regenerated on every build. Manual edits to those files are discarded. Never edit under `site-docs/solutions/{slug}/` directly.
 

--- a/DEPLOYMENT-GUIDE.md
+++ b/DEPLOYMENT-GUIDE.md
@@ -225,9 +225,27 @@ The table below maps each solution to the governance zones (Personal / Team / En
 
 <!-- END:ZONE_ROADMAP -->
 
-## Related Documentation
+## Post-Release Operations
 
-- [Solutions Index](https://judeper.github.io/FSI-AgentGov/reference/solutions-index/) — Detailed descriptions and framework alignment
+After publishing a new tagged release (`vX.Y.Z`), the published-artifact health probe automatically targets the new tag — no manual workflow edit is required.
+
+### Health probe ([`.github/workflows/health-check.yml`](.github/workflows/health-check.yml))
+
+- Runs every 30 minutes on cron and on demand via `gh workflow run health-check.yml`.
+- Probes the published Pages URLs and the raw `solutions.json` at the **latest published GitHub release**, resolved dynamically via `gh api repos/${{ github.repository }}/releases/latest --jq .tag_name`.
+- Validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`).
+- Opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if any check fails.
+
+If the workflow logs `No published release found`, tag and publish at least one release for the repository — the probe requires at least one release to compare against.
+
+### Recommended post-release checklist
+
+1. Tag the release (`git tag -a vX.Y.Z -m "release notes" && git push origin vX.Y.Z`).
+2. Publish a GitHub Release pointing at the tag (the `release.yml` workflow attaches SBOMs + provenance attestations).
+3. Trigger the health probe manually to confirm the new artifacts are reachable: `gh workflow run health-check.yml`.
+4. Update the entry count in `health-check.yml` (currently `35`) only if the manifest count changes; this is the one value still hardcoded.
+
+
 - [Solutions Coverage Gaps](https://judeper.github.io/FSI-AgentGov/reference/solutions-coverage-gaps/) — Coverage analysis across the 78-control baseline
 - [FSI Agent Governance Framework](https://github.com/judeper/FSI-AgentGov) — Full framework documentation
 - [SECURITY.md](https://github.com/judeper/FSI-AgentGov-Solutions/blob/main/SECURITY.md) — Vulnerability disclosure and supported versions


### PR DESCRIPTION
Resolves #39 (stretch / automation goal).

## Change

Replaces the hardcoded `LATEST_TAG: v1.4.1` env in `.github/workflows/health-check.yml` with a new **Resolve latest release tag** step that queries the GitHub Releases API:

```bash
gh api repos/${{ github.repository }}/releases/latest --jq .tag_name
```

The probe step then consumes the resolved tag via job output. After every release, **no manual workflow edit is required** ΓÇö the next scheduled run picks up the new tag automatically. The workflow fails loudly with a clear error message if no published release exists.

## Files

| File | Change |
|---|---|
| `.github/workflows/health-check.yml` | New `Resolve latest release tag` step + probe consumes `steps.tag.outputs.tag` |
| `DEPLOYMENT-GUIDE.md` | New `## Post-Release Operations` section + recommended post-release checklist |
| `AGENTS.md` | Updated "Continuous health monitoring" wording |
| `CLAUDE.md` | Same |
| `.github/copilot-instructions.md` | Same |
| `CHANGELOG.md` (root) | New entry under [Unreleased] |

## Notes

- The hardcoded entry-count check (`count != 35`) is intentionally **left unchanged** ΓÇö that is a separate concern (catalog count) tracked in the Phase 2 `catalog-reconcile-acrd` work item (after `agent-communication-restriction-detector` is added to the catalogs, count becomes 36).
- `permissions: contents: read` already includes the read scope needed for `gh api repos/.../releases/latest`.

## Verification

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/health-check.yml'))"` Γ†' OK
- `python scripts/build-manifest.py --check`         Γ†' exit 0
- `python scripts/lint-odata-columns.py --strict`    Γ†' exit 0

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
