### PR TITLE
chore(catalog): add agent-communication-restriction-detector row to all catalog files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@ Deployable Power Platform solutions for the [FSI Agent Governance Framework](htt
 | action-confirmation-auditor | v1.1.0 | 2.12, 1.10 | HITL confirmation step validation in Copilot Studio agent topics |
 | agent-365-lifecycle-governance | v1.1.3 | 2.3, 1.2, 1.11, 2.1, 2.8, 2.12, 3.1 | Automated lifecycle governance for AI agents using Agent 365 and Entra ID Governance |
 | agent-access-monitor | v1.1.0 | 3.8 | Automated detection of overly permissive agent access configurations |
-|  | 2.17 | Inter-agent communication restriction validation |
+| agent-communication-restriction-detector | v1.1.0 | 2.17 | Detects unauthorized agent-to-agent communication, zone boundary violations, cross-tenant communication, and maker/checker violations in Copilot Studio multi-agent orchestration |
 | agent-knowledge-source-scanner | v1.1.0 | 4.3, 1.4, 1.5 | Item-level permission scanning for agent knowledge source SharePoint libraries |
 | agent-registry-automation | v2.0.0 | 1.2, 1.7, 2.1, 2.13 | Automated discovery, registration, approval, and lifecycle governance of AI agents |
 | agent-observability-foundation | v1.2.0 | 1.7, 2.8, 2.9, 3.2 | Foundational observability infrastructure for agent monitoring |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ This file provides guidance for autonomous AI agents working on this repository.
 | action-confirmation-auditor | v1.1.0 | 2.12, 1.10 | HITL confirmation step validation in Copilot Studio agent topics |
 | agent-365-lifecycle-governance | v1.1.3 | 2.3, 1.2, 1.11, 2.1, 2.8, 2.12, 3.1 | Automated lifecycle governance for AI agents using Agent 365 and Entra ID Governance |
 | agent-access-monitor | v1.1.0 | 3.8 | Automated detection of overly permissive agent access configurations |
-|  | 2.17 | Inter-agent communication restriction validation |
+| agent-communication-restriction-detector | v1.1.0 | 2.17 | Detects unauthorized agent-to-agent communication, zone boundary violations, cross-tenant communication, and maker/checker violations in Copilot Studio multi-agent orchestration |
 | agent-knowledge-source-scanner | v1.1.0 | 4.3, 1.4, 1.5 | Item-level permission scanning for agent knowledge source SharePoint libraries |
 | agent-registry-automation | v2.0.0 | 1.2, 1.7, 2.1, 2.13 | Automated discovery, registration, approval, and lifecycle governance of AI agents |
 | agent-observability-foundation | v1.2.0 | 1.7, 2.8, 2.9, 3.2 | Foundational observability infrastructure for agent monitoring |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ git rev-parse --show-toplevel
 | [action-confirmation-auditor](./action-confirmation-auditor/) | HITL confirmation step validation in Copilot Studio agent topics | PowerShell/Python | v1.1.0 |
 | [agent-365-lifecycle-governance](./agent-365-lifecycle-governance/) | Automated lifecycle governance for AI agents using Agent 365 and Entra ID Governance | PowerShell/Python | v1.1.3 |
 | [agent-access-monitor](./agent-access-monitor/) | Automated detection of overly permissive agent access configurations | PowerShell/Python | v1.1.0 |
-| [ |
+| [agent-communication-restriction-detector](./agent-communication-restriction-detector/) | Detects unauthorized agent-to-agent communication, zone boundary violations, and maker/checker violations in Copilot Studio multi-agent orchestration | PowerShell/Python | v1.1.0 |
 | [agent-knowledge-source-scanner](./agent-knowledge-source-scanner/) | Item-level permission scanning for agent knowledge source SharePoint libraries | PowerShell | v1.1.0 |
 | [agent-observability-foundation](./agent-observability-foundation/) | Foundational observability infrastructure for agent monitoring and diagnostics | KQL/Docs | v1.2.0 |
 | [agent-registry-automation](./agent-registry-automation/) | Automated discovery, registration, approval, and lifecycle governance of AI agents | PowerShell/Python | v2.0.0 |


### PR DESCRIPTION
Fills in the broken half-row stub for ACRD in AGENTS.md, CLAUDE.md (Solutions table), and .github/copilot-instructions.md. ACRD's manifest, solutions.json entry, README, and CLAUDE.md's Control Implementations table are already correct.

No functional change. Phase 2 of the 2026-Q2 repo health sweep.