### PR TITLE
chore(manifests): dataClassification audit (issue #37)

### DIFF
--- a/DEPLOYMENT-GUIDE.md
+++ b/DEPLOYMENT-GUIDE.md
@@ -193,7 +193,7 @@ The table below maps each solution to the governance zones (Personal / Team / En
 | [Agent Registry Automation](./agent-registry-automation/) | ✅ | ✅ | ✅ | internal |
 | [Agent Sharing Access Restriction Detector](./agent-sharing-access-restriction-detector/) | — | ✅ | ✅ | confidential |
 | [Audit Compliance Manager](./audit-compliance-manager/) | — | ✅ | ✅ | confidential |
-| [Compliance Dashboard](./compliance-dashboard/) | — | — | ✅ | confidential |
+| [Compliance Dashboard](./compliance-dashboard/) | — | — | ✅ | restricted |
 | [Conditional Access Automation](./conditional-access-automation/) | — | ✅ | ✅ | confidential |
 | [Conflict of Interest Testing](./coi-testing/) | — | ✅ | ✅ | confidential |
 | [Content Moderation Monitor](./content-moderation-monitor/) | ✅ | ✅ | ✅ | internal |
@@ -207,8 +207,8 @@ The table below maps each solution to the governance zones (Personal / Team / En
 | [File Upload Security](./file-upload-security/) | ✅ | ✅ | ✅ | internal |
 | [FINRA Supervision Workflow](./finra-supervision-workflow/) | — | — | ✅ | restricted |
 | [Generative AI Config Auditor](./generative-ai-config-auditor/) | — | ✅ | ✅ | internal |
-| [Hallucination Feedback Tracker](./hallucination-tracker/) | ✅ | ✅ | ✅ | internal |
-| [HITL Workflow Governance](./hitl-workflow-governance/) | ✅ | ✅ | ✅ | internal |
+| [Hallucination Feedback Tracker](./hallucination-tracker/) | ✅ | ✅ | ✅ | confidential |
+| [HITL Workflow Governance](./hitl-workflow-governance/) | ✅ | ✅ | ✅ | confidential |
 | [Inactivity Timeout Enforcement](./inactivity-timeout-enforcement/) | — | ✅ | ✅ | internal |
 | [Message Center Monitor](./message-center-monitor/) | — | — | ✅ | internal |
 | [MIME Type Restrictions for File Uploads](./mime-type-restrictions/) | ✅ | ✅ | ✅ | internal |

--- a/compliance-dashboard/manifest.yaml
+++ b/compliance-dashboard/manifest.yaml
@@ -25,4 +25,4 @@ dependencies:
 #   enterprise reporting across the framework
 zones:
 - enterprise
-dataClassification: confidential
+dataClassification: restricted

--- a/hallucination-tracker/manifest.yaml
+++ b/hallucination-tracker/manifest.yaml
@@ -22,4 +22,4 @@ zones:
 - personal
 - team
 - enterprise
-dataClassification: internal
+dataClassification: confidential

--- a/hitl-workflow-governance/manifest.yaml
+++ b/hitl-workflow-governance/manifest.yaml
@@ -21,4 +21,4 @@ zones:
 - personal
 - team
 - enterprise
-dataClassification: internal
+dataClassification: confidential

--- a/solutions.json
+++ b/solutions.json
@@ -327,7 +327,7 @@
       "zones": [
         "enterprise"
       ],
-      "dataClassification": "confidential"
+      "dataClassification": "restricted"
     },
     "conditional-access-automation": {
       "id": "conditional-access-automation",
@@ -686,7 +686,7 @@
         "team",
         "enterprise"
       ],
-      "dataClassification": "internal"
+      "dataClassification": "confidential"
     },
     "hitl-workflow-governance": {
       "id": "hitl-workflow-governance",
@@ -713,7 +713,7 @@
         "team",
         "enterprise"
       ],
-      "dataClassification": "internal"
+      "dataClassification": "confidential"
     },
     "inactivity-timeout-enforcement": {
       "id": "inactivity-timeout-enforcement",


### PR DESCRIPTION
## Summary

Closes **AC #3** of issue #37 — `dataClassification` field-level audit across all 36 solution manifests.

Audited per the evidence rubric:
- **`restricted`** = stores supervisory or regulatory evidence (FINRA 3110/4511, OCC 2011-12, SR 11-7, SOX 302/404, SEC 17a-4)
- **`confidential`** = stores PII, customer data, RBAC config, credential metadata, identity-bearing governance metadata
- **`internal`** = configuration audit data, governance counters, no customer/PII content

Of the 36 manifests, 33 already had defensible values. Three are promoted in this PR.

## Changes

| Solution | Old | New | Rationale | Manifest line |
|---|---|---|---|---|
| `compliance-dashboard` | confidential | **restricted** | Aggregates FINRA 3120(a)(1) supervisory control reporting, SOX 404 ICFR, and OCC 2011-12 / SR 11-7 model-risk evidence into a central `fsi_complianceevidence` Dataverse table; depends on FINRA Supervision Workflow (which is itself `restricted`). README §"FINRA Rule 3120(a)(1) support", §"OCC Bulletin 2011-12 / FRB SR 11-7 support", §"SOX Section 404 support" make this explicit. | `compliance-dashboard/manifest.yaml:28` |
| `hallucination-tracker` | internal | **confidential** | Collects "customer complaints" (README §5), Microsoft 365 Copilot Product Feedback comments, and supervisor rejections. Per README line 9: "user reactions, feedback comments, supervisor rejections, … customer complaints". Customer comment text is PII / customer-data per rubric. | `hallucination-tracker/manifest.yaml:25` |
| `hitl-workflow-governance` | internal | **confidential** | Stores reviewer / approver identity (control 1.10 mapping: "Reviewer identity, decision context, and timestamp retention"), exception-approval metadata, and SHA-256-hashed evidence packages exported for FINRA 3110, FINRA 4511(a), SEC 17a-3/4, SOX 302/404, GLBA 501(b) examination (README §"Regulatory Context"). Identity-bearing governance metadata fits `confidential`. | `hitl-workflow-governance/manifest.yaml:24` |

## Investigated but unchanged

- **`audit-compliance-manager`** — Stores audit configuration validation history (`AuditValidationHistory`) and SHA-256-hashed configuration evidence. The records describe whether audit logging was correctly configured at scan time, not the underlying SEC 17a-4 retained records themselves. `confidential` (configuration-with-regulatory-implications) is appropriate.
- All other 32 manifests — current values match what the README + manifest description say the solution actually persists.

## Validation

```text
$ python scripts/build-manifest.py --check
INFO: OK: all generated artifacts match manifests.
$ # exit 0
```

Files touched: 3 manifest edits + auto-regenerated `solutions.json` + `DEPLOYMENT-GUIDE.md` (zone roadmap block).

## Notes

- Schema 1.4.2 — `dataClassification` is an optional additive field. No schema bump required.
- All three changed manifests retain their `# zones/dataClassification CONFIRMED 2026-Q2 (issue #37):` marker comment.
- Issue #37 stays open — AC #4 (schema 1.5.0 cutover making `zones` required) is still pending.

Refs #37