### PR TITLE
feat(schema)!: bump solutions.json to 1.5.0 (zones required)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,7 +146,7 @@ A separate CI gate, `.github/workflows/manifest-check.yml`, runs `build-manifest
 
 ### Continuous health monitoring
 
-`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the latest tag, validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. Update the `LATEST_TAG` env var in that workflow whenever a new release is tagged so the lock-file probe stays current.
+`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the **latest published GitHub release** (auto-derived via `gh api repos/{repo}/releases/latest --jq .tag_name`; see Issue #39), validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. No manual `LATEST_TAG` bump is required after a release; see `DEPLOYMENT-GUIDE.md` "Post-Release Operations" for the full checklist.
 
 **Critical:** `site-docs/solutions/*/` is **gitignored** and regenerated on every build. Manual edits to those files are discarded. Never edit under `site-docs/solutions/{slug}/` directly.
 
@@ -161,7 +161,7 @@ Edit files under `{slug}/docs/`. `build-manifest.py` copies them with filename n
 
 ### Schema evolution policy
 
-`solutions.json` schema 1.4.x is **additive-only** (current: **1.4.2**, added optional `zones`/`dataClassification`/`dataResidency`/`retention`). Field renames, new required fields, or shape changes require 1.5.0 with a coordinated `judeper/fsi-agentgov` update — `zones` will become required at that point.
+`solutions.json` schema **1.5.0 (current)**. 1.5.0 made `zones` a **required** field on every solution entry — a breaking change from 1.4.x (which had introduced `zones` as optional in 1.4.2). The framework consumer in `judeper/fsi-agentgov` was widened ahead of this change to accept both 1.4.x and 1.5.x. Future field renames or new required fields require **1.6.0** with a coordinated `judeper/fsi-agentgov` update.
 
 ### Security and release CI
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,7 +230,7 @@ A separate CI gate, `.github/workflows/manifest-check.yml`, runs `build-manifest
 
 ### Continuous health monitoring
 
-`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the latest tag (currently `v1.4.1`), validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. Update the `LATEST_TAG` env var in that workflow whenever a new release is tagged so the lock-file probe stays current.
+`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the **latest published GitHub release** (auto-derived via `gh api repos/{repo}/releases/latest --jq .tag_name`; see Issue #39), validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. No manual `LATEST_TAG` bump is required after a release; see `DEPLOYMENT-GUIDE.md` "Post-Release Operations" for the full checklist.
 
 ### To change overview / catalog content
 
@@ -243,7 +243,7 @@ Edit files under `{slug}/docs/`. `build-manifest.py` copies them into `site-docs
 
 ### Schema evolution policy
 
-`solutions.json` schema 1.4.x is **additive-only**. Optional fields may be added in 1.4.1+ (1.4.2 added `zones`, `dataClassification`, `dataResidency`, `retention` per solution). Field renames, new required fields, or shape changes require **1.5.0** with a coordinated `judeper/fsi-agentgov` update — `zones` becomes required at that point.
+`solutions.json` schema **1.5.0 (current)**. 1.5.0 made `zones` a **required** field on every solution entry — a breaking change from 1.4.x (which had introduced `zones` as optional in 1.4.2). The framework consumer in `judeper/fsi-agentgov` was widened ahead of this change to accept both 1.4.x and 1.5.x. Future field renames or new required fields require **1.6.0** with a coordinated `judeper/fsi-agentgov` update.
 
 ### To verify before committing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased] - 2026-Q2 — Schema 1.5.0 (BREAKING)
+
+### Changed (BREAKING)
+- **schema 1.5.0**: `zones` is now a **required** field on every solution entry in `solutions.json`. Previously optional in 1.4.x (introduced in 1.4.2 as part of the additive zone-backfill). The schema 1.5.0 change is a tightening, not a data change — all 36 catalog solutions already have `zones` populated and confirmed (commit `ce82f83`).
+- **`scripts/manifest.schema.json`**: appended `"zones"` to `required[]`; tightened the field description so it no longer says "Optional in 1.4.2".
+- **`scripts/build-manifest.py`**: emits `schemaVersion: 1.5.0` (was `1.4.2`); `zones` is now projected unconditionally for every solution (was conditional on presence).
+- **`solutions.json`**: regenerated with `schemaVersion: 1.5.0`. No data fields changed for any solution.
+
+### Changed — documentation drift cleanup (same PR)
+- Updated schema-evolution paragraphs in `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md` to describe 1.5.0 as the current schema and 1.6.0 as the next breaking-change line.
+- Replaced stale "Update the `LATEST_TAG` env var" wording in the same three files with the current behavior (auto-derived from `gh api repos/{repo}/releases/latest --jq .tag_name`; see Issue #39).
+
+### Migration
+- Consumers needing the old behavior (e.g., a parser that expects `zones` to possibly be absent) must pin to a 1.4.x release tag. Latest 1.4.x: **`v1.4.1`** (`gh release list --repo judeper/FSI-AgentGov-Solutions`).
+- Consumers parsing `solutions.json` should expect `zones: string[]` (subset of `personal | team | enterprise`, `minItems: 1`) on every solution.
+- The companion validator in `judeper/fsi-agentgov` (`scripts/validate_solutions_lock.py`) was widened in [judeper/fsi-agentgov#195](https://github.com/judeper/fsi-agentgov/pull/195) to accept both 1.4.x and 1.5.x ahead of this change.
+
+### References
+- Closes #37 (AC #4)
+
+---
+
 ## [v1.5.0-preview] - Unreleased — agent-intake MVP (Express path)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,14 +182,14 @@ When writing documentation in this repository, follow the language guidelines fr
 
 The MkDocs site at https://judeper.github.io/FSI-AgentGov-Solutions/ is built in two steps by CI (`.github/workflows/publish_docs.yml`):
 
-1. `python scripts/build-manifest.py` — reads each `<slug>/manifest.yaml` (canonical source of truth), validates against `scripts/manifest.schema.json` and the framework `controls.json` (pinned to `${{ vars.FRAMEWORK_REF || 'v1.4.0' }}` in CI), then emits `solutions.json` (repo root, schemaVersion **1.4.2**), the README solutions table (between `<!-- BEGIN:SOLUTIONS -->` markers), `site-docs/solutions/index.md`, every per-solution detail page at `site-docs/solutions/{slug}/index.md`, `site-docs/reference/control-mapping.md` (all 78 framework controls), the home-page hero metrics block, the deployment-guide `<!-- BEGIN:DEPLOY_LAYERS -->` and `<!-- BEGIN:ZONE_ROADMAP -->` blocks, and copies `{slug}/docs/*.md` with filename normalization (lowercase, hyphens).
+1. `python scripts/build-manifest.py` — reads each `<slug>/manifest.yaml` (canonical source of truth), validates against `scripts/manifest.schema.json` and the framework `controls.json` (pinned to `${{ vars.FRAMEWORK_REF || 'v1.4.0' }}` in CI), then emits `solutions.json` (repo root, schemaVersion **1.5.0**), the README solutions table (between `<!-- BEGIN:SOLUTIONS -->` markers), `site-docs/solutions/index.md`, every per-solution detail page at `site-docs/solutions/{slug}/index.md`, `site-docs/reference/control-mapping.md` (all 78 framework controls), the home-page hero metrics block, the deployment-guide `<!-- BEGIN:DEPLOY_LAYERS -->` and `<!-- BEGIN:ZONE_ROADMAP -->` blocks, and copies `{slug}/docs/*.md` with filename normalization (lowercase, hyphens).
 2. `mkdocs build --strict` — renders the site from `site-docs/`.
 
 A separate CI gate, `.github/workflows/manifest-check.yml`, runs `build-manifest.py --check` on every PR and fails when manifests reference unknown framework control IDs or generated artifacts drift.
 
 ### Continuous health monitoring
 
-`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the latest tag, validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. Update the `LATEST_TAG` env var in that workflow whenever a new release is tagged so the lock-file probe stays current.
+`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the **latest published GitHub release** (auto-derived via `gh api repos/{repo}/releases/latest --jq .tag_name`; see Issue #39), validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. No manual `LATEST_TAG` bump is required after a release.
 
 **Critical:** `site-docs/solutions/*/` is **gitignored** and regenerated on every build. Manual edits to those files are discarded. Never edit under `site-docs/solutions/{slug}/` directly.
 
@@ -204,14 +204,14 @@ Edit files under `{slug}/docs/`. `build-manifest.py` copies them into `site-docs
 
 ### Schema evolution policy
 
-`solutions.json` schema 1.4.x is **additive-only**. Optional fields may be added in 1.4.x+ (1.4.2 added `zones`, `dataClassification`, `dataResidency`, `retention` per solution). Field renames, new required fields, or shape changes require **1.5.0** with a coordinated `judeper/fsi-agentgov` update — this is when `zones` will become required.
+`solutions.json` schema **1.5.0 (current)**. 1.5.0 made `zones` a **required** field on every solution entry — a breaking change from 1.4.x (which had introduced `zones` as optional in 1.4.2). The framework consumer in `judeper/fsi-agentgov` was widened ahead of this change to accept both 1.4.x and 1.5.x. Future field renames or new required fields require **1.6.0** with a coordinated `judeper/fsi-agentgov` update.
 
 ### Manifest fields
 
 `<slug>/manifest.yaml` carries (schema in `scripts/manifest.schema.json`):
 
 - **Required**: `id`, `name`, `description`, `version`, `domain`, `tier`, `controls[]`, `prerequisites[]`, `verification`, `status`.
-- **Optional (1.4.2)**: `zones` (subset of `personal|team|enterprise`), `dataClassification` (`internal|confidential|restricted`), `dataResidency`, `retention`. Backfilled across all 35 solutions with sentinel comments pending product-team confirmation.
+- **Optional (1.4.2)**: `dataClassification` (`internal|confidential|restricted`), `dataResidency`, `retention`. Backfilled across all 36 solutions with sentinel comments pending product-team confirmation. (`zones` was optional in 1.4.2 and became **required** in 1.5.0.)
 
 ### Security and release CI
 

--- a/scripts/build-manifest.py
+++ b/scripts/build-manifest.py
@@ -5,7 +5,7 @@ Walks every top-level folder, loads `manifest.yaml`, and emits the following
 deterministic artifacts from a single source of truth:
 
 * `solutions.json` (committed at repo root) — mirrors the framework
-  `solutions-lock.json` schema 1:1 so `refresh_solutions_lock.py --tag v1.4.x`
+  `solutions-lock.json` schema 1:1 so `refresh_solutions_lock.py --tag v1.5.x`
   in fsi-agentgov can consume the tagged release directly.
 * `README.md` solutions table inside `<!-- BEGIN:SOLUTIONS -->` /
   `<!-- END:SOLUTIONS -->` markers.
@@ -35,25 +35,31 @@ Usage:
 Schema evolution policy
 -----------------------
 
-`solutions.json.schemaVersion` is `1.4.x` for this branch. The contract is
-**additive-only** for the 1.4.x line: new optional fields MAY be introduced
-in 1.4.1+ without bumping the framework lock contract. Any of the following
-require a 1.5.0 bump AND a coordinated PR against fsi-agentgov:
+`solutions.json.schemaVersion` is `1.5.0` for this branch. The contract was
+**additive-only** for the 1.4.x line: new optional fields could be introduced
+in 1.4.1+ without bumping the framework lock contract. 1.5.0 is the first
+breaking change since 1.4.0 — it makes `zones` a REQUIRED field on every
+solution entry. Any of the following require a 1.6.0 bump AND a coordinated
+PR against fsi-agentgov:
 
 * renaming an existing field
 * removing or repurposing an existing field
 * changing the JSON shape of an existing field (string -> object, etc.)
 * adding a new REQUIRED field
 
-This guarantee lets the framework pin `v1.4.0` and consume any later 1.4.x
-patch release without code changes.
+The framework consumer (`fsi-agentgov/scripts/validate_solutions_lock.py`)
+was widened to accept both 1.4.x and 1.5.x in the companion PR before this
+change shipped.
 
-1.4.2 changelog (additive only):
+1.5.0 changelog (BREAKING):
+* `zones` is now REQUIRED on every solution entry. All 35 catalog
+  solutions already have `zones` populated and confirmed (commit
+  `ce82f83`); the schema change is a tightening, not a data change.
+
+1.4.2 changelog (additive only — historical):
 * Optional `zones` field — array of {personal, team, enterprise}.
 * Optional `dataClassification` field — public|internal|confidential|restricted.
 * Optional `dataResidency` and `retention` free-form notes.
-These will become REQUIRED in 1.5.0 once product-team review of the inferred
-zones is complete.
 
 Framework version pinning
 -------------------------
@@ -285,10 +291,10 @@ def project_to_lock(m: dict) -> dict:
         "prerequisites": dict(m["prerequisites"]),
         "verification": m["verification"],
     }
+    # zones is required as of schema 1.5.0; project always.
+    out["zones"] = list(m["zones"])
     # Additive 1.4.2 fields. Only project when present so absent manifests
     # remain valid for staged backfill.
-    if "zones" in m:
-        out["zones"] = list(m["zones"])
     if "dataClassification" in m:
         out["dataClassification"] = m["dataClassification"]
     if "dataResidency" in m:
@@ -300,7 +306,7 @@ def project_to_lock(m: dict) -> dict:
 
 def emit_solutions_json(
     manifests: dict[str, dict],
-    schema_version: str = "1.4.2",
+    schema_version: str = "1.5.0",
 ) -> str:
     """Return the canonical solutions.json content (deterministic)."""
     out = {

--- a/scripts/manifest.schema.json
+++ b/scripts/manifest.schema.json
@@ -16,7 +16,8 @@
     "controls",
     "url",
     "prerequisites",
-    "verification"
+    "verification",
+    "zones"
   ],
   "properties": {
     "id": {
@@ -92,7 +93,7 @@
       "items": { "type": "string", "enum": ["personal", "team", "enterprise"] },
       "uniqueItems": true,
       "minItems": 1,
-      "description": "Governance zones in which this solution applies. 'personal' = individual maker/Default environment, 'team' = departmental/managed, 'enterprise' = regulated/Managed. Optional in 1.4.2 to allow staged backfill; will become REQUIRED in 1.5.0."
+      "description": "Governance zones in which this solution applies. 'personal' = individual maker/Default environment, 'team' = departmental/managed, 'enterprise' = regulated/Managed. Required as of schema 1.5.0."
     },
     "dataClassification": {
       "type": "string",

--- a/solutions.json
+++ b/solutions.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.4.2",
+  "schemaVersion": "1.5.0",
   "generatedBy": "scripts/build-manifest.py",
   "solutions": {
     "action-confirmation-auditor": {


### PR DESCRIPTION
## ΓÜá∩╕Å Merge order**This PR is intentionally DRAFT.** Do NOT mark ready or merge until the companion PR has merged.- [ ] **Companion PR `judeper/fsi-agentgov#195` merged at SHA `e83ced42c001b9cee50bebb9a2c2ece2ef299c28`** ΓåÉ reviewer fills in this SHA before marking ready- [ ] CI green on this PR- [ ] Auto-merge intentionally disabled## BackgroundBumps `solutions.json` `schemaVersion` from **1.4.2** ΓåÆ **1.5.0** and makes `zones` a **required** field on every solution entry. This is a breaking change for any consumer that parses `solutions.json` and expects `zones` to be optional.All 36 current catalog solutions already have `zones` populated and confirmed in commit `ce82f83` (issue #37 partial). This PR is a schema **tightening**, not a data change ΓÇö `solutions.json` only differs from the previous build by the `schemaVersion` field.## Changes**Schema + emitter:**- `scripts/manifest.schema.json`: appended `"zones"` to `required[]`; tightened the field description so it no longer says "Optional in 1.4.2".- `scripts/build-manifest.py`: emits `schemaVersion: 1.5.0` (was `1.4.2`); `zones` is now projected unconditionally for every solution (was conditional on presence).- `solutions.json`: regenerated with `schemaVersion: 1.5.0`. No data changes.**Schema-evolution paragraphs (`CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`):**- Restated as: *"`solutions.json` schema **1.5.0 (current)**. 1.5.0 made `zones` a required field on every solution entry ΓÇö a breaking change from 1.4.x. Future field renames or new required fields require **1.6.0** with a coordinated `judeper/fsi-agentgov` update."***LATEST_TAG doc-drift cleanup (same three files, picked up incidentally):**- Replaced stale *"Update the `LATEST_TAG` env var in that workflow whenever a new release is tagged"* wording with the current auto-derive behavior shipped in #39: *"auto-derived via `gh api repos/{repo}/releases/latest --jq .tag_name`. No manual `LATEST_TAG` bump is required after a release."*- AGENTS.md previously said "currently `v1.4.1`" ΓÇö also removed.**CHANGELOG.md:**- New `[Unreleased] - 2026-Q2 ΓÇö Schema 1.5.0 (BREAKING)` section with breaking-change entry, doc-cleanup entry, and migration guidance pointing at v1.4.1 as the last 1.4.x pin.## Validation```text$ python scripts/build-manifest.py --checkINFO: OK: all generated artifacts match manifests.(exit 0)$ python -m mkdocs build --strictINFO    -  Documentation built in 13.05 seconds(exit 0)```Producer-side smoke (verified manually after build):- `schemaVersion: 1.5.0` Γ£à- 36 solutions Γ£à- 0 solutions missing `zones` Γ£à## MigrationConsumers needing backward compatibility (e.g., a parser that allows `zones` to be absent) must pin to a 1.4.x release tag ΓÇö latest is `v1.4.1`. After this PR merges, consumers parsing `solutions.json` should expect `zones: string[]` (subset of `personal | team | enterprise`, `minItems: 1`) on every solution.## References- Closes #37 (AC #4)- Companion PR (must merge first): https://github.com/judeper/FSI-AgentGov/pull/195- Zone-backfill confirmation commit: `ce82f83`- Health-check auto-derive of `LATEST_TAG`: #39## Out of scope- This PR does **not** cut a `v1.5.0` release tag. That happens after merge by the human reviewer (`gh release create v1.5.0 ...`), which is the natural trigger for `judeper/fsi-agentgov`'s `refresh_solutions_lock.py --tag v1.5.0`.- This PR does **not** change any per-solution data, manifest values, or the framework `controls.json`.