### PR TITLE
fix(health-check): replace hardcoded 35-entry check with MIN_SOLUTIONS floor (>=36)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,7 +146,7 @@ A separate CI gate, `.github/workflows/manifest-check.yml`, runs `build-manifest
 
 ### Continuous health monitoring
 
-`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the **latest published GitHub release** (auto-derived via `gh api repos/{repo}/releases/latest --jq .tag_name`; see Issue #39), validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. No manual `LATEST_TAG` bump is required after a release; see `DEPLOYMENT-GUIDE.md` "Post-Release Operations" for the full checklist.
+`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the **latest published GitHub release** (auto-derived via `gh api repos/{repo}/releases/latest --jq .tag_name`; see Issue #39), validates the lock file shape (count `>= MIN_SOLUTIONS` floor — currently 36, raise only when releasing intentional removals; non-empty `controls[]`; present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. No manual `LATEST_TAG` bump is required after a release; see `DEPLOYMENT-GUIDE.md` "Post-Release Operations" for the full checklist.
 
 **Critical:** `site-docs/solutions/*/` is **gitignored** and regenerated on every build. Manual edits to those files are discarded. Never edit under `site-docs/solutions/{slug}/` directly.
 

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -66,8 +66,11 @@ jobs:
           # Validate solutions.json shape
           if curl -sS --max-time 20 "https://raw.githubusercontent.com/judeper/FSI-AgentGov-Solutions/${LATEST_TAG}/solutions.json" -o lock.json; then
             count=$(python -c "import json; d=json.load(open('lock.json')); print(len(d.get('solutions',{})))")
-            if [ "$count" != "35" ]; then
-              errors+=("solutions.json count expected 35 got $count")
+            # Catalog is additive — fail only on regression (lost solutions) below the floor.
+            # Bump MIN_SOLUTIONS only when shipping a release that intentionally removes solutions.
+            MIN_SOLUTIONS=36
+            if [ -z "$count" ] || [ "$count" -lt "$MIN_SOLUTIONS" ]; then
+              errors+=("solutions.json count below floor: got $count, expected >= $MIN_SOLUTIONS (catalog regression)")
               fail=1
             fi
             schema=$(python -c "import json; print(json.load(open('lock.json')).get('schemaVersion',''))")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,7 +230,7 @@ A separate CI gate, `.github/workflows/manifest-check.yml`, runs `build-manifest
 
 ### Continuous health monitoring
 
-`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the **latest published GitHub release** (auto-derived via `gh api repos/{repo}/releases/latest --jq .tag_name`; see Issue #39), validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. No manual `LATEST_TAG` bump is required after a release; see `DEPLOYMENT-GUIDE.md` "Post-Release Operations" for the full checklist.
+`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the **latest published GitHub release** (auto-derived via `gh api repos/{repo}/releases/latest --jq .tag_name`; see Issue #39), validates the lock file shape (count `>= MIN_SOLUTIONS` floor — currently 36, raise only when releasing intentional removals; non-empty `controls[]`; present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. No manual `LATEST_TAG` bump is required after a release; see `DEPLOYMENT-GUIDE.md` "Post-Release Operations" for the full checklist.
 
 ### To change overview / catalog content
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ A separate CI gate, `.github/workflows/manifest-check.yml`, runs `build-manifest
 
 ### Continuous health monitoring
 
-`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the **latest published GitHub release** (auto-derived via `gh api repos/{repo}/releases/latest --jq .tag_name`; see Issue #39), validates the lock file shape (35 entries, non-empty `controls[]`, present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. No manual `LATEST_TAG` bump is required after a release.
+`.github/workflows/health-check.yml` runs every 30 minutes on a cron (and on demand via `gh workflow run health-check.yml`). It probes the published Pages URLs and the raw `solutions.json` at the **latest published GitHub release** (auto-derived via `gh api repos/{repo}/releases/latest --jq .tag_name`; see Issue #39), validates the lock file shape (count `>= MIN_SOLUTIONS` floor — currently 36, raise only when releasing intentional removals; non-empty `controls[]`; present `schemaVersion`), and **opens or comments on a GitHub issue titled "Health check failure: published artifacts not healthy" if anything fails**. No manual `LATEST_TAG` bump is required after a release.
 
 **Critical:** `site-docs/solutions/*/` is **gitignored** and regenerated on every build. Manual edits to those files are discarded. Never edit under `site-docs/solutions/{slug}/` directly.
 


### PR DESCRIPTION
## Background
Health-check workflow has been opening issues since the catalog grew from 35 → 36 solutions (agent-intake added in #42). Most recent: #132 ("solutions.json count expected 35 got 36"), filed automatically by the same workflow run that this PR closes.

## Root cause
`.github/workflows/health-check.yml` had a hard-coded `count != 35` check. Catalog is additive — exact-match was the wrong test.

## Fix
Replace with `count >= MIN_SOLUTIONS` floor (currently 36):

```bash
MIN_SOLUTIONS=36
if [ -z "$count" ] || [ "$count" -lt "$MIN_SOLUTIONS" ]; then
  errors+=("solutions.json count below floor: got $count, expected >= $MIN_SOLUTIONS (catalog regression)")
  fail=1
fi
```

This still catches regression (lost solutions) but does not require a workflow edit on every catalog addition. The floor is bumped only when intentionally removing solutions in a release.

Updated companion doc paragraphs in `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md` to describe the floor behavior.

## Validation
- YAML parse: clean (`python -c "import yaml; yaml.safe_load(...)"`)
- After merge: manual `gh workflow run health-check.yml` will confirm the failure clears

## References
- Closes #132