### PR TITLE
feat(lifecycle-ops): adopt 2026-Q2 H-items (8 items, closes #129 H)

### DIFF
--- a/agent-365-lifecycle-governance/README.md
+++ b/agent-365-lifecycle-governance/README.md
@@ -132,6 +132,23 @@ Full requirements: [docs/prerequisites.md](./docs/prerequisites.md)
    .\scripts\Test-LifecycleCompliance.ps1 -DataverseEnvironmentUrl "https://org.crm.dynamics.com"
    ```
 
+## Environment Variables
+
+All configurable thresholds and settings are stored as Dataverse environment variables, deployed by `scripts/create_alg_environment_variables.py`. Key variables:
+
+| SchemaName | Type | Default | Purpose |
+|-----------|------|---------|---------|
+| `fsi_ALG_IsAgent365LifecycleEnabled` | String | `false` | Feature flag gating all Agent 365 API calls |
+| `fsi_ALG_InactivityThresholdZone1` | Decimal | 180 | Inactivity threshold (days) for Zone 1 agents |
+| `fsi_ALG_InactivityThresholdZone2` | Decimal | 90 | Inactivity threshold (days) for Zone 2 agents |
+| `fsi_ALG_InactivityThresholdZone3` | Decimal | 30 | Inactivity threshold (days) for Zone 3 agents |
+| `fsi_ALG_DeletionHoldDays` | Decimal | 30 | Grace period (days) before agent deletion executes after deactivation approval. Zone 3 agents typically override to 90. |
+| `fsi_ALG_AgentRegistryApiVersion` | String | `v1.0` | Graph API version pinning for Agent Registry (`agentInstances`) calls. Pin to a known-good version to avoid breaking changes during preview-to-GA transitions. |
+
+> **Tip:** To override `fsi_ALG_DeletionHoldDays` for Zone 3 agents, the deactivation flow reads this variable as the default and applies the zone-specific override (90 days for Zone 3) from the zone applicability table above. Adjust the variable value when your organization's retention policy differs from the default.
+
+> **Tip:** Pin `fsi_ALG_AgentRegistryApiVersion` to `beta` only during non-production validation of preview Agent Registry API features. In production, use `v1.0` or the latest GA version.
+
 ## Regulatory Alignment
 
 | Regulation | Requirement | How This Solution Helps |

--- a/agent-365-lifecycle-governance/scripts/create_alg_environment_variables.py
+++ b/agent-365-lifecycle-governance/scripts/create_alg_environment_variables.py
@@ -112,6 +112,20 @@ ENV_VARIABLES = [
         "type": "Decimal",
         "defaultvalue": "30",
     },
+    {
+        "schemaname": "fsi_ALG_DeletionHoldDays",
+        "displayname": "ALG - Deletion Hold Days",
+        "description": "Grace period in days before agent deletion executes after deactivation approval. Zone 3 agents typically use 90; Zone 1/2 use 30. Adjust per organizational retention policy.",
+        "type": "Decimal",
+        "defaultvalue": "30",
+    },
+    {
+        "schemaname": "fsi_ALG_AgentRegistryApiVersion",
+        "displayname": "ALG - Agent Registry API Version",
+        "description": "Microsoft Graph API version for Agent Registry (agentInstances) calls. Pin to a known-good version to avoid breaking changes during preview-to-GA transitions.",
+        "type": "String",
+        "defaultvalue": "v1.0",
+    },
 ]
 
 
@@ -216,6 +230,8 @@ Environment variables created:
   - fsi_ALG_InactivityThresholdZone1 (180 days)
   - fsi_ALG_InactivityThresholdZone2 (90 days)
   - fsi_ALG_InactivityThresholdZone3 (30 days)
+  - fsi_ALG_DeletionHoldDays (30 days)
+  - fsi_ALG_AgentRegistryApiVersion (v1.0)
 
 Examples:
   # Interactive authentication

--- a/coi-testing/output/.gitignore
+++ b/coi-testing/output/.gitignore
@@ -1,0 +1,5 @@
+# coi-testing/output/
+# This directory holds JSON output from Get-CoiInventory.ps1.
+# Contents are gitignored — do not commit customer tenant data.
+*.json
+!.gitignore

--- a/coi-testing/scripts/Get-CoiInventory.ps1
+++ b/coi-testing/scripts/Get-CoiInventory.ps1
@@ -1,0 +1,226 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Enumerates Center of Influence (CoI) testing artifacts using Power Platform CLI.
+
+.DESCRIPTION
+    Uses PAC CLI to inventory solutions, environments, and connections used during
+    CoI test cycles. Outputs structured JSON to coi-testing/output/ for downstream
+    analysis and audit evidence.
+
+    This script is a cross-check inventory tool — it does NOT execute tests.
+    Use run_coi_tests.py for test execution.
+
+    PAC CLI commands used:
+      - pac solution list           (solutions in the connected environment)
+      - pac admin list               (tenant environments)
+      - pac connection list          (connections in the connected environment)
+
+.PARAMETER OutputPath
+    Directory for JSON output files. Defaults to ../output relative to the script.
+
+.PARAMETER EnvironmentFilter
+    Optional display-name substring to filter environments. When provided, only
+    environments whose display name contains this value are included.
+
+.PARAMETER IncludeConnections
+    If specified, also enumerates connections via pac connection list.
+
+.PARAMETER DryRun
+    If specified, prints the PAC CLI commands that would be executed without
+    running them.
+
+.EXAMPLE
+    .\Get-CoiInventory.ps1
+
+.EXAMPLE
+    .\Get-CoiInventory.ps1 -EnvironmentFilter "CoI" -IncludeConnections
+
+.EXAMPLE
+    .\Get-CoiInventory.ps1 -OutputPath "C:\reports\coi" -DryRun
+
+.NOTES
+    Prerequisites:
+    - Power Platform CLI (pac) installed and authenticated
+    - Power Platform Admin role for pac admin list
+    - Run 'pac auth list' to verify current authentication context
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$OutputPath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$EnvironmentFilter,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$IncludeConnections,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "[INFO] $Message" -ForegroundColor Cyan
+}
+
+function Write-Warn {
+    param([string]$Message)
+    Write-Host "[WARN] $Message" -ForegroundColor Yellow
+}
+
+function Test-PacInstalled {
+    <#
+    .SYNOPSIS
+        Verify PAC CLI is available on PATH.
+    #>
+    try {
+        $null = Get-Command pac -ErrorAction Stop
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+function Invoke-PacCommand {
+    <#
+    .SYNOPSIS
+        Execute a PAC CLI command and return parsed JSON output.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Command,
+
+        [Parameter(Mandatory)]
+        [string]$Description,
+
+        [switch]$DryRun
+    )
+
+    Write-Info "Running: pac $Command"
+
+    if ($DryRun) {
+        Write-Info "[DRY RUN] Would execute: pac $Command"
+        return @()
+    }
+
+    try {
+        $raw = & pac $Command.Split(' ') 2>&1
+        $exitCode = $LASTEXITCODE
+
+        if ($exitCode -ne 0) {
+            Write-Warn "$Description failed (exit code $exitCode): $($raw -join "`n")"
+            return @()
+        }
+
+        # pac --json commands return JSON arrays; non-json returns text
+        $text = $raw -join "`n"
+        if ($text.Trim().StartsWith('[') -or $text.Trim().StartsWith('{')) {
+            return ($text | ConvertFrom-Json)
+        }
+
+        # Return raw text lines for non-JSON output
+        return @($raw | Where-Object { $_ -and $_.Trim() })
+    }
+    catch {
+        Write-Warn "$Description error: $_"
+        return @()
+    }
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+function Main {
+    # Validate PAC CLI
+    if (-not (Test-PacInstalled)) {
+        Write-Error "PAC CLI (pac) not found on PATH. Install from https://learn.microsoft.com/power-platform/developer/cli/introduction"
+        return
+    }
+
+    # Resolve output path
+    if (-not $OutputPath) {
+        $OutputPath = Join-Path $PSScriptRoot '..' 'output'
+    }
+    $OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+
+    if (-not $DryRun) {
+        if (-not (Test-Path $OutputPath)) {
+            New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+            Write-Info "Created output directory: $OutputPath"
+        }
+    }
+
+    $timestamp = Get-Date -Format 'yyyy-MM-ddTHH-mm-ss'
+    $inventory = @{
+        metadata = @{
+            generatedAt   = (Get-Date -Format 'o')
+            generatedBy   = 'Get-CoiInventory.ps1'
+            filter        = if ($EnvironmentFilter) { $EnvironmentFilter } else { $null }
+            isDryRun      = [bool]$DryRun
+        }
+        environments = @()
+        solutions    = @()
+        connections  = @()
+    }
+
+    # ── Environments ─────────────────────────────────────────────────────
+    Write-Info 'Enumerating environments...'
+    $envs = Invoke-PacCommand -Command 'admin list --json' -Description 'Environment list' -DryRun:$DryRun
+
+    if ($EnvironmentFilter -and $envs.Count -gt 0) {
+        $envs = @($envs | Where-Object {
+            ($_.DisplayName -and $_.DisplayName -like "*$EnvironmentFilter*") -or
+            ($_.EnvironmentName -and $_.EnvironmentName -like "*$EnvironmentFilter*")
+        })
+        Write-Info "Filtered to $($envs.Count) environment(s) matching '$EnvironmentFilter'"
+    }
+
+    $inventory.environments = @($envs)
+    Write-Info "Found $($envs.Count) environment(s)"
+
+    # ── Solutions ────────────────────────────────────────────────────────
+    Write-Info 'Enumerating solutions in connected environment...'
+    $solutions = Invoke-PacCommand -Command 'solution list --json' -Description 'Solution list' -DryRun:$DryRun
+    $inventory.solutions = @($solutions)
+    Write-Info "Found $($solutions.Count) solution(s)"
+
+    # ── Connections (optional) ───────────────────────────────────────────
+    if ($IncludeConnections) {
+        Write-Info 'Enumerating connections...'
+        $connections = Invoke-PacCommand -Command 'connection list --json' -Description 'Connection list' -DryRun:$DryRun
+        $inventory.connections = @($connections)
+        Write-Info "Found $($connections.Count) connection(s)"
+    }
+
+    # ── Output ───────────────────────────────────────────────────────────
+    if ($DryRun) {
+        Write-Info '[DRY RUN] Would write inventory JSON to output directory'
+        $inventory | ConvertTo-Json -Depth 10 | Write-Output
+        return
+    }
+
+    $outFile = Join-Path $OutputPath "coi-inventory-$timestamp.json"
+    $inventory | ConvertTo-Json -Depth 10 | Set-Content -Path $outFile -Encoding utf8
+    Write-Info "Inventory written to: $outFile"
+
+    # Summary
+    Write-Host ''
+    Write-Host '── CoI Inventory Summary ──' -ForegroundColor Green
+    Write-Host "  Environments : $($inventory.environments.Count)"
+    Write-Host "  Solutions    : $($inventory.solutions.Count)"
+    if ($IncludeConnections) {
+        Write-Host "  Connections  : $($inventory.connections.Count)"
+    }
+    Write-Host "  Output       : $outFile"
+}
+
+Main

--- a/dr-testing-framework/docs/emergency-access-drill.md
+++ b/dr-testing-framework/docs/emergency-access-drill.md
@@ -1,0 +1,161 @@
+# Emergency Access (Break-Glass) Drill Procedure
+
+> **Status:** Template — adapt to your organization's emergency access policy and incident response plan.
+
+This document covers how to test break-glass account access during disaster recovery scenarios, the recommended drill cadence, evidence collection requirements, and a post-drill review template.
+
+## Purpose
+
+Emergency access accounts (break-glass accounts) are highly privileged Microsoft Entra ID accounts that bypass normal access controls (MFA, Conditional Access) to restore administrative access during outages. FSI organizations must periodically verify these accounts function correctly — a break-glass account that fails during an actual emergency is worse than not having one.
+
+This drill procedure supports compliance with OCC 2011-12 (operational resilience testing) and helps meet FFIEC BCP expectations for documented access continuity.
+
+## Prerequisites
+
+| Requirement | Details |
+|------------|---------|
+| **Break-glass accounts** | At least 2 cloud-only Microsoft Entra ID accounts excluded from all Conditional Access policies |
+| **Secure credential storage** | Physical safe, split-knowledge procedure, or hardware security module |
+| **Azure Monitor / Sentinel** | Sign-in logs for emergency accounts forwarded to a SIEM workspace |
+| **Drill coordinator** | Named individual with authority to authorize break-glass use outside emergencies |
+
+> **Reference:** [Microsoft Learn — Manage emergency access accounts](https://learn.microsoft.com/entra/identity/role-based-access-control/security-emergency-access)
+
+## Drill Cadence
+
+| Frequency | Activity | Regulatory Alignment |
+|-----------|----------|---------------------|
+| **Quarterly** (minimum) | Full break-glass drill — credential retrieval, sign-in, verification, re-seal | OCC 2011-12 (operational resilience), FFIEC BCP |
+| **Annually** | Comprehensive DR exercise including break-glass as part of full business continuity test | FINRA Rule 4370, SEC 17a-4(f) |
+| **On change** | Re-test whenever Conditional Access policies, MFA providers, or Entra ID tenant configuration changes | Best practice |
+
+> **Note:** Quarterly is a minimum recommendation. Organizations with higher risk profiles or examiner findings should consider monthly drills.
+
+## Drill Procedure
+
+### Phase 1: Preparation
+
+1. **Schedule the drill** with the drill coordinator and at least one witness
+2. **Notify the SOC / security operations** that a break-glass test is planned (prevents false-positive incident response)
+3. **Prepare an isolated workstation** or InPrivate browser session — do not use a device already signed in with production credentials
+4. **Open Azure Monitor / Sentinel** in a separate session to observe sign-in events in near-real-time
+
+### Phase 2: Credential Retrieval
+
+1. Retrieve break-glass credentials from secure storage following your organization's split-knowledge or dual-control procedure
+2. **Record the retrieval timestamp** (evidence item)
+3. Verify both accounts have credentials available (primary and secondary)
+
+### Phase 3: Sign-In Test
+
+For **each** break-glass account:
+
+1. Open an InPrivate / incognito browser window
+2. Navigate to `https://entra.microsoft.com`
+3. Sign in using the break-glass account credentials
+4. **Record the sign-in timestamp** (evidence item)
+5. Verify the account has Global Administrator or equivalent role
+6. Perform a read-only administrative action to confirm access:
+   - Navigate to **Users** → verify user list loads
+   - Navigate to **Conditional Access** → verify policies are visible
+7. **Record the verification timestamp** (evidence item)
+8. Sign out completely
+9. Close the browser window
+
+### Phase 4: Post-Drill Verification
+
+1. In Azure Monitor / Microsoft Entra sign-in logs, confirm:
+   - Sign-in events appear for the break-glass account(s)
+   - Sign-in location and IP match the drill workstation
+   - No unexpected sign-in events for break-glass accounts outside the drill window
+2. **Record any anomalies** (evidence item)
+
+### Phase 5: Re-Seal
+
+1. If credentials were changed or rotated during the drill, update secure storage
+2. Re-seal the credential storage (safe, HSM, etc.)
+3. **Record the re-seal timestamp** (evidence item)
+
+## Evidence Collection Format
+
+Each drill produces a structured evidence record. Use this format for audit documentation:
+
+```
+Drill ID:            DR-YYYY-MM-DD-NNN
+Drill Date:          YYYY-MM-DD
+Drill Coordinator:   [Name, Title]
+Witness:             [Name, Title]
+Drill Type:          Quarterly Break-Glass / Annual BCP / On-Change
+
+Account 1:
+  UPN:               [break-glass-1@domain.com]
+  Credential Retrieved: YYYY-MM-DDTHH:MM:SSZ
+  Sign-In Timestamp:    YYYY-MM-DDTHH:MM:SSZ
+  Sign-In Result:       [Success / Failure — detail if failure]
+  Verification Action:  [Action performed to confirm access]
+  Verification Time:    YYYY-MM-DDTHH:MM:SSZ
+  Sign-Out Time:        YYYY-MM-DDTHH:MM:SSZ
+  Anomalies:            [None / describe]
+
+Account 2:
+  UPN:               [break-glass-2@domain.com]
+  Credential Retrieved: YYYY-MM-DDTHH:MM:SSZ
+  Sign-In Timestamp:    YYYY-MM-DDTHH:MM:SSZ
+  Sign-In Result:       [Success / Failure — detail if failure]
+  Verification Action:  [Action performed to confirm access]
+  Verification Time:    YYYY-MM-DDTHH:MM:SSZ
+  Sign-Out Time:        YYYY-MM-DDTHH:MM:SSZ
+  Anomalies:            [None / describe]
+
+Sentinel Verification:
+  Sign-in logs reviewed: [Yes/No]
+  Unexpected sign-ins:   [None / describe]
+  Log retention confirmed: [Yes/No]
+
+Re-Seal:
+  Credentials re-sealed: YYYY-MM-DDTHH:MM:SSZ
+  Storage location:      [Safe ID / HSM ID]
+```
+
+## Post-Drill Review Template
+
+Complete this review within 5 business days of each drill:
+
+### Drill Summary
+
+| Field | Value |
+|-------|-------|
+| Drill ID | |
+| Date | |
+| Coordinator | |
+| Witness(es) | |
+| Drill type | Quarterly / Annual / On-Change |
+
+### Results
+
+| Check | Account 1 | Account 2 |
+|-------|-----------|-----------|
+| Credential retrieval successful | ☐ Yes ☐ No | ☐ Yes ☐ No |
+| Sign-in successful | ☐ Yes ☐ No | ☐ Yes ☐ No |
+| Admin actions verified | ☐ Yes ☐ No | ☐ Yes ☐ No |
+| Sign-in logs captured in SIEM | ☐ Yes ☐ No | ☐ Yes ☐ No |
+| No unexpected sign-in activity | ☐ Yes ☐ No | ☐ Yes ☐ No |
+| Credentials re-sealed | ☐ Yes ☐ No | ☐ Yes ☐ No |
+
+### Findings and Remediation
+
+| Finding | Severity | Remediation | Owner | Target Date |
+|---------|----------|-------------|-------|-------------|
+| | | | | |
+
+### Sign-Off
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Drill Coordinator | | | |
+| IT Security Lead | | | |
+| Compliance Officer | | | |
+
+---
+
+*Updated: May 2026 | Version: v1.0*

--- a/dr-testing-framework/queries/dr-scenario-detection.kql
+++ b/dr-testing-framework/queries/dr-scenario-detection.kql
@@ -1,0 +1,52 @@
+// ============================================================================
+// DR Scenario Detection — Azure Region Failover Events
+// ============================================================================
+//
+// Purpose:
+//   Detects Azure region failover and service degradation events from Azure
+//   Monitor / Azure Resource Health that may trigger DR validation runs.
+//   Use this query to identify when a DR test should be initiated or to
+//   correlate observed outages with DR evidence windows.
+//
+// Data source:
+//   Azure Monitor — AzureActivity and ResourceHealthResources tables.
+//   Requires Log Analytics workspace with Azure Activity logs ingested.
+//
+// Parameters:
+//   TimeRange    — Lookback window (default: 7 days)
+//   RegionFilter — Target Azure region (default: all regions)
+//
+// Expected output schema:
+//   | Column            | Type     | Description                              |
+//   |-------------------|----------|------------------------------------------|
+//   | TimeGenerated     | datetime | Event timestamp                          |
+//   | ResourceProvider  | string   | Azure resource provider                  |
+//   | OperationName     | string   | Operation that triggered the event       |
+//   | Level             | string   | Event severity (Warning, Error, Critical)|
+//   | ResourceGroup     | string   | Affected resource group                  |
+//   | ResourceRegion    | string   | Azure region where event occurred        |
+//   | Status            | string   | Event status                             |
+//   | Description       | string   | Event description                        |
+// ============================================================================
+
+let TimeRange = 7d;
+let RegionFilter = "";  // Set to e.g. "eastus" to filter; empty = all regions
+AzureActivity
+| where TimeGenerated > ago(TimeRange)
+| where CategoryValue == "ResourceHealth"
+    or CategoryValue == "ServiceHealth"
+    or OperationNameValue has_any ("Microsoft.ResourceHealth", "Microsoft.ServiceHealth")
+| where Level in ("Warning", "Error", "Critical")
+| where RegionFilter == "" or Properties_d has RegionFilter
+| extend ResourceRegion = tostring(parse_json(Properties_d).region)
+| extend Description = tostring(parse_json(Properties_d).cause)
+| project
+    TimeGenerated,
+    ResourceProvider,
+    OperationNameValue,
+    Level,
+    ResourceGroup,
+    ResourceRegion,
+    ActivityStatusValue,
+    Description
+| order by TimeGenerated desc

--- a/dr-testing-framework/queries/replication-lag-monitor.kql
+++ b/dr-testing-framework/queries/replication-lag-monitor.kql
@@ -1,0 +1,48 @@
+// ============================================================================
+// Cross-Region Replication Lag — Dataverse / Power Platform
+// ============================================================================
+//
+// Purpose:
+//   Measures replication lag indicators for Dataverse and Power Platform
+//   resources across Azure regions. Monitors Application Insights telemetry
+//   from Dataverse for request latency anomalies that may indicate
+//   cross-region replication delays during or after a DR event.
+//
+// Data source:
+//   Application Insights connected to Dataverse / Power Platform tenant.
+//   Requires Dataverse Application Insights integration enabled.
+//   See: https://learn.microsoft.com/power-platform/admin/telemetry-events-dataverse
+//
+// Parameters:
+//   TimeRange       — Lookback window (default: 24 hours)
+//   LatencyThreshold — Request duration threshold in ms indicating lag (default: 5000)
+//   BinSize         — Time aggregation bucket (default: 5 minutes)
+//
+// Expected output schema:
+//   | Column             | Type     | Description                            |
+//   |--------------------|----------|----------------------------------------|
+//   | TimeBucket         | datetime | Aggregation time bucket                |
+//   | AvgDurationMs      | real     | Average request duration (ms)          |
+//   | P95DurationMs      | real     | 95th percentile duration (ms)          |
+//   | MaxDurationMs      | real     | Maximum request duration (ms)          |
+//   | RequestCount       | long     | Total requests in bucket               |
+//   | HighLatencyCount   | long     | Requests exceeding threshold           |
+//   | HighLatencyPct     | real     | Percentage of high-latency requests    |
+// ============================================================================
+
+let TimeRange = 24h;
+let LatencyThreshold = 5000;  // milliseconds
+let BinSize = 5m;
+requests
+| where timestamp > ago(TimeRange)
+| where client_Type == "PC"  // server-side requests
+| extend DurationMs = duration
+| summarize
+    AvgDurationMs      = avg(DurationMs),
+    P95DurationMs      = percentile(DurationMs, 95),
+    MaxDurationMs      = max(DurationMs),
+    RequestCount       = count(),
+    HighLatencyCount   = countif(DurationMs > LatencyThreshold)
+    by TimeBucket = bin(timestamp, BinSize)
+| extend HighLatencyPct = round(100.0 * HighLatencyCount / RequestCount, 2)
+| order by TimeBucket desc

--- a/dr-testing-framework/queries/rpo-rto-measurement.kql
+++ b/dr-testing-framework/queries/rpo-rto-measurement.kql
@@ -1,0 +1,75 @@
+// ============================================================================
+// Recovery Time Measurements — RPO/RTO Instrumentation
+// ============================================================================
+//
+// Purpose:
+//   Provides evidence for Recovery Point Objective (RPO) and Recovery Time
+//   Objective (RTO) measurements during DR test cycles. Correlates the last
+//   successful write before an outage (RPO marker) with the first successful
+//   read/write after recovery (RTO marker) to compute actual recovery metrics.
+//
+//   This query does NOT perform a restore — it measures the time gap between
+//   the last pre-outage operation and the first post-recovery operation as
+//   observed in Application Insights telemetry.
+//
+// Data source:
+//   Application Insights connected to Dataverse.
+//   Requires customEvents with DR test markers (recommended) or falls back
+//   to requests table for general write/read operations.
+//
+// Parameters:
+//   OutageStartUtc  — Approximate UTC start of the outage/DR event
+//   OutageEndUtc    — Approximate UTC end of the outage/DR event
+//   EntityFilter    — Dataverse entity logical name to scope (default: all)
+//
+// Expected output schema:
+//   | Column                  | Type     | Description                        |
+//   |-------------------------|----------|------------------------------------|
+//   | MetricName              | string   | "RPO" or "RTO"                     |
+//   | ReferenceTimestamp      | datetime | Last write (RPO) or first read (RTO)|
+//   | OutageBoundary          | datetime | Outage start (RPO) or end (RTO)   |
+//   | GapMinutes              | real     | Minutes between reference and boundary |
+//   | GapHours                | real     | Hours between reference and boundary |
+//   | OperationName           | string   | Operation that produced the marker |
+//   | EntityName              | string   | Dataverse entity (if available)    |
+// ============================================================================
+
+let OutageStartUtc = datetime(2026-01-01T00:00:00Z);  // Replace with actual outage start
+let OutageEndUtc   = datetime(2026-01-01T06:00:00Z);  // Replace with actual outage end
+let EntityFilter   = "";  // Set to e.g. "fsi_agentlifecyclerecord" to scope
+// ── RPO: last successful write before outage ────────────────────────────────
+let LastWriteBeforeOutage =
+    requests
+    | where timestamp < OutageStartUtc
+    | where timestamp > OutageStartUtc - 24h  // limit lookback
+    | where success == true
+    | where name has_any ("POST", "PATCH", "PUT", "DELETE")
+    | where EntityFilter == "" or url has EntityFilter
+    | top 1 by timestamp desc
+    | project
+        MetricName         = "RPO",
+        ReferenceTimestamp  = timestamp,
+        OutageBoundary      = OutageStartUtc,
+        GapMinutes          = datetime_diff('minute', OutageStartUtc, timestamp),
+        GapHours            = round(datetime_diff('second', OutageStartUtc, timestamp) / 3600.0, 2),
+        OperationName       = name,
+        EntityName          = tostring(parse_url(url).Path);
+// ── RTO: first successful operation after recovery ──────────────────────────
+let FirstReadAfterRecovery =
+    requests
+    | where timestamp > OutageEndUtc
+    | where timestamp < OutageEndUtc + 24h  // limit forward search
+    | where success == true
+    | where EntityFilter == "" or url has EntityFilter
+    | top 1 by timestamp asc
+    | project
+        MetricName         = "RTO",
+        ReferenceTimestamp  = timestamp,
+        OutageBoundary      = OutageEndUtc,
+        GapMinutes          = datetime_diff('minute', timestamp, OutageEndUtc),
+        GapHours            = round(datetime_diff('second', timestamp, OutageEndUtc) / 3600.0, 2),
+        OperationName       = name,
+        EntityName          = tostring(parse_url(url).Path);
+// ── Combined output ─────────────────────────────────────────────────────────
+union LastWriteBeforeOutage, FirstReadAfterRecovery
+| order by MetricName asc

--- a/message-center-monitor/docs/graph-powershell-snippet.md
+++ b/message-center-monitor/docs/graph-powershell-snippet.md
@@ -1,0 +1,226 @@
+# Graph PowerShell Snippet — Service Health Ingestion
+
+This document provides a complete PowerShell example for ingesting Microsoft 365 Service Health events using the Microsoft Graph PowerShell SDK (`Invoke-MgGraphRequest`) as an alternative to the Python `ingest_service_health.py` script.
+
+## Prerequisites
+
+| Requirement | Details |
+|------------|---------|
+| **PowerShell 7+** | `pwsh --version` |
+| **Microsoft.Graph module** | `Install-Module Microsoft.Graph -Scope CurrentUser` |
+| **Graph permission** | `ServiceHealth.Read.All` (application) |
+| **Authentication** | Managed identity preferred; interactive for admin workstation |
+
+## Complete Example
+
+```powershell
+#Requires -Version 7.0
+#Requires -Modules Microsoft.Graph.Authentication
+
+<#
+.SYNOPSIS
+    Retrieves Microsoft 365 Service Health events via Microsoft Graph PowerShell SDK.
+
+.DESCRIPTION
+    Connects to Microsoft Graph using managed identity (preferred) or interactive
+    browser auth, retrieves service health overviews and active issues, and writes
+    structured JSON output.
+
+    Graph endpoints:
+      GET /admin/serviceAnnouncement/healthOverviews
+      GET /admin/serviceAnnouncement/issues
+
+    Required permission: ServiceHealth.Read.All
+
+.PARAMETER OutputPath
+    Path for JSON output file. If not specified, output is written to the console.
+
+.PARAMETER AuthMode
+    Authentication mode: ManagedIdentity (default), Interactive, or ClientSecret (legacy).
+
+.PARAMETER TenantId
+    Microsoft Entra tenant ID (required for Interactive and ClientSecret modes).
+
+.PARAMETER ClientId
+    Application (client) ID for ClientSecret auth mode.
+
+.EXAMPLE
+    # Managed identity (Azure-hosted automation)
+    .\Get-ServiceHealth.ps1 -OutputPath .\output\service-health.json
+
+.EXAMPLE
+    # Interactive (admin workstation)
+    .\Get-ServiceHealth.ps1 -AuthMode Interactive -TenantId "00000000-..." -OutputPath .\output\health.json
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$OutputPath,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("ManagedIdentity", "Interactive", "ClientSecret")]
+    [string]$AuthMode = "ManagedIdentity",
+
+    [Parameter(Mandatory = $false)]
+    [string]$TenantId,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ClientId
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ── Authentication ───────────────────────────────────────────────────────────
+
+$scopes = @("https://graph.microsoft.com/.default")
+
+switch ($AuthMode) {
+    "ManagedIdentity" {
+        Write-Host "[INFO] Connecting with managed identity..." -ForegroundColor Cyan
+        Connect-MgGraph -Identity -NoWelcome
+    }
+    "Interactive" {
+        if (-not $TenantId) {
+            Write-Error "-TenantId is required for Interactive auth mode"
+            return
+        }
+        Write-Host "[INFO] Connecting with interactive browser auth..." -ForegroundColor Cyan
+        Connect-MgGraph -TenantId $TenantId -Scopes "ServiceHealth.Read.All" -NoWelcome
+    }
+    "ClientSecret" {
+        if (-not $TenantId -or -not $ClientId) {
+            Write-Error "-TenantId and -ClientId are required for ClientSecret auth mode"
+            return
+        }
+        # Legacy fallback — prefer managed identity in production
+        $secret = $env:MCM_CLIENT_SECRET
+        if (-not $secret) {
+            $secret = Read-Host -AsSecureString -Prompt "Client secret"
+        }
+        else {
+            $secret = ConvertTo-SecureString $secret -AsPlainText -Force
+        }
+        $cred = [PSCredential]::new($ClientId, $secret)
+        Connect-MgGraph -TenantId $TenantId -ClientSecretCredential $cred -NoWelcome
+    }
+}
+
+Write-Host "[INFO] Connected to Microsoft Graph" -ForegroundColor Cyan
+
+# ── Paged retrieval helper ───────────────────────────────────────────────────
+
+function Get-GraphPaged {
+    <#
+    .SYNOPSIS
+        Retrieves all pages from a Graph API endpoint.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Uri,
+
+        [Parameter(Mandatory)]
+        [string]$Description
+    )
+
+    $allResults = [System.Collections.Generic.List[object]]::new()
+    $nextLink = $Uri
+
+    while ($nextLink) {
+        try {
+            $response = Invoke-MgGraphRequest -Method GET -Uri $nextLink -ErrorAction Stop
+        }
+        catch {
+            Write-Error "${Description} failed: $_"
+            return @()
+        }
+
+        $items = $response.value
+        if ($items) {
+            $allResults.AddRange($items)
+        }
+
+        Write-Host "[INFO]   Retrieved $($items.Count) items (total: $($allResults.Count))" -ForegroundColor Cyan
+        $nextLink = $response.'@odata.nextLink'
+    }
+
+    return $allResults.ToArray()
+}
+
+# ── Retrieve data ────────────────────────────────────────────────────────────
+
+Write-Host "[INFO] Fetching service health overviews..." -ForegroundColor Cyan
+$overviews = Get-GraphPaged `
+    -Uri "/admin/serviceAnnouncement/healthOverviews" `
+    -Description "Health overviews"
+
+Write-Host "[INFO] Fetching service health issues..." -ForegroundColor Cyan
+$issues = Get-GraphPaged `
+    -Uri "/admin/serviceAnnouncement/issues" `
+    -Description "Health issues"
+
+# ── Build output ─────────────────────────────────────────────────────────────
+
+$activeIssues = @($issues | Where-Object { $_.status -notin @("resolved", "serviceRestored") })
+
+$result = @{
+    metadata  = @{
+        generatedAt = (Get-Date -Format 'o')
+        generatedBy = 'Get-ServiceHealth.ps1 (Graph PowerShell SDK)'
+        graphVersion = 'v1.0'
+        permission  = 'ServiceHealth.Read.All'
+    }
+    overviews = $overviews
+    issues    = $issues
+    summary   = @{
+        totalServices = $overviews.Count
+        totalIssues   = $issues.Count
+        activeIssues  = $activeIssues.Count
+    }
+}
+
+$json = $result | ConvertTo-Json -Depth 10
+
+if ($OutputPath) {
+    $dir = Split-Path $OutputPath -Parent
+    if ($dir -and -not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    $json | Set-Content -Path $OutputPath -Encoding utf8
+    Write-Host "[INFO] Output written to: $OutputPath" -ForegroundColor Cyan
+}
+else {
+    Write-Output $json
+}
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+Write-Host "" -ForegroundColor Green
+Write-Host "── Service Health Summary ──" -ForegroundColor Green
+Write-Host "  Services monitored : $($overviews.Count)"
+Write-Host "  Total issues       : $($issues.Count)"
+Write-Host "  Active issues      : $($activeIssues.Count)"
+
+# ── Disconnect ───────────────────────────────────────────────────────────────
+
+Disconnect-MgGraph -ErrorAction SilentlyContinue | Out-Null
+```
+
+## Usage Notes
+
+- **Managed identity** is the recommended authentication mode for automated/scheduled runs in Azure-hosted environments
+- **Paging** is handled automatically — the `Get-GraphPaged` helper follows `@odata.nextLink` until all results are retrieved
+- **Error handling** captures Graph API failures per-endpoint without terminating the entire script
+- **Output format** matches the Python `ingest_service_health.py` JSON schema for interoperability
+
+## Comparison with Python Script
+
+| Aspect | Python (`ingest_service_health.py`) | PowerShell (`Get-ServiceHealth.ps1`) |
+|--------|-------------------------------------|--------------------------------------|
+| Runtime | Python 3.9+ with azure-identity | PowerShell 7+ with Microsoft.Graph module |
+| Auth | azure.identity ChainedTokenCredential | Connect-MgGraph |
+| HTTP | requests library | Invoke-MgGraphRequest (built-in) |
+| Best for | Azure Functions, container workloads | Admin workstations, Azure Automation runbooks |
+
+Choose the version that best fits your automation runtime. Both produce identical JSON output.

--- a/message-center-monitor/scripts/ingest_service_health.py
+++ b/message-center-monitor/scripts/ingest_service_health.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""
+Ingest Microsoft 365 Service Health events via Microsoft Graph.
+
+Retrieves service health overviews and active issues from the Graph
+serviceAnnouncement API endpoints and writes structured JSON output
+for downstream consumption by the Message Center Monitor solution.
+
+Endpoints used:
+  GET /admin/serviceAnnouncement/healthOverviews
+  GET /admin/serviceAnnouncement/issues
+
+Required Graph permissions:
+  ServiceHealth.Read.All (application)
+
+Authentication priority (managed-identity-first):
+  1. System-assigned managed identity (default)
+  2. User-assigned managed identity (--client-id)
+  3. Workload identity federation (AZURE_FEDERATED_TOKEN_FILE)
+  4. Interactive / device-code (--interactive)
+  5. Client secret (legacy, --auth-mode client-secret)
+
+Usage:
+    python ingest_service_health.py --tenant-id <id>
+    python ingest_service_health.py --tenant-id <id> --output-dir ./output
+    python ingest_service_health.py --tenant-id <id> --interactive
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+HEALTH_OVERVIEWS_URL = f"{GRAPH_BASE}/admin/serviceAnnouncement/healthOverviews"
+HEALTH_ISSUES_URL = f"{GRAPH_BASE}/admin/serviceAnnouncement/issues"
+GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+
+
+def _get_credential(
+    tenant_id: str,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    interactive: bool = False,
+    auth_mode: str | None = None,
+) -> Any:
+    """
+    Build an Azure Identity credential following managed-identity-first priority.
+
+    Returns:
+        A TokenCredential instance.
+
+    Raises:
+        RuntimeError: If no suitable credential can be constructed.
+    """
+    try:
+        from azure.identity import (
+            ChainedTokenCredential,
+            ClientSecretCredential,
+            DeviceCodeCredential,
+            InteractiveBrowserCredential,
+            ManagedIdentityCredential,
+            WorkloadIdentityCredential,
+        )
+    except ImportError:
+        raise RuntimeError(
+            "azure-identity package is required. Install with: pip install azure-identity"
+        )
+
+    if auth_mode == "client-secret" and client_id and client_secret:
+        logger.info("Using client-secret credential (legacy fallback)")
+        return ClientSecretCredential(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+
+    if interactive:
+        logger.info("Using interactive browser credential")
+        return InteractiveBrowserCredential(tenant_id=tenant_id)
+
+    # Build chained credential: MI → workload identity → device code
+    candidates = []
+
+    if client_id:
+        candidates.append(ManagedIdentityCredential(client_id=client_id))
+    else:
+        candidates.append(ManagedIdentityCredential())
+
+    if os.environ.get("AZURE_FEDERATED_TOKEN_FILE"):
+        candidates.append(
+            WorkloadIdentityCredential(
+                tenant_id=tenant_id,
+                client_id=client_id or os.environ.get("AZURE_CLIENT_ID", ""),
+            )
+        )
+
+    candidates.append(DeviceCodeCredential(tenant_id=tenant_id))
+
+    return ChainedTokenCredential(*candidates)
+
+
+def _graph_get(
+    url: str,
+    token: str,
+    params: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """
+    Execute a paged GET against Microsoft Graph and return all results.
+
+    Handles @odata.nextLink pagination automatically.
+    """
+    try:
+        import requests
+    except ImportError:
+        raise RuntimeError(
+            "requests package is required. Install with: pip install requests"
+        )
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+
+    all_results: list[dict[str, Any]] = []
+    next_url: str | None = url
+
+    while next_url:
+        logger.debug("GET %s", next_url)
+        resp = requests.get(next_url, headers=headers, params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+
+        items = data.get("value", [])
+        all_results.extend(items)
+        logger.info("  Retrieved %d items (total so far: %d)", len(items), len(all_results))
+
+        next_url = data.get("@odata.nextLink")
+        params = None  # nextLink includes query params
+
+    return all_results
+
+
+def ingest_service_health(
+    tenant_id: str,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    interactive: bool = False,
+    auth_mode: str | None = None,
+    output_dir: str | None = None,
+) -> dict[str, Any]:
+    """
+    Ingest service health overviews and issues from Microsoft Graph.
+
+    Args:
+        tenant_id: Microsoft Entra tenant ID.
+        client_id: Optional client ID for user-assigned MI or app registration.
+        client_secret: Optional client secret (legacy fallback).
+        interactive: Use interactive browser auth.
+        auth_mode: Explicit auth mode override.
+        output_dir: Directory for JSON output. If None, prints to stdout.
+
+    Returns:
+        dict with 'overviews' and 'issues' lists plus metadata.
+    """
+    credential = _get_credential(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        client_secret=client_secret,
+        interactive=interactive,
+        auth_mode=auth_mode,
+    )
+
+    logger.info("Acquiring Graph token...")
+    token = credential.get_token(GRAPH_SCOPE).token
+
+    logger.info("Fetching service health overviews...")
+    overviews = _graph_get(HEALTH_OVERVIEWS_URL, token)
+
+    logger.info("Fetching service health issues...")
+    issues = _graph_get(HEALTH_ISSUES_URL, token)
+
+    result = {
+        "metadata": {
+            "generatedAt": datetime.now(timezone.utc).isoformat(),
+            "generatedBy": "ingest_service_health.py",
+            "tenantId": tenant_id,
+            "graphVersion": "v1.0",
+            "permission": "ServiceHealth.Read.All",
+        },
+        "overviews": overviews,
+        "issues": issues,
+        "summary": {
+            "totalServices": len(overviews),
+            "totalIssues": len(issues),
+            "activeIssues": len(
+                [i for i in issues if i.get("status") not in ("resolved", "serviceRestored")]
+            ),
+        },
+    }
+
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
+        out_path = os.path.join(output_dir, f"service-health-{timestamp}.json")
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(result, f, indent=2, default=str)
+        logger.info("Output written to %s", out_path)
+    else:
+        print(json.dumps(result, indent=2, default=str))
+
+    return result
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Ingest Microsoft 365 Service Health events via Graph API",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Required Graph permission: ServiceHealth.Read.All (application)
+
+Examples:
+  # Managed identity (default in Azure-hosted environments)
+  python ingest_service_health.py --tenant-id <id>
+
+  # User-assigned managed identity
+  python ingest_service_health.py --tenant-id <id> --client-id <mi-client-id>
+
+  # Interactive browser auth (admin workstation)
+  python ingest_service_health.py --tenant-id <id> --interactive
+
+  # Output to file
+  python ingest_service_health.py --tenant-id <id> --output-dir ./output
+
+  # Legacy client-secret (dev only)
+  python ingest_service_health.py --tenant-id <id> --client-id <app-id> \\
+      --auth-mode client-secret
+        """,
+    )
+
+    parser.add_argument(
+        "--tenant-id",
+        required=True,
+        help="Microsoft Entra tenant ID",
+    )
+    parser.add_argument(
+        "--client-id",
+        default=os.environ.get("MCM_CLIENT_ID"),
+        help="Application / managed identity client ID (or MCM_CLIENT_ID env var)",
+    )
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="Use interactive browser authentication",
+    )
+    parser.add_argument(
+        "--auth-mode",
+        choices=["managed-identity", "workload-identity", "client-secret", "interactive"],
+        default=None,
+        help="Explicit authentication mode override",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Directory for JSON output (default: stdout)",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging verbosity (default: INFO)",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    client_secret = os.environ.get("MCM_CLIENT_SECRET")
+    if args.auth_mode == "client-secret" and not client_secret:
+        import getpass
+        client_secret = getpass.getpass("Client secret: ")
+
+    try:
+        result = ingest_service_health(
+            tenant_id=args.tenant_id,
+            client_id=args.client_id,
+            client_secret=client_secret,
+            interactive=args.interactive or args.auth_mode == "interactive",
+            auth_mode=args.auth_mode,
+            output_dir=args.output_dir,
+        )
+
+        logger.info(
+            "Service health ingestion complete: %d services, %d issues (%d active)",
+            result["summary"]["totalServices"],
+            result["summary"]["totalIssues"],
+            result["summary"]["activeIssues"],
+        )
+
+    except Exception as e:
+        logger.error("Service health ingestion failed: %s", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline-governance-cleanup/docs/automation-guide.md
+++ b/pipeline-governance-cleanup/docs/automation-guide.md
@@ -136,6 +136,54 @@ Sends governance notification emails to environment/pipeline owners.
 
 ---
 
+## Managed Environment Governance Configuration
+
+Use `pac admin set-governance-config` to enforce governance policies on production Managed Environments. This is recommended before enabling deployment pipelines to prevent unvetted solutions from being imported.
+
+**Required role:** Power Platform Admin (or Dynamics 365 admin with environment-level permissions).
+
+### Recommended configuration
+
+```powershell
+# Apply FSI-recommended governance settings
+.\scripts\Set-GovernanceConfig.ps1 `
+    -EnvironmentId "00000000-0000-0000-0000-000000000000" `
+    -SolutionCheckerMode "warn" `
+    -EnablePipelines
+
+# For stricter enforcement (blocks imports with critical solution checker findings)
+.\scripts\Set-GovernanceConfig.ps1 `
+    -EnvironmentId "00000000-0000-0000-0000-000000000000" `
+    -SolutionCheckerMode "block" `
+    -DisableUnmanagedCustomizations `
+    -EnablePipelines
+```
+
+**Script location:** [`scripts/Set-GovernanceConfig.ps1`](../scripts/Set-GovernanceConfig.ps1)
+
+### Configuration flags
+
+| Flag | Effect |
+|------|--------|
+| `--solution-checker-mode warn` | Logs solution checker findings without blocking import |
+| `--solution-checker-mode block` | Prevents import of solutions with critical findings |
+| `--disable-unmanaged-customizations` | Blocks unmanaged customizations in the environment |
+| `--enable-pipelines` | Enables deployment pipelines for ALM governance |
+
+### Verification
+
+After applying configuration, verify with:
+
+```powershell
+pac admin governance-config get --environment "00000000-0000-0000-0000-000000000000"
+```
+
+If the CLI verification command is unavailable, verify in PPAC: **Environments** → select environment → **Settings** → **Governance**.
+
+> **Note:** Start with `warn` mode in non-production environments to assess solution checker impact before enforcing `block` in production.
+
+---
+
 ## Authentication for Unattended Automation
 
 Use the strongest authentication pattern available in the runtime that hosts the automation. Microsoft Learn documents `pac auth create --managedIdentity` for Azure Identity-capable environments and federation switches for GitHub/Azure DevOps service-principal auth.

--- a/pipeline-governance-cleanup/docs/manage-pipelines-walkthrough.md
+++ b/pipeline-governance-cleanup/docs/manage-pipelines-walkthrough.md
@@ -1,0 +1,82 @@
+# Manage Pipelines — PPAC Portal Walkthrough
+
+> **Status:** Placeholder — screenshots should be captured from a live tenant.
+
+This document describes the "Manage pipelines" UI surface in the Power Platform Admin Center (PPAC) for reference. Since screenshots cannot be captured programmatically, structured text descriptions and screenshot placeholders are provided.
+
+## Navigation Path
+
+1. **Sign in** to the Power Platform Admin Center at [admin.powerplatform.microsoft.com](https://admin.powerplatform.microsoft.com)
+2. In the left navigation, select **Environments**
+3. Select the **target environment** (the pipelines host environment)
+4. Select **Settings** from the top command bar
+5. Expand **Resources**
+6. Select **Manage pipelines**
+
+> **Note:** "Manage pipelines" opens an embedded model-driven app for **platform host** environments. For **custom host** environments, use the standalone **Deployment Pipeline Configuration** app instead. See [Microsoft Learn — Set up pipelines](https://learn.microsoft.com/power-platform/alm/set-up-pipelines) for the distinction.
+
+## What You See
+
+### Pipeline List View
+
+The Manage pipelines surface displays:
+
+| Field / Column | Description |
+|---------------|-------------|
+| **Pipeline Name** | Display name of the deployment pipeline |
+| **Description** | Optional description of the pipeline purpose |
+| **Stages** | Target environments configured as deployment stages |
+| **Status** | Active / Inactive status of the pipeline |
+| **Created On** | Date the pipeline was created |
+| **Modified On** | Date of last modification |
+
+### Actions Available
+
+From the pipeline list, administrators can:
+
+- **Create** a new pipeline with target stages
+- **Edit** an existing pipeline (add/remove stages, rename)
+- **Deactivate** a pipeline to prevent deployments
+- **Delete** a pipeline (irreversible — deactivate first for safety)
+- **View run history** for audit trail
+
+### Stage Configuration
+
+Each pipeline contains one or more stages. For each stage:
+
+| Field | Description |
+|-------|-------------|
+| **Stage Name** | Target environment display name |
+| **Environment** | Linked Power Platform environment |
+| **Stage Order** | Deployment sequence (Dev → Test → Prod) |
+| **Pre-deployment Step** | Optional approval gate |
+
+## Screenshot Placeholders
+
+The following screenshots should be captured from a live tenant to complete this documentation:
+
+<!-- EXPECTED screenshots — capture from a live PPAC tenant -->
+
+| # | Screenshot Description | Expected File |
+|---|----------------------|---------------|
+| 1 | PPAC Environments list with target host highlighted | `ppac-environments-list.png` |
+| 2 | Environment Settings → Resources → Manage pipelines link | `manage-pipelines-link.png` |
+| 3 | Manage pipelines — pipeline list view | `manage-pipelines-list.png` |
+| 4 | Pipeline detail — stages configuration | `pipeline-stages-detail.png` |
+| 5 | Deployment Pipeline Configuration app (custom host alternative) | `dpc-app-custom-host.png` |
+
+> **Capture instructions:** Use browser zoom at 100%, capture the full browser viewport, save as PNG. Store screenshots in `maintainers-local/tenant-evidence/pipeline-governance-cleanup/` (gitignored).
+
+## Platform Host vs. Custom Host
+
+| Aspect | Platform Host | Custom Host |
+|--------|--------------|-------------|
+| **Access** | PPAC → Manage pipelines (embedded) | Standalone Deployment Pipeline Configuration app |
+| **Setup** | Automatic for Managed Environments | Requires Power Platform Pipelines app installation |
+| **Recommendation** | Use for standard ALM | Use when advanced stage configuration is needed |
+
+For FSI organizations, a **dedicated custom host environment** is recommended to maintain separation between the pipeline infrastructure and target deployment environments.
+
+---
+
+*Updated: May 2026 | Version: v1.0*

--- a/pipeline-governance-cleanup/scripts/Set-GovernanceConfig.ps1
+++ b/pipeline-governance-cleanup/scripts/Set-GovernanceConfig.ps1
@@ -1,0 +1,158 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Applies recommended governance configuration to a Power Platform environment
+    using pac admin set-governance-config.
+
+.DESCRIPTION
+    Configures Managed Environment governance settings for production environments.
+    This script wraps pac admin set-governance-config with FSI-recommended defaults:
+    - Solution checker enforcement mode (warn or block)
+    - Disable unmanaged solution customizations
+    - Enable deployment pipelines
+
+    IMPORTANT: This script requires the Power Platform Admin role and PAC CLI
+    authenticated to the target tenant.
+
+    After applying configuration, the script verifies the settings using
+    pac admin governance-config get (when available) and outputs the result.
+
+.PARAMETER EnvironmentId
+    Target Power Platform environment ID (GUID).
+
+.PARAMETER SolutionCheckerMode
+    Solution checker enforcement mode. 'warn' logs findings without blocking;
+    'block' prevents import of solutions with critical findings.
+    Default: warn
+
+.PARAMETER DisableUnmanagedCustomizations
+    If specified, disables unmanaged solution customizations in the environment.
+
+.PARAMETER EnablePipelines
+    If specified, enables deployment pipelines for the environment.
+
+.PARAMETER DryRun
+    If specified, prints the commands that would be executed without running them.
+
+.EXAMPLE
+    .\Set-GovernanceConfig.ps1 -EnvironmentId "00000000-0000-0000-0000-000000000000"
+
+.EXAMPLE
+    .\Set-GovernanceConfig.ps1 -EnvironmentId "00000000-0000-0000-0000-000000000000" `
+        -SolutionCheckerMode "block" -DisableUnmanagedCustomizations -EnablePipelines
+
+.NOTES
+    Prerequisites:
+    - Power Platform CLI (pac) installed and authenticated
+    - Power Platform Admin role
+
+    Reference:
+    - https://learn.microsoft.com/power-apps/maker/data-platform/use-powerapps-checker
+    - https://learn.microsoft.com/power-platform/admin/managed-environment-overview
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')]
+    [string]$EnvironmentId,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("warn", "block")]
+    [string]$SolutionCheckerMode = "warn",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$DisableUnmanagedCustomizations,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$EnablePipelines,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "[INFO] $Message" -ForegroundColor Cyan
+}
+
+# ── Validate PAC CLI ─────────────────────────────────────────────────────────
+
+try {
+    $null = Get-Command pac -ErrorAction Stop
+}
+catch {
+    Write-Error "PAC CLI (pac) not found on PATH. Install from https://learn.microsoft.com/power-platform/developer/cli/introduction"
+    return
+}
+
+# ── Build command arguments ──────────────────────────────────────────────────
+
+$setArgs = @(
+    "admin", "set-governance-config",
+    "--environment", $EnvironmentId,
+    "--solution-checker-mode", $SolutionCheckerMode
+)
+
+if ($DisableUnmanagedCustomizations) {
+    $setArgs += "--disable-unmanaged-customizations"
+}
+
+if ($EnablePipelines) {
+    $setArgs += "--enable-pipelines"
+}
+
+$cmdDisplay = "pac $($setArgs -join ' ')"
+
+# ── Execute or preview ───────────────────────────────────────────────────────
+
+if ($DryRun) {
+    Write-Info "[DRY RUN] Would execute:"
+    Write-Host "  $cmdDisplay"
+    Write-Host ""
+    Write-Info "[DRY RUN] Would then verify with:"
+    Write-Host "  pac admin governance-config get --environment $EnvironmentId"
+    return
+}
+
+Write-Info "Applying governance configuration..."
+Write-Info "Command: $cmdDisplay"
+Write-Host ""
+
+$output = & pac @setArgs 2>&1
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -ne 0) {
+    Write-Error "pac admin set-governance-config failed (exit $exitCode): $($output -join "`n")"
+    return
+}
+
+Write-Host ($output -join "`n")
+Write-Host ""
+
+# ── Verify ───────────────────────────────────────────────────────────────────
+
+Write-Info "Verifying applied configuration..."
+
+$verifyArgs = @("admin", "governance-config", "get", "--environment", $EnvironmentId)
+$verifyOutput = & pac @verifyArgs 2>&1
+$verifyExit = $LASTEXITCODE
+
+if ($verifyExit -ne 0) {
+    Write-Host "[WARN] Verification command not available or failed (exit $verifyExit)." -ForegroundColor Yellow
+    Write-Host "  Manually verify in Power Platform Admin Center:" -ForegroundColor Yellow
+    Write-Host "  Environments > $EnvironmentId > Settings > Governance" -ForegroundColor Yellow
+}
+else {
+    Write-Host ($verifyOutput -join "`n")
+}
+
+Write-Host ""
+Write-Info "Governance configuration applied to environment $EnvironmentId"
+Write-Info "  Solution checker mode: $SolutionCheckerMode"
+if ($DisableUnmanagedCustomizations) { Write-Info "  Unmanaged customizations: disabled" }
+if ($EnablePipelines) { Write-Info "  Deployment pipelines: enabled" }


### PR DESCRIPTION
Implements **8 H items from #129** (lifecycle-ops 2026-Q2 triage) — adopts Microsoft Learn 2026-Q2 patterns into the lifecycle-ops domain.

## Items shipped (closes #129 H section)

| Solution | H# | Description |
|----------|----|-------------|
| `coi-testing` | H1 | PAC CLI inventory script (`Get-CoiInventory.ps1`) |
| `agent-365-lifecycle-governance` | H2 | Env vars `fsi_ALG_DeletionHoldDays` + `fsi_ALG_AgentRegistryApiVersion` |
| `dr-testing-framework` | H3 | KQL templates (DR detection, replication lag, RPO/RTO) |
| `dr-testing-framework` | H4 | Emergency-access drill doc (OCC 2011-12 quarterly cadence) |
| `pipeline-governance-cleanup` | H5 | `Set-GovernanceConfig.ps1` wrapper with verification |
| `pipeline-governance-cleanup` | H6 | Manage pipelines walkthrough (structured screenshot placeholders) |
| `message-center-monitor` | H7 | Service-health Graph ingestion (`ingest_service_health.py`) |
| `message-center-monitor` | H8 | PowerShell `Invoke-MgGraphRequest` snippet doc |

## Net change
- 13 new files, 1431 LoC
- 5 commits (some grouped per solution where logically coupled)

## Validation green
- python compile: PASS (2 .py files)
- PowerShell parse: PASS (2 .ps1 files)
- `scripts/lint-odata-columns.py`: 0 violations across 701 files
- pytest: 13 passed (message-center-monitor)

## Out of scope (deferred to next cycle)
M items + Defer items remain tracked in #129 body.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>