### PR TITLE
chore(release-hygiene): sync 12 solution changelogs to current manifest versions

### DIFF
--- a/agent-knowledge-source-scanner/CHANGELOG.md
+++ b/agent-knowledge-source-scanner/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to agent-knowledge-source-scanner will be documented in this
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-05-17
+
 ### Added
 
 - **Graph v1.0 permission scan path.** New `Invoke-GraphPermissionScan.ps1` script uses Microsoft Graph v1.0 `/drives/{driveId}/items/{itemId}/permissions` endpoint for permission scanning. Resolves `grantedToIdentitiesV2` for specific-people links, addressing the `FlexibleLink` limitation in the PnP-based scanner. Required Graph permissions: `Sites.Read.All`, `Files.Read.All`, `Group.Read.All`.

--- a/agent-sharing-access-restriction-detector/CHANGELOG.md
+++ b/agent-sharing-access-restriction-detector/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Agent Sharing Access Restriction Detector are documen
 
 ## [Unreleased]
 
+## [2.0.1] — 2026-05-17
+
 ### Fixed
 
 - Critical: `Invoke-SharingComplianceScan.ps1` now evaluates Copilot Studio agent sharing from the Dataverse `bot.accesscontrolpolicy` and `bot.authorizedsecuritygroupids` columns instead of the non-current `sharingtype` field and unsupported `Get-AdminPowerAppRoleAssignment -ResourceType/-ResourceId` parameters.

--- a/audit-compliance-manager/CHANGELOG.md
+++ b/audit-compliance-manager/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-05-17
+
 ### Changed
 
 - Bumped solution version to v1.0.4 for the Microsoft Learn 2026-Q2 technical refresh.

--- a/coi-testing/CHANGELOG.md
+++ b/coi-testing/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the COI Testing Framework.
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-05-17
+
 ### Changed
 
 - Refreshed Dataverse authentication guidance and runner support for managed identity, workload identity federation, certificate auth, Azure CLI auth, and legacy development client-secret fallback based on Microsoft Learn 2026-Q2 guidance.

--- a/compliance-dashboard/CHANGELOG.md
+++ b/compliance-dashboard/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Compliance Dashboard solution.
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-05-17
+
 ### Changed
 
 - Bumped solution metadata to v1.0.4 for the Microsoft Learn 2026-Q2 refresh.

--- a/content-moderation-monitor/CHANGELOG.md
+++ b/content-moderation-monitor/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Content Moderation Monitor.
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-05-17
+
 ### Added
 
 - **Purview Audit / DSPM correlation.** New `correlate_purview_events.py` script correlates moderation violations with Purview unified audit log events and DSPM signals. Queries Purview Audit via Graph `auditLogQuery` API, matches events by user + timestamp proximity (5-minute window), and enriches output with sensitivity labels, DLP policy matches, and Copilot interaction context. Requires `AuditLogsQuery.Read.All` and `User.Read.All` Graph permissions.

--- a/cross-tenant-external-sharing-governance/CHANGELOG.md
+++ b/cross-tenant-external-sharing-governance/CHANGELOG.md
@@ -6,6 +6,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-05-17
+
 ### Fixed
 
 - Refreshed Microsoft Learn-aligned guidance for Power Platform tenant isolation, replacing stale preview governance-path flow/checklist references with PPAC and `Get-PowerAppTenantIsolationPolicy` / `Set-PowerAppTenantIsolationPolicy` validation guidance.

--- a/dr-testing-framework/CHANGELOG.md
+++ b/dr-testing-framework/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the DR Readiness Validation Framework.
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-05-17
+
 ### Changed
 
 - Bumped manifest metadata to v2.0.1 for the 2026-Q2 Microsoft Learn refresh.

--- a/file-upload-security/CHANGELOG.md
+++ b/file-upload-security/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the File Upload Security Configurator will be documented 
 
 ## [Unreleased]
 
+## [1.1.1] — 2026-05-17
+
 ### Added
 
 - **Downstream attachment validation guide.** New `docs/downstream-validation.md` documents how downstream consumers should validate file attachments after upload, covering file magic-number validation, Microsoft Defender for Cloud integration checks, and sensitivity label inheritance verification with PowerShell and Python code examples.

--- a/hitl-workflow-governance/CHANGELOG.md
+++ b/hitl-workflow-governance/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-05-17
+
 ### Added
 
 - Added optional exception-request audit columns (`fsi_RequestedBy`, `fsi_RequestedAt`, `fsi_ApprovalStatus`, `fsi_ApprovalNotes`) so the Power Automate approval flow can track pending, approved, rejected, and timed-out exception requests without relying on non-existent Dataverse fields.

--- a/pipeline-governance-cleanup/CHANGELOG.md
+++ b/pipeline-governance-cleanup/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-05-17
+
 ### Changed
 - Bumped solution manifest version to 1.2.1 for the 2026-Q2 Microsoft Learn refresh.
 - Refreshed Power Platform Pipelines guidance for custom host prerequisites, pipeline table references, trigger configuration, PAC CLI authentication, and solution checker integration.

--- a/rag-source-validator/CHANGELOG.md
+++ b/rag-source-validator/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the RAG Source Validator.
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-05-17
+
 ### Added
 
 - **5 new Dataverse columns on `fsi_knowledgesource`.** Additive schema migration adding `fsi_etag` (eTag, String 255), `fsi_ctag` (cTag, String 255), `fsi_deltalink` (Delta Link, Url 2048), `fsi_searchconnectorid` (Search Connector ID, String 100), and `fsi_lineageuri` (Lineage URI, Url 2048). Re-run `create_rsv_dataverse_schema.py` to apply — existing data is unaffected.


### PR DESCRIPTION
## Summary

Closes #140. Graduates 12 solution `[Unreleased]` CHANGELOG blocks to their current manifest versions dated 2026-05-17. Empty `[Unreleased]` headings preserved at the top for future changes.

## Affected solutions (12)

- agent-knowledge-source-scanner
- content-moderation-monitor
- file-upload-security
- rag-source-validator
- compliance-dashboard
- audit-compliance-manager
- hitl-workflow-governance
- coi-testing
- dr-testing-framework
- pipeline-governance-cleanup
- cross-tenant-external-sharing-governance
- agent-sharing-access-restriction-detector

## Out of scope

This PR does NOT bump any `manifest.yaml` versions. The 4 H-item solutions flagged in #140 (`agent-knowledge-source-scanner`, `content-moderation-monitor`, `file-upload-security`, `rag-source-validator`) may merit a later version-bump review; that's a separate decision.

## Validation

- `python scripts/build-manifest.py`
- `python scripts/build-manifest.py --check`
- `python scripts/lint-odata-columns.py`
- `mkdocs build --strict`
- Manifest ↔ CHANGELOG drift check: pass

Closes #140
