### PR TITLE
chore(metadata): formalize canonical README version+status header per solution

### DIFF
--- a/action-confirmation-auditor/README.md
+++ b/action-confirmation-auditor/README.md
@@ -8,8 +8,9 @@ coe_function: govern
 ---
 # Action Confirmation Auditor
 
-> **Version:** v1.1.1
-> **Status:** Completed
+> **Version:** v1.2.0
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Validates that Copilot Studio agent topics include user confirmation steps before executing actions (connector calls, cloud flows, plugins, HTTP requests), with zone-based policy enforcement for financial services governance.
 

--- a/agent-365-lifecycle-governance/README.md
+++ b/agent-365-lifecycle-governance/README.md
@@ -9,7 +9,10 @@ coe_function: enable
 ---
 # Agent 365 Lifecycle Governance
 
-> **Status:** v1.1.4 — GA (Microsoft Agent 365 generally available for Commercial segment as of May 1, 2026)
+> **Version:** v1.1.4
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
+> **Upstream Microsoft dependency:** Mixed — Microsoft Agent 365 is generally available for commercial tenants, but Agent Registry and package-management APIs remain preview and should be validated before the feature flag is enabled.
 
 Automated lifecycle governance for AI agents using Microsoft Agent 365, Entra ID Governance, and Power Platform. Covers the full lifecycle loop: sponsor assignment, access reviews, inactivity detection, deactivation workflows, and deletion holds with zone-based policy enforcement.
 

--- a/agent-365-lifecycle-governance/manifest.yaml
+++ b/agent-365-lifecycle-governance/manifest.yaml
@@ -19,6 +19,9 @@ prerequisites:
   security-admin: Microsoft Entra ID Governance or Microsoft Entra Suite, AgentInstance Graph permissions, security groups, and admin consent.
   power-platform-admin: Managed Dataverse environment, Power Automate Premium, and LTR-enabled schema deployment.
 verification: Confirm Test-LifecycleCompliance.ps1 completes and writes a lifecycle compliance event row.
+upstreamDependency:
+  status: mixed
+  note: Microsoft Agent 365 is generally available for commercial tenants, but Agent Registry and package-management APIs remain preview and should be validated before the feature flag is enabled.
 
 # zones/dataClassification CONFIRMED 2026-Q2 (issue #37):
 #   Agent 365 + Entra ID Governance; tenant-wide enterprise capability

--- a/agent-access-monitor/README.md
+++ b/agent-access-monitor/README.md
@@ -8,10 +8,11 @@ coe_function: optimize
 ---
 # Agent Access Governance Monitor
 
-Automated validation of Power Platform environment agent access settings against zone-specific governance requirements.
-
 > **Version:** v1.1.1
-> **Status:** Completed
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
+
+Automated validation of Power Platform environment agent access settings against zone-specific governance requirements.
 
 See [CHANGELOG](./CHANGELOG.md) for version history.
 

--- a/agent-communication-restriction-detector/README.md
+++ b/agent-communication-restriction-detector/README.md
@@ -8,16 +8,11 @@ coe_function: govern
 ---
 # Agent Communication Restriction Detector
 
+> **Version:** v1.2.0
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
+
 Detects unauthorized agent-to-agent communication patterns, zone boundary violations, cross-tenant communication, and maker/checker violations in Copilot Studio multi-agent orchestration.
-
-## Status
-
-| Property | Value |
-|----------|-------|
-| Status | Released |
-| Version | 1.1.1 |
-| Primary Control | [2.17 -- Multi-Agent Orchestration Limits](https://judeper.github.io/FSI-AgentGov/controls/pillar-2-management/2.17-multi-agent-orchestration-limits/) |
-| Regulatory Context | FINRA 3110, GLBA 501(b), SOX 404 |
 
 ## Overview
 

--- a/agent-knowledge-source-scanner/README.md
+++ b/agent-knowledge-source-scanner/README.md
@@ -8,7 +8,9 @@ coe_function: govern
 ---
 # Agent Knowledge Source Scanner
 
-> **Status:** Completed | **Version:** v1.1.1
+> **Version:** v1.1.1
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Item-level permission scanning for SharePoint libraries backing Copilot Studio agent knowledge sources.
 

--- a/agent-observability-foundation/README.md
+++ b/agent-observability-foundation/README.md
@@ -9,7 +9,8 @@ coe_function: optimize
 # Agent Observability Foundation
 
 > **Version:** v1.2.1
-> **Status:** Completed
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 FSI-compliant telemetry infrastructure for Microsoft Copilot Studio agents with long-term audit retention, operational workbooks, and proactive alerting.
 

--- a/agent-registry-automation/README.md
+++ b/agent-registry-automation/README.md
@@ -9,7 +9,9 @@ coe_function: enable
 ---
 # Agent Registry Automation
 
-> **Status:** Production Ready (v2.1.0)
+> **Version:** v2.1.0
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Automated discovery, registration, approval, and lifecycle governance of AI agents across Power Platform environments, supporting FSI agent inventory and record-keeping requirements.
 

--- a/agent-sharing-access-restriction-detector/README.md
+++ b/agent-sharing-access-restriction-detector/README.md
@@ -9,7 +9,8 @@ coe_function: govern
 # Agent Sharing Access Restriction Detector
 
 > **Version:** v2.0.1
-> **Status:** Completed
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 See [CHANGELOG](./CHANGELOG.md) for version history.
 

--- a/audit-compliance-manager/README.md
+++ b/audit-compliance-manager/README.md
@@ -9,7 +9,8 @@ coe_function: govern
 # Audit Compliance Manager (ACM)
 
 > **Version:** v1.0.4
-> **Status:** Completed
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Unified audit compliance solution for Microsoft 365 and Power Platform environments. Consolidates the Audit Configuration Validator (ACV) and Audit Logging Compliance Automation (ALCA) into a single solution that validates audit configurations, detects compliance gaps, and remediates non-compliant environments.
 

--- a/coi-testing/README.md
+++ b/coi-testing/README.md
@@ -7,7 +7,10 @@ coe_function: govern
 ---
 # Conflict of Interest Testing
 
-> **Status:** Scaffold (Preview) — scenario library and persistence pipeline are
+> **Version:** v1.1.1
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
+
 > implemented; the agent-interaction layer that drives a Copilot Studio agent
 > via Direct Line is not yet implemented. Scenarios currently report `SKIPPED`
 > until the integration is added. See *Implementation Status* below.

--- a/compliance-dashboard/README.md
+++ b/compliance-dashboard/README.md
@@ -8,7 +8,9 @@ coe_function: optimize
 ---
 # Compliance Dashboard
 
-> **Status:** Completed
+> **Version:** v1.0.4
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Aggregated compliance reporting dashboard for the FSI Agent Governance Framework, providing unified visibility across the control records loaded into Dataverse with zone-based filtering. The included sample dataset contains 62 controls; organizations should load the validated 78-control framework baseline before describing the dashboard as full-framework coverage.
 

--- a/conditional-access-automation/README.md
+++ b/conditional-access-automation/README.md
@@ -8,7 +8,9 @@ coe_function: govern
 ---
 # Conditional Access Automation
 
-> **Status:** Completed | **Version:** v2.0.1
+> **Version:** v2.0.1
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Automated deployment and compliance monitoring of Entra ID Conditional Access policies for Microsoft 365 AI workloads (Copilot Studio, Agent Builder, M365 Copilot).
 

--- a/content-moderation-monitor/README.md
+++ b/content-moderation-monitor/README.md
@@ -8,17 +8,17 @@ coe_function: optimize
 ---
 # Content Moderation Monitor
 
-Automated validation of Copilot Studio agent content moderation levels against zone-specific governance requirements.
+> **Version:** v1.1.1
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
-> **Status:** Completed
+Automated validation of Copilot Studio agent content moderation levels against zone-specific governance requirements.
 
 ## Overview
 
 The Content Moderation Monitor detects when Copilot Studio agents have insufficient content moderation settings for their governance zone. Unlike environment-level solutions, this monitor performs **per-agent validation** — examining each bot deployed across your Power Platform environments.
 
 It supports Control 1.27 (AI Agent Content Moderation Enforcement) by automating compliance validation against the FSI Agent Governance Framework's zone-based moderation requirements, and contributes complementary evidence to Control 1.8 (Runtime Protection and External Threat Detection). See [Scope and Limitations](#scope-and-limitations) below.
-
-**Version:** 1.1.1
 
 See [CHANGELOG](./CHANGELOG.md) for version history.
 

--- a/copilot-studio-analytics/README.md
+++ b/copilot-studio-analytics/README.md
@@ -9,7 +9,8 @@ coe_function: optimize
 # Copilot Studio Analytics
 
 > **Version:** v2.0.1
-> **Status:** Active
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Business impact analytics for Copilot Studio agents -- session outcomes, CSAT, Agent Assisted Hours, and ROI calculations. Provides a customizable, partial alternative to Microsoft Viva Insights for organizations without Viva Insights licenses or that need zone-based governance and regulatory-reporting integration. Not a full Viva replacement -- see [docs/viva-insights-parity-matrix.md](docs/viva-insights-parity-matrix.md).
 

--- a/credential-oversharing-detector/README.md
+++ b/credential-oversharing-detector/README.md
@@ -8,7 +8,11 @@ coe_function: govern
 ---
 # Credential Oversharing Detector
 
-> **Version:** v2.0.1 | **Controls:** 1.14, 1.4, 1.18 | **Status:** Public Preview
+> **Version:** v2.1.0
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
+> **Upstream Microsoft dependency:** Preview — Copilot Studio credential-oversharing detection is currently listed by Microsoft for public preview and should be validated in a non-production tenant before regulated production use.
+
 >
 > ⚠️ **Preview Feature Dependency:** This solution tracks the Microsoft "Enforce safe sharing by detecting credential oversharing" capability, which the Microsoft release plan currently lists for public preview in July 2026 and general availability in September 2026. Verify current feature status at the [Microsoft release plan](https://learn.microsoft.com/en-us/power-platform/release-plan/2026wave1/microsoft-copilot-studio/enforce-safe-sharing-detecting-credential-oversharing) before production deployment.
 

--- a/credential-oversharing-detector/manifest.yaml
+++ b/credential-oversharing-detector/manifest.yaml
@@ -13,6 +13,9 @@ url: https://judeper.github.io/FSI-AgentGov-Solutions/solutions/credential-overs
 prerequisites:
   power-platform-admin: Power Platform admin tenant role and Dataverse environment with the fsi publisher prefix.
 verification: Confirm Invoke-CredentialScan.ps1 writes rows to `fsi_credentialscans` and `fsi_credentialviolations`.
+upstreamDependency:
+  status: preview
+  note: Copilot Studio credential-oversharing detection is currently listed by Microsoft for public preview and should be validated in a non-production tenant before regulated production use.
 
 # zones/dataClassification CONFIRMED 2026-Q2 (issue #37):
 #   per-connector credential governance applies wherever agents call connectors

--- a/cross-solution-integration/README.md
+++ b/cross-solution-integration/README.md
@@ -8,9 +8,11 @@ coe_function: scale
 ---
 # Cross-Solution Integration
 
-Integration layer that connects the 6 Tier 2 governance solutions into the Compliance Dashboard and Environment Lifecycle Management workflow.
+> **Version:** v2.0.2
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
-> **Status:** Completed
+Integration layer that connects the 6 Tier 2 governance solutions into the Compliance Dashboard and Environment Lifecycle Management workflow.
 
 ## Overview
 

--- a/cross-tenant-external-sharing-governance/README.md
+++ b/cross-tenant-external-sharing-governance/README.md
@@ -9,7 +9,8 @@ coe_function: govern
 # Cross-Tenant and External Sharing Governance
 
 > **Version:** v1.0.3
-> **Status:** Completed
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Automated detection, validation, and remediation of cross-tenant access for Power Platform AI agents in FSI environments.
 

--- a/deny-event-correlation-report/README.md
+++ b/deny-event-correlation-report/README.md
@@ -8,7 +8,9 @@ coe_function: optimize
 ---
 # Deny Event Correlation Report
 
-> **Status:** Validated
+> **Version:** v2.0.3
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Daily operational reporting solution for correlating "deny/no content returned" events across Microsoft Copilot and Copilot Studio agents.
 

--- a/dr-testing-framework/README.md
+++ b/dr-testing-framework/README.md
@@ -8,7 +8,9 @@ coe_function: govern
 ---
 # DR Readiness Validation Framework (DR-Testing-Framework)
 
-> **Version:** 2.0.1 | **Controls:** 2.4, 2.1, 1.9
+> **Version:** v2.0.1
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Scheduled validation that the post-recovery state of an AI agent environment in Microsoft Power Platform is observable, reachable, and correctly configured — packaging structured evidence for FFIEC BCP, FINRA Rule 4370, OCC Heightened Standards, and SEC Rule 17a-4(f) supervisory review.
 

--- a/environment-lifecycle-management/README.md
+++ b/environment-lifecycle-management/README.md
@@ -8,7 +8,9 @@ coe_function: enable
 ---
 # Environment Lifecycle Management
 
-> **Status:** Completed
+> **Version:** v1.2.1
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Automated Power Platform environment provisioning with zone-based governance classification.
 

--- a/file-upload-security/README.md
+++ b/file-upload-security/README.md
@@ -8,9 +8,11 @@ coe_function: govern
 ---
 # File Upload Security Configurator
 
-Automated validation of Copilot Studio agent file upload settings against governance zone policies. Supports Control 1.14 (Data Minimization and Agent Scope Control) by detecting agents with file uploads enabled in zones where uploads should be restricted or disabled.
+> **Version:** v1.1.1
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
-> **Status:** Completed
+Automated validation of Copilot Studio agent file upload settings against governance zone policies. Supports Control 1.14 (Data Minimization and Agent Scope Control) by detecting agents with file uploads enabled in zones where uploads should be restricted or disabled.
 
 ## Solution Overview
 

--- a/finra-supervision-workflow/README.md
+++ b/finra-supervision-workflow/README.md
@@ -9,7 +9,9 @@ coe_function: govern
 ---
 # FINRA Supervision Workflow
 
-> **Status:** Preview (v1.1.0)
+> **Version:** v1.1.0
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Automated **retrospective** supervision workflow for AI agent outputs to support FINRA Rule 3110 compliance in financial services organizations. This solution provides a post-delivery review queue, SLA tracking, escalation, append-only Dataverse audit logging, and WORM-ready evidence export fed by Microsoft Purview Communication Compliance.
 
@@ -311,7 +313,6 @@ Reference Microsoft Learn guidance: [Azure Blob immutable storage](https://learn
 ### FINRA 3120 Testing Evidence
 
 Quarterly testing reports per FINRA Rule 3120:
-
 
 > **Planned — not yet implemented.** A `generate_3120_report.py` script for automated quarterly report generation is planned for a future release. In the interim, use the weekly supervision evidence exports to compile quarterly testing evidence manually.
 

--- a/generative-ai-config-auditor/README.md
+++ b/generative-ai-config-auditor/README.md
@@ -7,16 +7,11 @@ coe_function: govern
 ---
 # Generative AI Config Auditor
 
+> **Version:** v1.2.0
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
+
 Validates generative AI feature configurations (Azure OpenAI integration, generative orchestration, generative answers nodes, knowledge sources, Allow ungrounded responses / AI general knowledge, and Work IQ / semantic search) for Copilot Studio agents against zone-specific governance policies.
-
-## Status
-
-| Property | Value |
-|----------|-------|
-| Status | In Development |
-| Version | 1.1.1 |
-| Primary Control | [2.24 -- Agent Feature Enablement Governance](https://judeper.github.io/FSI-AgentGov/controls/pillar-2-management/2.24-agent-feature-enablement-governance/) |
-| Regulatory Context | FINRA Rule 3110, GLBA Section 501(b), SOX Section 404 |
 
 ## Overview
 

--- a/hallucination-tracker/README.md
+++ b/hallucination-tracker/README.md
@@ -9,7 +9,9 @@ coe_function: optimize
 ---
 # Hallucination Feedback Tracker
 
-> **Version:** 1.2.0 — This solution provides Dataverse schema deployment scripts, Python pattern analysis, PowerShell governance scripts, environment variables, and connection references for feedback aggregation and hallucination pattern review.
+> **Version:** v1.2.0
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Feedback aggregation pipeline for tracking and analyzing hallucination patterns in AI agent outputs.
 

--- a/hitl-workflow-governance/README.md
+++ b/hitl-workflow-governance/README.md
@@ -9,7 +9,9 @@ coe_function: govern
 # HITL Workflow Governance
 
 > **Version:** v1.1.1
-> **Status:** Completed
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
+> **Upstream Microsoft dependency:** Preview — The Request for Information and Run a Multistage Approval actions remain preview in Microsoft Learn and should be reviewed against preview terms before regulated-data use.
 
 Validates that Copilot Studio agent flows include required human-in-the-loop (HITL) checkpoints per zone governance policy, using Microsoft's **Request for Information** and **Run a Multistage Approval** actions from the `shared_advancedapprovals` connector.
 

--- a/hitl-workflow-governance/manifest.yaml
+++ b/hitl-workflow-governance/manifest.yaml
@@ -14,6 +14,9 @@ prerequisites:
   power-platform-admin: "Power Platform admin tenant role or Dataverse environment administration for Copilot Studio scanning and schema deployment."
   security-admin: "Entra Global Admin or Application Administrator permissions for app registration, consent, and service principal setup."
 verification: "Run a scan and confirm new rows in fsi_HitlScanRun and fsi_HitlCheckpointResult, then verify the target Copilot Studio bot is listed in the maker portal."
+upstreamDependency:
+  status: preview
+  note: The Request for Information and Run a Multistage Approval actions remain preview in Microsoft Learn and should be reviewed against preview terms before regulated-data use.
 
 # zones/dataClassification CONFIRMED 2026-Q2 (issue #37):
 #   per-agent HITL checkpoint governance applies wherever the agent has flows

--- a/inactivity-timeout-enforcement/README.md
+++ b/inactivity-timeout-enforcement/README.md
@@ -9,7 +9,8 @@ coe_function: govern
 # Inactivity Timeout Enforcement
 
 > **Version:** v1.1.1
-> **Status:** Completed
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Cloud Flow template for daily compliance detection of inactivity timeout settings across Power Platform environments.
 

--- a/message-center-monitor/README.md
+++ b/message-center-monitor/README.md
@@ -8,7 +8,9 @@ coe_function: scale
 ---
 # Message Center Monitor
 
+> **Version:** v2.5.1
 > **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Monitor Microsoft 365 Message Center for platform changes that could impact AI agent deployments (Copilot Studio, Agent Builder).
 

--- a/mime-type-restrictions/README.md
+++ b/mime-type-restrictions/README.md
@@ -9,7 +9,8 @@ coe_function: govern
 # MIME Type Restrictions for File Uploads
 
 > **Version:** v1.2.1
-> **Status:** Completed
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Dataverse plugin, connector-classification reference, and Sentinel queries for MIME type restriction governance in Copilot Studio agent file upload scenarios.
 

--- a/model-risk-management-automation/README.md
+++ b/model-risk-management-automation/README.md
@@ -8,7 +8,9 @@ coe_function: govern
 ---
 # Model Risk Management Automation
 
-> **Status:** Production Ready (v1.0.3)
+> **Version:** v1.0.3
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Automated model risk management workflows for AI agents deployed on Power Platform, aligned to OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) and Fed SR 26-2 (formerly Fed SR 11-7) principles where applicable. This solution automates model inventory submission, risk scoring, independent validation workflows, ongoing monitoring, and examiner-facing Agent Card generation.
 

--- a/pipeline-governance-cleanup/README.md
+++ b/pipeline-governance-cleanup/README.md
@@ -8,7 +8,9 @@ coe_function: enable
 ---
 # Pipeline Governance Cleanup
 
-> **Status:** Completed
+> **Version:** v1.2.1
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Discover, notify, and clean up personal Power Platform pipelines before enforcing centralized ALM governance.
 

--- a/rag-source-validator/README.md
+++ b/rag-source-validator/README.md
@@ -8,7 +8,9 @@ coe_function: govern
 ---
 # RAG Source Validator
 
-> **Status:** Completed (v1.3.0)
+> **Version:** v1.3.0
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Integrity validation for Retrieval-Augmented Generation (RAG) knowledge sources with change detection and audit capabilities.
 

--- a/scope-drift-monitor/README.md
+++ b/scope-drift-monitor/README.md
@@ -8,7 +8,9 @@ coe_function: optimize
 ---
 # Scope Drift Monitor
 
-> **Status:** Completed (v1.2.1)
+> **Version:** v1.2.1
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Automated detection of AI agent data access beyond declared operational scope, supporting GDPR data minimization and FSI data governance requirements.
 

--- a/scripts/build-manifest.py
+++ b/scripts/build-manifest.py
@@ -28,6 +28,11 @@ Validation runs on every invocation:
 * Every `controls[]` entry MUST exist in the framework `controls.json`
   (path resolved from FRAMEWORK_CONTROLS env var, defaulting to a sibling
   `fsi-agentgov` checkout).
+* Every top-level solution `README.md` MUST expose a parseable metadata header
+  near the H1 that matches the manifest-driven version/status contract:
+  `Version`, `Status`, `Validated against framework version`, and an optional
+  `Upstream Microsoft dependency` line when `manifest.yaml.upstreamDependency`
+  is present.
 
 Usage:
 
@@ -143,6 +148,30 @@ ZONE_ROADMAP_BEGIN = "<!-- BEGIN:ZONE_ROADMAP -->"
 ZONE_ROADMAP_END = "<!-- END:ZONE_ROADMAP -->"
 
 DEPLOYMENT_GUIDE = ROOT / "DEPLOYMENT-GUIDE.md"
+
+README_HEADER_FIELD_LABELS = {
+    "version": "Version",
+    "status": "Status",
+    "validated against framework version": "Validated against framework version",
+    "upstream microsoft dependency": "Upstream Microsoft dependency",
+}
+README_STATUS_SECTION_RE = re.compile(
+    r"^## Status\s*$\n(?:\n|\r\n)(?P<body>\|.*(?:\n|\r\n))+?(?=^## |\Z)",
+    re.MULTILINE,
+)
+README_STATUS_ROW_RE = re.compile(
+    r"^\|\s*(?P<prop>[^|]+?)\s*\|\s*(?P<value>[^|]+?)\s*\|$",
+    re.MULTILINE,
+)
+README_VERSION_TOKEN_RE = re.compile(r"v?(\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?)")
+README_CAPE_VERSION_RE = re.compile(
+    r"^#\s*(v\d+\.\d+\.\d+)\s+CAPE alignment metadata$", re.MULTILINE
+)
+UPSTREAM_DEPENDENCY_STATUS_LABELS = {
+    "preview": "Preview",
+    "ga": "GA",
+    "mixed": "Mixed",
+}
 
 CHANGELOG_PATTERNS = {"acv-changelog.md", "alca-changelog.md"}
 
@@ -292,6 +321,146 @@ def validate_manifests(
                     f"{slug}/manifest.yaml: dependency {dep!r} is not a known solution"
                 )
 
+    return errors
+
+
+def extract_cape_framework_version(readme_text: str) -> str | None:
+    """Return the CAPE-alignment framework version embedded in README frontmatter."""
+    match = README_CAPE_VERSION_RE.search(readme_text[:500])
+    return match.group(1) if match else None
+
+
+def render_readme_status(status: str) -> str:
+    """Render the manifest enum for human-facing README headers."""
+    return status.capitalize()
+
+
+def render_upstream_dependency(dependency: dict[str, str]) -> str:
+    """Render the optional upstream Microsoft dependency header value."""
+    status = UPSTREAM_DEPENDENCY_STATUS_LABELS[dependency["status"]]
+    note = dependency["note"].strip()
+    return f"{status} — {note}" if note else status
+
+
+def build_expected_readme_header(readme_text: str, manifest: dict) -> dict[str, str]:
+    """Return the expected README header fields for one solution."""
+    header = {
+        "version": f"v{manifest['version']}",
+        "status": render_readme_status(manifest.get("status", "live")),
+    }
+    framework_version = extract_cape_framework_version(readme_text)
+    if framework_version:
+        header["validated against framework version"] = framework_version
+    dependency = manifest.get("upstreamDependency")
+    if dependency:
+        header["upstream microsoft dependency"] = render_upstream_dependency(dependency)
+    return header
+
+
+def parse_readme_header_fields(readme_text: str) -> dict[str, str]:
+    """Parse the top-of-file README metadata header into a normalized mapping."""
+    top = "\n".join(readme_text.splitlines()[:80])
+    fields: dict[str, str] = {}
+    for key, label in README_HEADER_FIELD_LABELS.items():
+        match = re.search(rf"\*\*{re.escape(label)}:\*\*\s*(?P<value>[^\n]+)", top)
+        if match:
+            fields[key] = match.group("value").strip()
+
+    if "version" not in fields or "status" not in fields:
+        section = README_STATUS_SECTION_RE.search(top)
+        if section:
+            for row in README_STATUS_ROW_RE.finditer(section.group("body")):
+                prop = row.group("prop").strip().lower()
+                value = row.group("value").strip()
+                if prop == "version" and "version" not in fields:
+                    fields["version"] = value
+                elif prop == "status" and "status" not in fields:
+                    fields["status"] = value
+    return fields
+
+
+def parse_version_claim(value: str | None) -> str | None:
+    """Extract a semver token from a README metadata value."""
+    if not value:
+        return None
+    match = README_VERSION_TOKEN_RE.search(value)
+    return match.group(1) if match else None
+
+
+def normalize_status_claim(value: str | None) -> str | None:
+    """Map legacy README labels to the manifest status enum."""
+    if not value:
+        return None
+    lowered = value.lower()
+    patterns = (
+        (r"\b(public\s+)?preview\b", "preview"),
+        (r"\bscaffold\b", "preview"),
+        (r"\bin development\b", "preview"),
+        (r"\blive\b", "live"),
+        (r"\bproduction ready\b", "live"),
+        (r"\bcompleted\b", "live"),
+        (r"\bvalidated\b", "live"),
+        (r"\bactive\b", "live"),
+        (r"\breleased\b", "live"),
+        (r"\bcomplete\b", "live"),
+        (r"\bga\b", "live"),
+    )
+    for pattern, normalized in patterns:
+        if re.search(pattern, lowered):
+            return normalized
+    return None
+
+
+def validate_solution_readme_headers(manifests: dict[str, dict]) -> list[str]:
+    """Validate that each solution README header agrees with manifest metadata."""
+    errors: list[str] = []
+    for slug, manifest in manifests.items():
+        path = ROOT / slug / "README.md"
+        if not path.is_file():
+            errors.append(f"{slug}/README.md: missing top-level solution README")
+            continue
+
+        readme_text = path.read_text(encoding="utf-8")
+        header_fields = parse_readme_header_fields(readme_text)
+        expected_header = build_expected_readme_header(readme_text, manifest)
+
+        claimed_version = parse_version_claim(
+            header_fields.get("version") or header_fields.get("status")
+        )
+        if claimed_version is None:
+            errors.append(f"{slug}/README.md: missing parseable Version header")
+        elif claimed_version != manifest["version"]:
+            errors.append(
+                f"{slug}/README.md: Version header claims v{claimed_version}, "
+                f"expected v{manifest['version']} from manifest.yaml"
+            )
+
+        claimed_status = normalize_status_claim(header_fields.get("status"))
+        expected_status = manifest.get("status", "live")
+        if claimed_status is None:
+            errors.append(f"{slug}/README.md: missing parseable Status header")
+        elif claimed_status != expected_status:
+            errors.append(
+                f"{slug}/README.md: Status header claims {header_fields.get('status')!r}, "
+                f"expected {render_readme_status(expected_status)!r}"
+            )
+
+        for key in (
+            "validated against framework version",
+            "upstream microsoft dependency",
+        ):
+            expected_value = expected_header.get(key)
+            claimed_value = header_fields.get(key)
+            if expected_value and claimed_value != expected_value:
+                errors.append(
+                    f"{slug}/README.md: {README_HEADER_FIELD_LABELS[key]!r} should be "
+                    f"{expected_value!r}, got {claimed_value!r}"
+                )
+            if not expected_value and claimed_value:
+                errors.append(
+                    f"{slug}/README.md: unexpected {README_HEADER_FIELD_LABELS[key]!r} "
+                    f"header {claimed_value!r}; declare it in manifest.yaml first"
+                )
     return errors
 
 
@@ -971,6 +1140,7 @@ def run(check: bool) -> int:
     log.info("  manifests loaded: %d", len(manifests))
 
     errors = validate_manifests(manifests, framework_pillars)
+    errors.extend(validate_solution_readme_headers(manifests))
     if errors:
         for e in errors:
             log.error(e)

--- a/scripts/manifest.schema.json
+++ b/scripts/manifest.schema.json
@@ -108,6 +108,22 @@
       "type": "string",
       "description": "Optional retention guidance for any evidence/output the solution produces (e.g., '7 years per SEC 17a-4')."
     },
+    "upstreamDependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "note"],
+      "description": "Optional Microsoft platform dependency maturity note rendered in the README header.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["preview", "ga", "mixed"]
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
     "extras": {
       "type": "object",
       "description": "Free-form additive fields preserved across regeneration. NOT projected into solutions.json."

--- a/segregation-detector/README.md
+++ b/segregation-detector/README.md
@@ -8,7 +8,9 @@ coe_function: govern
 ---
 # Segregation of Duties Detector
 
-> **Status:** Validated
+> **Version:** v1.2.0
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Automated role conflict detection that supports Maker/Checker controls in AI agent deployment pipelines, helping address SOX Section 404 IT General Controls.
 

--- a/session-security-configurator/README.md
+++ b/session-security-configurator/README.md
@@ -8,7 +8,9 @@ coe_function: govern
 ---
 # Session Security Configurator
 
-> **Status:** v1.1.1 — Complete
+> **Version:** v1.2.0
+> **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Automated session security baseline management for Microsoft 365 AI agent administration, supporting compliance with FINRA, SEC, and GLBA session control requirements.
 

--- a/unrestricted-agent-sharing-detector/README.md
+++ b/unrestricted-agent-sharing-detector/README.md
@@ -10,6 +10,7 @@ coe_function: optimize
 
 > **Version:** v2.0.1
 > **Status:** Live
+> **Validated against framework version:** v1.6.0
 
 Continuous detection of overly permissive agent sharing configurations with automated remediation and exception management.
 


### PR DESCRIPTION
## Summary

Closes #145. Formalizes a canonical README version+status header schema across solution READMEs, backfills 35 solutions, resolves 6 explicit drifts, and extends `build-manifest.py --check` to fail on README/manifest version+status drift.

## Schema (top-of-file blockquote metadata header)

```
> **Version:** <semver>
> **Status:** <enum: Live | Preview | Validated | Scaffold>
> **Validated against framework version:** <semver>
> **Upstream Microsoft dependency:** <optional>
```

## Changes

- **35 READMEs backfilled** with the canonical header (out of 36 — `agent-intake/` intentionally untouched while user has WIP on it)
- **6 explicit drifts resolved**: 3 version drifts + 3 status drifts (includes the 2 called out in the issue body: `action-confirmation-auditor`, `credential-oversharing-detector`)
- **29 status labels normalized** to the canonical enum
- **Drift check extended**: `scripts/build-manifest.py --check` now fails if any README header contradicts its manifest

## Foundation series — now complete

Together, this trio of PRs makes `solutions.json` the authoritative downstream sync contract:

| Issue | PR | What's canonical |
|---|---|---|
| #143 | #149 | `solutions.json.counts` (total/live/preview) |
| #144 | #152 | `solutions.json[].controls` |
| #145 | (this PR) | Per-solution README version + status header |

Framework surfaces should consume `solutions.json`, not parse READMEs.

## Excluded by design

- `agent-intake/**` (user has separate WIP on a feature branch)
- Solution README bodies beyond the header section
- Solution code / scripts / tests

## Validation

- `python scripts/build-manifest.py`: pass
- `python scripts/build-manifest.py --check`: pass
- `python scripts/sync-agent-md-versions.py --check`: pass
- `python -m mkdocs build --strict`: clean
- `python -m pytest -q message-center-monitor/tests mime-type-restrictions/tests`: pass

Closes #145