### PR TITLE
chore(csa): bump workbook ARM apiVersion to Microsoft.Insights/workbooks@2023-06-01

### DIFF
--- a/copilot-studio-analytics/workbooks/agent-overview/workbook-template.json
+++ b/copilot-studio-analytics/workbooks/agent-overview/workbook-template.json
@@ -38,7 +38,7 @@
   "resources": [
     {
       "type": "Microsoft.Insights/workbooks",
-      "apiVersion": "2018-06-17-preview",
+      "apiVersion": "2023-06-01",
       "name": "[parameters('workbookId')]",
       "location": "[resourceGroup().location]",
       "kind": "shared",

--- a/copilot-studio-analytics/workbooks/behavior-analysis/workbook-template.json
+++ b/copilot-studio-analytics/workbooks/behavior-analysis/workbook-template.json
@@ -38,7 +38,7 @@
   "resources": [
     {
       "type": "Microsoft.Insights/workbooks",
-      "apiVersion": "2018-06-17-preview",
+      "apiVersion": "2023-06-01",
       "name": "[parameters('workbookId')]",
       "location": "[resourceGroup().location]",
       "kind": "shared",

--- a/copilot-studio-analytics/workbooks/business-impact/workbook-template.json
+++ b/copilot-studio-analytics/workbooks/business-impact/workbook-template.json
@@ -38,7 +38,7 @@
   "resources": [
     {
       "type": "Microsoft.Insights/workbooks",
-      "apiVersion": "2018-06-17-preview",
+      "apiVersion": "2023-06-01",
       "name": "[parameters('workbookId')]",
       "location": "[resourceGroup().location]",
       "kind": "shared",

--- a/copilot-studio-analytics/workbooks/quality-metrics/workbook-template.json
+++ b/copilot-studio-analytics/workbooks/quality-metrics/workbook-template.json
@@ -38,7 +38,7 @@
   "resources": [
     {
       "type": "Microsoft.Insights/workbooks",
-      "apiVersion": "2018-06-17-preview",
+      "apiVersion": "2023-06-01",
       "name": "[parameters('workbookId')]",
       "location": "[resourceGroup().location]",
       "kind": "shared",


### PR DESCRIPTION
## Summary

Closes #154. Bumps all 4 CSA workbook ARM templates from the stale `2018-06-17-preview` API version to `2023-06-01`, matching what `agent-observability-foundation` already uses.

## Changes (4 files, +4 / -4)

- `copilot-studio-analytics/workbooks/agent-overview/workbook-template.json`
- `copilot-studio-analytics/workbooks/behavior-analysis/workbook-template.json`
- `copilot-studio-analytics/workbooks/business-impact/workbook-template.json`
- `copilot-studio-analytics/workbooks/quality-metrics/workbook-template.json`

Single change per file: `"apiVersion": "2018-06-17-preview"` → `"apiVersion": "2023-06-01"` (only on `Microsoft.Insights/workbooks` resource declarations).

## Validation

- ✅ All 4 modified templates parse as valid JSON
- ✅ AOF cross-check confirms `2023-06-01` is what AOF uses
- ✅ Repo-wide grep confirms no stale `2018-06-17-preview` remains under CSA workbooks
- N/A `copilot-studio-analytics/tests` doesn't exist
- ⚠️ `python scripts/build-manifest.py --check` fails on pre-existing generated-artifact drift unrelated to this PR (also seen on PR #155)

Closes #154