### PR TITLE
chore(wave-5): narrative 35->36, agent-intake stale callout, RSV schema doc regen

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 Deployable Power Platform solutions for the [FSI Agent Governance Framework](https://github.com/judeper/FSI-AgentGov). These solutions help Financial Services organizations implement operational controls and monitoring for AI agents (Copilot Studio, Agent Builder).
 
-- **35 live solution implementations** mapped to the 78-control framework across all 4 pillars
+- **36 solution implementations (35 live, 1 preview)** mapped to the 78-control framework across all 4 pillars
 - **Target regulations:** FINRA 4511/3110/25-07, SEC 17a-3/4, SOX 302/404, GLBA 501(b), OCC 2011-12, Fed SR 11-7, CFTC 1.31
 - **Technologies:** PowerShell, Python, KQL, Dataverse (documentation-only for Power Automate — no exported flow artifacts)
 - **Audience:** M365 administrators and DevOps engineers in US financial services

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance for autonomous AI agents working on this repository.
 
 **FSI-AgentGov-Solutions** — Deployable Power Platform solutions for the [FSI Agent Governance Framework](https://github.com/judeper/FSI-AgentGov). These solutions help Financial Services organizations implement operational controls and monitoring for AI agents (Copilot Studio, Agent Builder).
 
-- **35 live solution implementations** mapped to the 78-control framework across all 4 pillars
+- **36 solution implementations (35 live, 1 preview)** mapped to the 78-control framework across all 4 pillars
 - **Target regulations:** FINRA 4511/3110/25-07, SEC 17a-3/4, SOX 302/404, GLBA 501(b), OCC 2011-12, Fed SR 11-7, CFTC 1.31
 - **Technologies:** PowerShell, Python, KQL, Dataverse (documentation-only for Power Automate — no exported flow artifacts)
 
@@ -103,7 +103,7 @@ Some solutions carry a per-solution `AGENTS.md` at their root (e.g., `agent-inta
 
 Active per-solution `AGENTS.md` files:
 
-- [`agent-intake/AGENTS.md`](agent-intake/AGENTS.md) — v1.0.0-preview · PR #142 open
+- [`agent-intake/AGENTS.md`](agent-intake/AGENTS.md) — v1.0.0-preview · merged via PR #142
 
 When you add a per-solution `AGENTS.md`, list it here and link to it from the solution's README.
 

--- a/rag-source-validator/docs/dataverse-schema.md
+++ b/rag-source-validator/docs/dataverse-schema.md
@@ -29,6 +29,11 @@
 | fsi_AlertOnChange | fsi_alertonchange | Boolean | No | Send notification when source content changes | `1` = Yes, `0` = No |
 | fsi_FreshnessThreshold | fsi_freshnessthreshold | Integer | No | Maximum acceptable age in days before source is considered stale |  |
 | fsi_LastModified | fsi_lastmodified | DateTime | No | Timestamp of last detected source modification |  |
+| fsi_eTag | fsi_etag | String | No | Document eTag from SharePoint/OneDrive for change detection |  |
+| fsi_cTag | fsi_ctag | String | No | Document cTag from SharePoint/OneDrive (catalog tag) |  |
+| fsi_DeltaLink | fsi_deltalink | String | No | Microsoft Graph delta query link for incremental change tracking |  |
+| fsi_SearchConnectorId | fsi_searchconnectorid | String | No | Microsoft Search connector identifier |  |
+| fsi_LineageUri | fsi_lineageuri | String | No | Source lineage URI for RAG provenance tracking |  |
 
 ### fsi_ValidationResult (`fsi_validationresult`)
 


### PR DESCRIPTION
**Wave 5 orchestrator-direct cleanup PR.**

Three minor narrative + doc fixes folded into a single chore commit. No solution version bumps; no CI workflow changes.

## Changes

### Narrative count (35 → 36)
The repo has had 36 solution folders on disk for some time (35 live + 1 preview), but two hand-maintained narrative files still said "35 live solution implementations":
- `AGENTS.md` L9
- `.github/copilot-instructions.md` L7

Updated to **"36 solution implementations (35 live, 1 preview)"** — matches root `README.md` BEGIN:SOLUTIONS block (line 41).

### `agent-intake/AGENTS.md` stale callout
`AGENTS.md` L106 still said `agent-intake/AGENTS.md - v1.0.0-preview . PR #142 open` even though PR #142 was merged long ago. Updated to `merged via PR #142`.

### RSV schema doc regen
`rag-source-validator/docs/dataverse-schema.md` had drifted from `create_rsv_dataverse_schema.py` — 5 columns (`fsi_etag`, `fsi_ctag`, `fsi_deltalink`, `fsi_searchconnectorid`, `fsi_lineageuri`) were added to the schema script but the auto-generated doc was never regenerated. Detected during Wave 5 E2 baseline audit. Ran `python rag-source-validator/scripts/create_rsv_dataverse_schema.py --output-docs`.

## Validation

- `python scripts/build-manifest.py --check` → `INFO: OK: all generated artifacts match manifests.`
- `python scripts/sync-agent-md-versions.py --check` → `No drift between solutions.json and inventory tables.`
- No schema script changes, no script behavior changes.

## Wave 5 context

This PR is part of the systemic-cleanup wave following Wave 1–4 council remediations. Tracker:
- E2 (schema regen sweep) → 16 of 17 solutions were already clean; only RSV drifted → folded here as a 5-line fix.
- E1, E4, E5, E6, E7-linter, E7-bulkfix → separate PRs to follow (orchestrator-direct or background-dispatch as needed).

Closes nothing.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
