### PR TITLE
feat(ci): w5-e5 manifest <-> CHANGELOG version drift gate (REPORT-ONLY)

### DIFF
--- a/.github/workflows/manifest-check.yml
+++ b/.github/workflows/manifest-check.yml
@@ -51,3 +51,8 @@ jobs:
       - name: Verify AGENTS.md and copilot-instructions.md inventory tables match solutions.json
         working-directory: solutions
         run: python scripts/sync-agent-md-versions.py --check
+
+      - name: Verify manifest.yaml.version matches CHANGELOG most-recent release
+        working-directory: solutions
+        run: python scripts/lint-version-drift.py
+        continue-on-error: true   # REPORT-ONLY initial mode (flip to --strict in follow-up PR after baseline)

--- a/scripts/lint-version-drift.py
+++ b/scripts/lint-version-drift.py
@@ -1,0 +1,134 @@
+"""Lint solution manifest versions against CHANGELOG release headers."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+LOGGER = logging.getLogger(__name__)
+VERSION_HEADING_RE = re.compile(r"^\s*##\s+\[(?P<version>v?\d+\.\d+\.\d+(?:-preview)?)\]")
+
+
+def normalize_version(value: Any) -> str:
+    """Return a comparable version string with one leading v/V removed."""
+    version = str(value).strip()
+    if version.lower().startswith("v"):
+        return version[1:]
+    return version
+
+
+def load_manifest_version(manifest_path: Path) -> str | None:
+    """Load and normalize manifest.yaml.version."""
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        manifest = yaml.safe_load(handle) or {}
+    version = manifest.get("version") if isinstance(manifest, dict) else None
+    if version is None:
+        return None
+    return normalize_version(version)
+
+
+def find_changelog_release(changelog_path: Path) -> tuple[str, int] | None:
+    """Find the first non-Unreleased version heading in a CHANGELOG."""
+    with changelog_path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if line.lstrip().startswith("<!--"):
+                continue
+            match = VERSION_HEADING_RE.match(line)
+            if match:
+                return normalize_version(match.group("version")), line_number
+    return None
+
+
+def lint_solution(solution_dir: Path) -> list[str]:
+    """Return version drift findings for one solution directory."""
+    slug = solution_dir.name
+    manifest_path = solution_dir / "manifest.yaml"
+    if not manifest_path.exists():
+        return []
+
+    manifest_version = load_manifest_version(manifest_path)
+    if manifest_version is None:
+        return [f"{slug}: manifest.yaml version missing"]
+
+    changelog_path = solution_dir / "CHANGELOG.md"
+    if not changelog_path.exists():
+        return [f"{slug}: CHANGELOG.md missing (manifest={manifest_version})"]
+
+    release = find_changelog_release(changelog_path)
+    if release is None:
+        return [
+            f"{slug}: manifest={manifest_version} but "
+            "CHANGELOG most-recent-release=<none: no release header found>"
+        ]
+
+    changelog_version, line_number = release
+    if manifest_version != changelog_version:
+        return [
+            f"{slug}: manifest={manifest_version} but "
+            f"CHANGELOG most-recent-release={changelog_version}  "
+            f"(CHANGELOG.md:L{line_number})"
+        ]
+
+    return []
+
+
+def iter_solution_dirs(root: Path, solution: str | None = None) -> list[Path]:
+    """Return solution directories that contain manifest.yaml files."""
+    if solution:
+        candidate = root / solution
+        return [candidate] if (candidate / "manifest.yaml").exists() else []
+
+    return sorted(
+        path
+        for path in root.iterdir()
+        if path.is_dir() and not path.name.startswith(".") and (path / "manifest.yaml").exists()
+    )
+
+
+def lint_repository(root: Path, solution: str | None = None) -> list[str]:
+    """Return version drift findings for all matching solution directories."""
+    findings: list[str] = []
+    for solution_dir in iter_solution_dirs(root, solution):
+        findings.extend(lint_solution(solution_dir))
+    return findings
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Lint manifest.yaml.version values against CHANGELOG release headers."
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 when version drift findings are present.",
+    )
+    parser.add_argument(
+        "--solution",
+        help="Limit linting to a single solution slug.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the version drift linter."""
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stdout)
+
+    findings = lint_repository(Path.cwd(), args.solution)
+    for finding in findings:
+        LOGGER.info("%s", finding)
+
+    if args.strict and findings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_lint_version_drift.py
+++ b/scripts/tests/test_lint_version_drift.py
@@ -1,0 +1,110 @@
+"""Tests for lint-version-drift.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "lint-version-drift.py"
+SPEC = importlib.util.spec_from_file_location("lint_version_drift", SCRIPT_PATH)
+assert SPEC is not None
+lint_version_drift = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(lint_version_drift)
+
+
+class LintVersionDriftTests(unittest.TestCase):
+    """Validate manifest-to-CHANGELOG version drift detection."""
+
+    def setUp(self) -> None:
+        self.temp_dir = Path(
+            tempfile.mkdtemp(prefix="lint-version-drift-", dir=Path(__file__).resolve().parent)
+        )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.temp_dir)
+
+    def write_solution(self, version: str, changelog: str | None = None) -> Path:
+        solution_dir = self.temp_dir / "sample-solution"
+        solution_dir.mkdir()
+        (solution_dir / "manifest.yaml").write_text(
+            f"id: sample-solution\nversion: \"{version}\"\n", encoding="utf-8"
+        )
+        if changelog is not None:
+            (solution_dir / "CHANGELOG.md").write_text(
+                textwrap.dedent(changelog).lstrip(), encoding="utf-8"
+            )
+        return solution_dir
+
+    def lint(self, version: str, changelog: str | None = None) -> list[str]:
+        return lint_version_drift.lint_solution(self.write_solution(version, changelog))
+
+    def test_match_case_has_no_finding(self) -> None:
+        findings = self.lint("1.2.1", """
+        # Changelog
+
+        ## [1.2.1]
+        - Updated.
+        """)
+
+        self.assertEqual([], findings)
+
+    def test_mismatch_case_has_finding(self) -> None:
+        findings = self.lint("1.2.1", """
+        # Changelog
+
+        ## [1.2.0]
+        - Updated.
+        """)
+
+        self.assertEqual(1, len(findings))
+        self.assertIn("manifest=1.2.1", findings[0])
+        self.assertIn("most-recent-release=1.2.0", findings[0])
+        self.assertIn("CHANGELOG.md:L3", findings[0])
+
+    def test_preview_case_strips_leading_v_and_matches(self) -> None:
+        findings = self.lint("v1.0.0-preview", """
+        # Changelog
+
+        ## [1.0.0-preview]
+        - Updated.
+        """)
+
+        self.assertEqual([], findings)
+
+    def test_unreleased_only_case_has_no_release_header_finding(self) -> None:
+        findings = self.lint("1.2.1", """
+        # Changelog
+
+        ## [Unreleased]
+        - Pending.
+        """)
+
+        self.assertEqual(1, len(findings))
+        self.assertIn("no release header found", findings[0])
+
+    def test_missing_changelog_case_has_finding(self) -> None:
+        findings = self.lint("1.2.1")
+
+        self.assertEqual(1, len(findings))
+        self.assertIn("CHANGELOG.md missing", findings[0])
+
+    def test_comment_line_is_not_parsed_as_header(self) -> None:
+        findings = self.lint("1.0.0", """
+        # Changelog
+
+        <!-- ## [1.0.0] -->
+        ## [0.9.0]
+        - Updated.
+        """)
+
+        self.assertEqual(1, len(findings))
+        self.assertIn("most-recent-release=0.9.0", findings[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Wave 5 / E5 — Manifest ↔ CHANGELOG version drift gate

Adds `scripts/lint-version-drift.py` — verifies each solution's `manifest.yaml.version` matches the latest non-`[Unreleased]` release header in its `CHANGELOG.md`. Wired into `manifest-check.yml` as **REPORT-ONLY** (`continue-on-error: true`).

### Why
Wave 1-3 council remediation surfaced multiple cases where a PR bumped `manifest.yaml.version` but forgot to close out the corresponding CHANGELOG release header (or vice versa). Caught only by manual review until now.

### v1 scope (intentionally narrow per rubber-duck)
- `manifest.yaml.version` ↔ latest non-Unreleased `## [X.Y.Z]` header
- Strips leading `v` for comparison
- Special-cases `agent-intake = v1.0.0-preview`
- Skips `[Unreleased]` sections + HTML comments
- Graceful handling of missing CHANGELOG or Unreleased-only CHANGELOG

### Deferred to v2
- Per-script `.SYNOPSIS Version:` headers (format too variable)
- Catalog inventory row verification (already covered by `sync-agent-md-versions.py`)
- m-1/m-2 internal lockstep tokens

### Baseline findings (REPORT-ONLY)
The linter immediately surfaces **2 real version drifts** that slipped through prior review:
- `deny-event-correlation-report`: manifest=2.0.4 vs CHANGELOG latest release=2.0.3 (Unreleased section documents v2.0.4 but never closed out)
- `hallucination-tracker`: manifest=1.2.0 vs CHANGELOG latest release=1.1.0 (Unreleased section documents v1.2.0 but never closed out)

These will be fixed in a follow-up PR (close out Unreleased sections to `## [2.0.4]` / `## [1.2.0]` release headers). Then a separate PR will flip the lint to `--strict`.

### Tests
6 unittest cases in `scripts/tests/test_lint_version_drift.py` — match, manifest-ahead, Unreleased-only, missing CHANGELOG, agent-intake preview, HTML-comment-skip. All pass.

### Validation
- `python scripts/build-manifest.py --check` ✅
- `python scripts/sync-agent-md-versions.py --check` ✅
- `python -m pytest scripts/tests/test_lint_version_drift.py` ✅ (6/6)
- Direct invocation: exit 0 (REPORT-ONLY), surfaces 2 expected findings.

### Code review verdict
SHIP. Linter is correct on every dimension. One non-blocking note: `mime-type-restrictions/CHANGELOG.md` has `## [1.2.1] — Unreleased — ...` (semver bracket but Unreleased intent) which v1 cannot detect — flagged as future hygiene issue.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
