### PR TITLE
chore(wave-5-baseline-cleanup): close 2 version drifts + 4 ELM table-name refs

### DIFF
--- a/agent-access-monitor/scripts/private/Get-ZoneClassification.ps1
+++ b/agent-access-monitor/scripts/private/Get-ZoneClassification.ps1
@@ -47,7 +47,7 @@ if ($DataverseUrl -and $AccessToken) {
             'OData-Version'    = '4.0'
         }
         $filter = "fsi_environmentid eq '$($EnvironmentId -replace "'", "''")'"
-        $uri = "$($DataverseUrl.TrimEnd('/'))/api/data/v9.2/fsi_environmentlifecycles?" +
+        $uri = "$($DataverseUrl.TrimEnd('/'))/api/data/v9.2/fsi_environmentrequests?" +
                "`$filter=$filter&`$select=fsi_zone&`$top=1"
         $response = Invoke-RestMethod -Uri $uri -Headers $headers -Method Get -ErrorAction Stop
         if ($response.value.Count -gt 0) {

--- a/content-moderation-monitor/docs/prerequisites.md
+++ b/content-moderation-monitor/docs/prerequisites.md
@@ -68,7 +68,7 @@ Add the automation identity as an application user in each Dataverse environment
 ## Environment Lifecycle Management (ELM) Integration
 
 For zone classification via ELM, the ELM solution must be deployed with:
-- `fsi_environmentlifecycles` table containing zone classifications
+- `fsi_environmentrequests` table containing zone classifications
 - Environment records linked to Power Platform environment GUIDs
 
 Without ELM, zone classification falls back to naming convention matching (e.g., `-Z3-` in environment name maps to Zone 3).

--- a/content-moderation-monitor/docs/troubleshooting.md
+++ b/content-moderation-monitor/docs/troubleshooting.md
@@ -36,7 +36,7 @@ Common issues and resolutions for the Content Moderation Governance Monitor solu
 | No agents found | Environment has no Copilot Studio bots, or bots are all drafts | Verify bots exist; use `-IncludeDrafts` to scan unpublished agents |
 | Unknown moderation level | Bot `configuration` JSON does not contain content moderation settings | Agent may not have generative AI enabled; Unknown agents receive Warning severity |
 | **All** agents show Unknown level | The `bot.configuration` JSON key for content moderation may have changed (Microsoft undocumented internal schema) | Verify at least one agent returns a known level (Lowest/Low/Medium/High/Highest). If none do, contact Microsoft support or check Copilot Studio release notes for schema changes. The script emits a warning when this occurs. |
-| Zone lookup failure | ELM `fsi_environmentlifecycles` table not deployed or empty | Verify ELM deployment; falls back to naming convention matching (`-Z1-`, `-Z2-`, `-Z3-` in environment name) |
+| Zone lookup failure | ELM `fsi_environmentrequests` table not deployed or empty | Verify ELM deployment; falls back to naming convention matching (`-Z1-`, `-Z2-`, `-Z3-` in environment name) |
 | Bot metadata query error | Environment Dataverse not provisioned | Skip environments without Dataverse; these cannot host Copilot Studio bots |
 | Sandbox environments included | `fsi_CMM_IncludeSandbox` set to true | Set environment variable to `false` or use `-ExcludeSandbox` parameter |
 | Moderation level shows "strict", "lowest", or "highest" | Copilot Studio and prompt-level surfaces can use related labels | `Get-BotModerationLevel` normalizes "lowest" → "Low", "highest"/"strict" → "High", "standard"/"moderate" → "Medium" |

--- a/content-moderation-monitor/scripts/private/Get-ZoneClassification.ps1
+++ b/content-moderation-monitor/scripts/private/Get-ZoneClassification.ps1
@@ -69,8 +69,8 @@ if ($DataverseUrl -and $AccessToken) {
             'Accept' = 'application/json'
         }
         $safeEnvId = $EnvironmentId -replace "'", "''"
-        $filter = "fsi_environmentguid eq '$safeEnvId'"
-        $url = "$($DataverseUrl.TrimEnd('/'))/api/data/v9.2/fsi_environmentlifecycles?`$filter=$filter&`$select=fsi_zone&`$top=1"
+        $filter = "fsi_environmentid eq '$safeEnvId'"
+        $url = "$($DataverseUrl.TrimEnd('/'))/api/data/v9.2/fsi_environmentrequests?`$filter=$filter&`$select=fsi_zone&`$top=1"
         $response = Invoke-RestMethod -Uri $url -Headers $headers -Method Get -ErrorAction Stop
         if ($response.value -and $response.value.Count -gt 0) {
             $zoneValue = $response.value[0].fsi_zone

--- a/deny-event-correlation-report/CHANGELOG.md
+++ b/deny-event-correlation-report/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Deny Event Correlation Report are documented here.
 
-## [Unreleased] — v2.0.4
+## [2.0.4] — 2026-05-23
 
 ### Fixed
 

--- a/hallucination-tracker/CHANGELOG.md
+++ b/hallucination-tracker/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Hallucination Feedback Tracker.
 
 ---
 
-## [Unreleased] - 2026-Q2 — Microsoft Learn refresh
+## [1.2.0] - 2026-05-23 — Microsoft Learn refresh
 
 ### Added
 


### PR DESCRIPTION
## Wave 5 baseline cleanup — close 2 version drifts + 4 ELM table-name refs

Closes the only remaining REPORT-ONLY findings from Wave 5 linters (#198, #201, #202) so they can be flipped to `--strict` in a follow-up.

### E5 `lint-version-drift` fixes (#198)

| Solution | Change |
|---|---|
| `deny-event-correlation-report` | `## [Unreleased] — v2.0.4` → `## [2.0.4] — 2026-05-23` |
| `hallucination-tracker` | `## [Unreleased] - 2026-Q2 — Microsoft Learn refresh` → `## [1.2.0] - 2026-05-23 — Microsoft Learn refresh` |

Both versions already exist in `manifest.yaml`; this only closes the open header.

### E4 `lint-odata-existence` fixes (#201)

ELM's environment-of-record table is `fsi_environmentrequest` (logical) / `fsi_environmentrequests` (entity set), per [`environment-lifecycle-management/scripts/create_dataverse_schema.py:178`](https://github.com/judeper/FSI-AgentGov-Solutions/blob/main/environment-lifecycle-management/scripts/create_dataverse_schema.py#L178). Four references to a non-existent `fsi_environmentlifecycles` entity set are renamed:

| File | Change |
|---|---|
| `agent-access-monitor/scripts/private/Get-ZoneClassification.ps1:50` | `fsi_environmentlifecycles` → `fsi_environmentrequests` |
| `content-moderation-monitor/scripts/private/Get-ZoneClassification.ps1:72-73` | table rename **and** filter `fsi_environmentguid` → `fsi_environmentid` (CMM's local violation table uses `fsi_environmentguid`, but the ELM lookup table is keyed on `fsi_environmentid`) |
| `content-moderation-monitor/docs/troubleshooting.md:39` | doc alignment |
| `content-moderation-monitor/docs/prerequisites.md:71` | doc alignment |

### Verification

\\\
python scripts/lint-odata-existence.py --cross-solution-ok
INFO: odata-existence-lint: scanned 624 files across 36 solution(s); 0 finding(s).   # was 2

python scripts/lint-version-drift.py
# (no output, was 2 findings)

python scripts/lint-optionset-values.py
INFO: optionset-values-lint: scanned 36 solution(s); 0 finding(s).   # unchanged

python scripts/build-manifest.py --check
INFO: OK: all generated artifacts match manifests.
\\\

### Follow-up (separate PR)

Flip `continue-on-error: true` → `--strict` in `.github/workflows/manifest-check.yml` (E5, E6) and `.github/workflows/odata-lint.yml` (E4) once this merges.