### PR TITLE
chore(ci): flip Wave 5 linters from REPORT-ONLY to --strict

### DIFF
--- a/.github/workflows/manifest-check.yml
+++ b/.github/workflows/manifest-check.yml
@@ -54,10 +54,10 @@ jobs:
 
       - name: Verify manifest.yaml.version matches CHANGELOG most-recent release
         working-directory: solutions
-        run: python scripts/lint-version-drift.py
-        continue-on-error: true   # REPORT-ONLY initial mode (flip to --strict in follow-up PR after baseline)
+        run: python scripts/lint-version-drift.py --strict
+        # Strict mode enabled in PR #204 (Wave 5 close-out) — baseline cleaned by PR #203.
 
       - name: Lint Dataverse Picklist option-set value ranges
         working-directory: solutions
-        run: python scripts/lint-optionset-values.py
-        continue-on-error: true   # REPORT-ONLY initial mode (flip to --strict in follow-up PR after baseline)
+        run: python scripts/lint-optionset-values.py --strict
+        # Strict mode enabled in PR #204 (Wave 5 close-out) — baseline is clean (0 findings).

--- a/.github/workflows/odata-lint.yml
+++ b/.github/workflows/odata-lint.yml
@@ -27,9 +27,8 @@ jobs:
         # from underscored snake_case to single-word PascalCase per the
         # team convention. Baseline is now clean.
 
-      # TODO(post-baseline): flip to `python scripts/lint-odata-existence.py --strict`
-      # after false-positive findings are triaged and the baseline is clean.
+      # Strict mode enabled in PR #204 (Wave 5 close-out) — baseline is now clean
+      # after PR #203 fixed AAM + CMM Get-ZoneClassification.ps1 ELM table-name refs.
       # --cross-solution-ok accepts column tokens declared in any solution's
       # schema (intentional cross-solution couplings like ARA → all agents, CAA → ELM).
-      - run: python scripts/lint-odata-existence.py --cross-solution-ok
-        continue-on-error: true
+      - run: python scripts/lint-odata-existence.py --cross-solution-ok --strict


### PR DESCRIPTION
## Wave 5 close-out — flip 3 linters from REPORT-ONLY to `--strict`

With PR #203 having driven all three Wave 5 lint baselines to 0 findings, the `continue-on-error: true` training wheels can come off.

### Flipped to strict

| Workflow | Step | New invocation |
|---|---|---|
| `.github/workflows/odata-lint.yml` | `lint` | `python scripts/lint-odata-existence.py --cross-solution-ok --strict` |
| `.github/workflows/manifest-check.yml` | Verify manifest.yaml.version | `python scripts/lint-version-drift.py --strict` |
| `.github/workflows/manifest-check.yml` | Lint Picklist option-set value ranges | `python scripts/lint-optionset-values.py --strict` |

### Local verification (on this branch)

\\\
python scripts/lint-odata-existence.py --cross-solution-ok --strict
INFO: odata-existence-lint: scanned 624 files across 36 solution(s); 0 finding(s).   exit 0

python scripts/lint-version-drift.py --strict
(no output)   exit 0

python scripts/lint-optionset-values.py --strict
INFO: optionset-values-lint: scanned 36 solution(s); 0 finding(s).   exit 0
\\\

### Why now

- **E4 baseline** (#201) cleaned by #203 — 4 ELM table refs renamed from `fsi_environmentlifecycles` to `fsi_environmentrequests`.
- **E5 baseline** (#198) cleaned by #203 — 2 `[Unreleased]` sections closed in DECR and HT CHANGELOGs.
- **E6 baseline** (#202) clean since landing — three hard-coded allowlists (TwoOption auto-detect, §9 acv-shared sets, solution-internally-consistent picklists) covered all known 0-based picklists at merge time.

After merge, these linters fail PRs that would re-introduce the exact bugs they were built to detect: Dataverse column drift (#201 mission), manifest/CHANGELOG version skew (#198 mission), and off-floor `fsi_*` picklist values (#202 mission). Wave 5 council-review remediation is now closed.