### PR TITLE
chore(ci): PSScriptAnalyzerSettings.psd1 + ci-powershell wiring (Wave 6 P1)

### DIFF
--- a/.github/workflows/ci-powershell.yml
+++ b/.github/workflows/ci-powershell.yml
@@ -40,13 +40,14 @@ jobs:
 
       - name: PSScriptAnalyzer
         shell: pwsh
-        # Soft-gate: report findings but do not break the build until the
-        # baseline is cleaned up. Flip continue-on-error to false (and remove
-        # the trailing print) once existing PSAvoidUsingConvertToSecureStringWithPlainText
-        # and similar findings are remediated.
+        # Soft-gate (Wave 6 P1): we now load the project-level
+        # PSScriptAnalyzerSettings.psd1 so the baseline reflects the actual
+        # policy (PSAvoidUsingWriteHost + PSUseSingularNouns excluded with
+        # documented rationale). The gate stays soft until Wave 6 P6 flips
+        # `-Severity` to `Error,Warning` and removes `continue-on-error`.
         continue-on-error: true
         run: |
-          $results = Invoke-ScriptAnalyzer -Path . -Recurse -Severity Error
+          $results = Invoke-ScriptAnalyzer -Path . -Recurse -Severity Error -Settings ./PSScriptAnalyzerSettings.psd1
           $results | Format-Table -AutoSize
           if ($results.Count -gt 0) {
             Write-Host "::warning::PSScriptAnalyzer reported $($results.Count) Error-severity findings (soft-gated)."

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,53 @@
+#
+# PSScriptAnalyzer settings for FSI-AgentGov-Solutions
+#
+# Loaded by `Invoke-ScriptAnalyzer -Settings ./PSScriptAnalyzerSettings.psd1`
+# in `.github/workflows/ci-powershell.yml` and during local development.
+#
+# Two rules are globally excluded. Both exclusions are deliberate and reviewed:
+#
+#   PSAvoidUsingWriteHost
+#     The .ps1 scripts in this repo are operator-facing CLI tools (governance
+#     scans, evidence exports, compliance runbooks). Their user-visible output
+#     surface is the colored console banner, status lines, and progress
+#     reporting that `Write-Host` produces. They are NOT library functions
+#     whose output is consumed by other scripts via the pipeline. Per the
+#     PowerShell team guidance (https://docs.microsoft.com/powershell/module/
+#     microsoft.powershell.utility/write-host), `Write-Host` is the correct
+#     choice for "the only thing the user is supposed to see" output. Replacing
+#     these with `Write-Information -InformationAction Continue` would alter
+#     observable script behavior (default `$InformationPreference = 'SilentlyContinue'`
+#     means operators would see no output unless they explicitly opt in) without
+#     improving correctness.
+#
+#   PSUseSingularNouns
+#     Several existing public-surface script and function names use plural nouns
+#     (e.g. `Get-AgentSkillRegistrations`, `Get-AAMValidationResults`,
+#     `Get-DataverseHeaders`). These names are referenced by customer
+#     deployment runbooks, scheduled task definitions, and downstream
+#     integrations. Renaming them constitutes a breaking surface change that
+#     would require coordinated `[BREAKING DEPLOY]` CHANGELOG entries across
+#     many solutions for cosmetic gain only. Singular-noun convention is
+#     enforced for net-new cmdlets via code review; not retroactively.
+#
+# See AGENTS.md "PowerShell Coding Patterns" for the formal policy. Any
+# additional exclusion must justify itself with the same rigor.
+#
+
+@{
+    # Run all built-in rules except those listed below.
+    IncludeDefaultRules = $true
+
+    # Gate at Warning + Error only. Information-severity findings (style
+    # suggestions like trailing whitespace, missing [OutputType()], positional
+    # parameter use) remain visible when developers invoke PSSA without
+    # `-Severity` filters, but are NOT part of the CI-enforced "no tech debt"
+    # bar. This matches the convention used by the PowerShell Standard Library
+    # and most Microsoft-published modules.
+    Severity = @('Error', 'Warning')
+
+    ExcludeRules = @(
+        'PSAvoidUsingWriteHost',
+        'PSUseSingularNouns'
+    )
+}


### PR DESCRIPTION
## Wave 6 Phase 1 — PSScriptAnalyzer project settings

Establishes the policy file that scopes the PSSA "no tech debt" bar for the remainder of Wave 6.

### What this adds

- **`PSScriptAnalyzerSettings.psd1`** at repo root with two globally excluded rules and pinned severity gate.
- **`ci-powershell.yml`** PSSA step now passes `-Settings ./PSScriptAnalyzerSettings.psd1`. Step remains soft-gated (`continue-on-error: true`, `-Severity Error` only) in this PR — strict-flip lands in **Wave 6 P6** after the remaining baseline reaches 0.

### Exclusion rationale (both documented in the .psd1 header)

| Rule | Hits | Why excluded |
|---|---|---|
| `PSAvoidUsingWriteHost` | 3,743 | These `.ps1` scripts are operator-facing CLI tools. The colored console banner / status / progress IS the user-visible product. Per [PowerShell team guidance](https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/write-host), `Write-Host` is correct for "the only thing the user is supposed to see" output. Switching to `Write-Information -InformationAction Continue` would silently suppress visible output for operators by default (`$InformationPreference` defaults to `SilentlyContinue`). |
| `PSUseSingularNouns` | 94 | Existing public-surface names (e.g. `Get-AgentSkillRegistrations`, `Get-AAMValidationResults`, `Get-DataverseHeaders`) are referenced by customer runbooks, scheduled tasks, and downstream integrations. Renaming = breaking surface change requiring coordinated `[BREAKING DEPLOY]` CHANGELOG entries across many solutions for cosmetic gain only. Singular-noun convention enforced for net-new cmdlets via review; not retroactively. |

### Baseline impact (verified locally on this branch)

```
BEFORE settings: 4,247 findings  (Warning + Error)
AFTER  settings:   410 findings  (Warning + Error)
                  ─────
suppressed:       3,837
```

The remaining 410 findings (27 Errors + 383 Warnings, 14 rules) are real tech debt addressed in Wave 6 PRs P2–P5.

### Severity gate

The settings file pins `Severity = @('Error', 'Warning')`. PSSA Information-tier findings (trailing whitespace, missing `[OutputType()]`, positional params) remain visible during local development but are NOT enforced. Matches the convention used by the PowerShell Standard Library and most Microsoft-published modules.

### What does NOT change in this PR

- CI step is still `-Severity Error` and `continue-on-error: true`. The settings file is just *loaded*; the gate strengthens in P6.
- No existing `.ps1`/`.psm1` source file is touched.
- No suppressions are added to source code.

### References

- `plan.md` → "Wave 6 — Tech-debt close-out / Phase 1"
- AGENTS.md PowerShell coding patterns will get an updated entry pointing at this settings file as part of Wave 6 P6.