### PR TITLE
fix(audit-compliance-manager): repair Validators.Tests.ps1 path discovery (Wave 6 P5)

### DIFF
--- a/audit-compliance-manager/scripts/Validators.Tests.ps1
+++ b/audit-compliance-manager/scripts/Validators.Tests.ps1
@@ -14,116 +14,122 @@
     Run with: Invoke-Pester -Path .\Validators.Tests.ps1 -Output Detailed
 #>
 
+BeforeDiscovery {
+    $validatorRoot = $PSScriptRoot
+
+    $validatorFiles = @(
+        @{ Name = "Test-UnifiedAuditLog.ps1"; Path = Join-Path $validatorRoot "Test-UnifiedAuditLog.ps1" }
+        @{ Name = "Test-MailboxAudit.ps1"; Path = Join-Path $validatorRoot "Test-MailboxAudit.ps1" }
+        @{ Name = "Test-PurviewRetention.ps1"; Path = Join-Path $validatorRoot "Test-PurviewRetention.ps1" }
+        @{ Name = "Test-EnvironmentAudit.ps1"; Path = Join-Path $validatorRoot "Test-EnvironmentAudit.ps1" }
+        @{ Name = "Test-EnvironmentRetention.ps1"; Path = Join-Path $validatorRoot "Test-EnvironmentRetention.ps1" }
+    )
+
+    $environmentRetentionValidator = @(
+        @{ Name = "Test-EnvironmentRetention.ps1"; Path = Join-Path $validatorRoot "Test-EnvironmentRetention.ps1" }
+    )
+
+    $unifiedAuditLogValidator = @(
+        @{ Name = "Test-UnifiedAuditLog.ps1"; Path = Join-Path $validatorRoot "Test-UnifiedAuditLog.ps1" }
+    )
+
+    $purviewRetentionValidator = @(
+        @{ Name = "Test-PurviewRetention.ps1"; Path = Join-Path $validatorRoot "Test-PurviewRetention.ps1" }
+    )
+
+    $mailboxAuditValidator = @(
+        @{ Name = "Test-MailboxAudit.ps1"; Path = Join-Path $validatorRoot "Test-MailboxAudit.ps1" }
+    )
+
+    $tenantValidators = @(
+        @{ Name = "Test-UnifiedAuditLog.ps1"; Path = Join-Path $validatorRoot "Test-UnifiedAuditLog.ps1" }
+        @{ Name = "Test-MailboxAudit.ps1"; Path = Join-Path $validatorRoot "Test-MailboxAudit.ps1" }
+        @{ Name = "Test-PurviewRetention.ps1"; Path = Join-Path $validatorRoot "Test-PurviewRetention.ps1" }
+    )
+
+    $privateRoot = Join-Path $validatorRoot "private"
+    $privateScripts = @(
+        @{ Name = "New-CanaryEvent.ps1"; Path = Join-Path $privateRoot "New-CanaryEvent.ps1" }
+        @{ Name = "Connect-AuditServices.ps1"; Path = Join-Path $privateRoot "Connect-AuditServices.ps1" }
+        @{ Name = "Connect-PowerPlatform.ps1"; Path = Join-Path $privateRoot "Connect-PowerPlatform.ps1" }
+        @{ Name = "Get-ValidationResults.ps1"; Path = Join-Path $privateRoot "Get-ValidationResults.ps1" }
+    )
+}
+
 BeforeAll {
-    $script:validatorDir = $PSScriptRoot
+    $script:validConfidenceValues = @("High", "Medium", "N/A")
 }
 
 Describe "Validator Confidence value consistency" {
     # All validators must use title-case Confidence values: High, Medium, or N/A (error only)
-    $validConfidenceValues = @("High", "Medium", "N/A")
+    It "<Name> uses only valid Confidence values (High, Medium, or N/A)" -ForEach $validatorFiles {
+        $Path | Should -Exist -Because "$Name should exist"
+        $content = Get-Content -LiteralPath $Path -Raw
 
-    $validatorFiles = @(
-        "Test-UnifiedAuditLog.ps1",
-        "Test-MailboxAudit.ps1",
-        "Test-PurviewRetention.ps1",
-        "Test-EnvironmentAudit.ps1",
-        "Test-EnvironmentRetention.ps1"
-    )
+        # Find all Confidence assignments (code lines, not comments/docstrings)
+        $matches = [regex]::Matches($content, '(?:Confidence\s*=\s*"([^"]+)"|\$confidence\s*=\s*"([^"]+)")')
 
-    foreach ($file in $validatorFiles) {
-        Context "$file" {
-            It "Uses only valid Confidence values (High, Medium, or N/A)" {
-                $filePath = Join-Path $script:validatorDir $file
-                $content = Get-Content $filePath -Raw
+        $matches.Count | Should -BeGreaterThan 0 -Because "$Name should contain Confidence assignments"
 
-                # Find all Confidence assignments (code lines, not comments/docstrings)
-                $matches = [regex]::Matches($content, '(?:Confidence\s*=\s*"([^"]+)"|\$confidence\s*=\s*"([^"]+)")')
-
-                $matches.Count | Should -BeGreaterThan 0 -Because "$file should contain Confidence assignments"
-
-                foreach ($match in $matches) {
-                    $value = if ($match.Groups[1].Success) { $match.Groups[1].Value } else { $match.Groups[2].Value }
-                    $value | Should -BeIn $validConfidenceValues -Because "Confidence value '$value' in $file must be title-case (High, Medium, or N/A)"
-                }
-            }
+        foreach ($match in $matches) {
+            $value = if ($match.Groups[1].Success) { $match.Groups[1].Value } else { $match.Groups[2].Value }
+            ($script:validConfidenceValues -ccontains $value) | Should -BeTrue -Because "Confidence value '$value' in $Name must be title-case (High, Medium, or N/A)"
         }
     }
 }
 
 Describe "Test-EnvironmentRetention output contract" {
-    It "Does not use undocumented Confidence value 'Low'" {
-        $filePath = Join-Path $script:validatorDir "Test-EnvironmentRetention.ps1"
-        $content = Get-Content $filePath -Raw
+    It "Does not use undocumented Confidence value 'Low'" -ForEach $environmentRetentionValidator {
+        $Path | Should -Exist -Because "$Name should exist"
+        $content = Get-Content -LiteralPath $Path -Raw
 
-        $content | Should -Not -Match 'Confidence\s*=\s*"Low"' -Because "Only High and Medium are documented Confidence values"
+        ($content -cnotmatch 'Confidence\s*=\s*"Low"') | Should -BeTrue -Because "Only High and Medium are documented Confidence values"
     }
 }
 
 Describe "Test-UnifiedAuditLog output contract" {
-    It "Docstring documents title-case Confidence values" {
-        $filePath = Join-Path $script:validatorDir "Test-UnifiedAuditLog.ps1"
-        $content = Get-Content $filePath -Raw
+    It "Docstring documents title-case Confidence values" -ForEach $unifiedAuditLogValidator {
+        $Path | Should -Exist -Because "$Name should exist"
+        $content = Get-Content -LiteralPath $Path -Raw
 
-        $content | Should -Match 'Confidence:\s*High\s*\|\s*Medium' -Because "Docstring should document title-case values"
+        ($content -cmatch 'Confidence:\s*High\s*\|\s*Medium') | Should -BeTrue -Because "Docstring should document title-case values"
     }
 }
 
 Describe "Test-PurviewRetention output contract" {
-    It "Uses title-case Confidence values" {
-        $filePath = Join-Path $script:validatorDir "Test-PurviewRetention.ps1"
-        $content = Get-Content $filePath -Raw
+    It "Uses title-case Confidence values" -ForEach $purviewRetentionValidator {
+        $Path | Should -Exist -Because "$Name should exist"
+        $content = Get-Content -LiteralPath $Path -Raw
 
-        $content | Should -Not -Match 'Confidence\s*=\s*"HIGH"' -Because "Should use 'High' not 'HIGH'"
+        ($content -cnotmatch 'Confidence\s*=\s*"HIGH"') | Should -BeTrue -Because "Should use 'High' not 'HIGH'"
     }
 }
 
 Describe "Test-MailboxAudit output contract" {
-    It "Uses title-case Confidence values" {
-        $filePath = Join-Path $script:validatorDir "Test-MailboxAudit.ps1"
-        $content = Get-Content $filePath -Raw
+    It "Uses title-case Confidence values" -ForEach $mailboxAuditValidator {
+        $Path | Should -Exist -Because "$Name should exist"
+        $content = Get-Content -LiteralPath $Path -Raw
 
-        $content | Should -Not -Match 'Confidence\s*=\s*"HIGH"' -Because "Should use 'High' not 'HIGH'"
+        ($content -cnotmatch 'Confidence\s*=\s*"HIGH"') | Should -BeTrue -Because "Should use 'High' not 'HIGH'"
     }
 }
 
 Describe "Tenant validator output shape includes RawValue" {
-    # Ensures the orchestrator (Invoke-TenantAuditValidation) can access .RawValue
+    # Verifies the orchestrator (Invoke-TenantAuditValidation) can access .RawValue
     # on results from all three tenant validators without silently falling back to N/A.
+    It "<Name> includes RawValue property in return PSCustomObject" -ForEach $tenantValidators {
+        $Path | Should -Exist -Because "$Name should exist"
+        $content = Get-Content -LiteralPath $Path -Raw
 
-    $tenantValidators = @(
-        "Test-UnifiedAuditLog.ps1",
-        "Test-MailboxAudit.ps1",
-        "Test-PurviewRetention.ps1"
-    )
-
-    foreach ($file in $tenantValidators) {
-        Context "$file" {
-            It "Includes RawValue property in return PSCustomObject" {
-                $filePath = Join-Path $script:validatorDir $file
-                $content = Get-Content $filePath -Raw
-
-                $content | Should -Match 'RawValue\s*=' -Because "$file must include a RawValue property so the orchestrator can record audit evidence to Dataverse"
-            }
-        }
+        ($content -cmatch 'RawValue\s*=') | Should -BeTrue -Because "$Name must include a RawValue property so the orchestrator can record audit evidence to Dataverse"
     }
 }
 
 Describe "Validator script direct-invocation blocks" {
-    $privateDir = Join-Path $script:validatorDir "private"
+    It "<Name> has a direct-invocation block" -ForEach $privateScripts {
+        $Path | Should -Exist -Because "$Name should exist"
+        $content = Get-Content -LiteralPath $Path -Raw
 
-    $privateScripts = @(
-        "New-CanaryEvent.ps1",
-        "Connect-AuditServices.ps1",
-        "Connect-PowerPlatform.ps1",
-        "Get-ValidationResults.ps1"
-    )
-
-    foreach ($script in $privateScripts) {
-        It "$script has a direct-invocation block" {
-            $filePath = Join-Path $privateDir $script
-            $content = Get-Content $filePath -Raw
-
-            $content | Should -Match 'MyInvocation\.InvocationName\s+-ne\s+' -Because "$script should support direct invocation"
-        }
+        ($content -cmatch 'MyInvocation\.InvocationName\s+-ne\s+') | Should -BeTrue -Because "$Name should support direct invocation"
     }
 }


### PR DESCRIPTION
## Summary
- Fixes the 16 `audit-compliance-manager/scripts/Validators.Tests.ps1` Pester failures by moving validator/private script path data into Pester discovery data and passing it with `-ForEach`.
- Uses `Get-Content -LiteralPath` for file reads and makes Confidence casing assertions case-sensitive.

## Root cause
`Validators.Tests.ps1` built paths from discovery-time `foreach` variables and a `$script:validatorDir` value initialized in `BeforeAll`. In Pester 5, `BeforeAll` does not run during discovery and the loop variables were not reliably carried into `It` blocks, so paths collapsed to null or the scripts directory.

## Validation
- Targeted: `Validators.Tests.ps1` now reports `Passed: 16, Failed: 0`.
- Repo-wide command was run; `Validators.Tests.ps1` passed, but the sweep reported `Passed: 96, Failed: 6` due out-of-scope `AuditComplianceHelpers.Tests.ps1` failures (retry jitter/upsert call-count tests) not present in the original baseline.

Reference: plan.md "Wave 6 — Tech-debt close-out / Phase 5".