### PR TITLE
chore(dr-testing-framework): suppress Invoke-Expression in Pester AST helpers (Wave 6 P4e)

### DIFF
--- a/dr-testing-framework/scripts/Invoke-DRTest.Tests.ps1
+++ b/dr-testing-framework/scripts/Invoke-DRTest.Tests.ps1
@@ -1,5 +1,11 @@
 #Requires -Modules Pester
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingInvokeExpression', '',
+    Justification = 'Pester test harness: extracts FunctionDefinitionAst nodes from production script and evaluates them in test scope via Invoke-Expression. The input is a verified AST .Extent.Text from a trusted file under source control, NOT untrusted user input. This is the standard pattern for testing nested helper functions that are not exported from their parent script.'
+)]
+param()
+
 <#
 .SYNOPSIS
     Pester tests for Invoke-DRTest.ps1


### PR DESCRIPTION
## Summary
- Adds a file-level `SuppressMessageAttribute` for `PSAvoidUsingInvokeExpression` in `dr-testing-framework/scripts/Invoke-DRTest.Tests.ps1`.
- Documents why the six `Invoke-Expression` calls are intentional: the Pester harness extracts trusted function bodies from source-controlled script AST/extent text and evaluates them in test scope to exercise nested helpers that are not exported.
- Does not remove or rewrite the existing test harness pattern.

## Validation
- `PSAvoidUsingInvokeExpression` hits: 6 -> 0
- Total PSSA findings: 410 -> 404
- Targeted Pester: 39 passed, 0 failed