### PR TITLE
chore(powershell): UTF-8 BOM re-encode sweep (Wave 6 P2)

### DIFF
--- a/action-confirmation-auditor/scripts/Get-PurviewAIHubEvidence.ps1
+++ b/action-confirmation-auditor/scripts/Get-PurviewAIHubEvidence.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Integrates with Microsoft Purview AI Hub (DSPM for AI) to cross-reference
     action confirmation events with AI data security posture evidence.

--- a/action-confirmation-auditor/scripts/Start-ActionConfirmationRunbook-MI.ps1
+++ b/action-confirmation-auditor/scripts/Start-ActionConfirmationRunbook-MI.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Sample Azure Automation runbook demonstrating managed identity authentication
     for action confirmation validation.

--- a/action-confirmation-auditor/scripts/governance/Import-ActionRiskClassifications.ps1
+++ b/action-confirmation-auditor/scripts/governance/Import-ActionRiskClassifications.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Imports action risk classification rules from CSV (v1.1 feature).
 

--- a/action-confirmation-auditor/scripts/private/Connect-EnvironmentDataverse.ps1
+++ b/action-confirmation-auditor/scripts/private/Connect-EnvironmentDataverse.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Per-environment Dataverse authentication helper.
 

--- a/action-confirmation-auditor/scripts/private/Get-ExpectedConfirmationPolicy.ps1
+++ b/action-confirmation-auditor/scripts/private/Get-ExpectedConfirmationPolicy.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Retrieves expected action confirmation policy and severity for a zone.
 

--- a/action-confirmation-auditor/scripts/private/Get-ZoneClassification.ps1
+++ b/action-confirmation-auditor/scripts/private/Get-ZoneClassification.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Zone Classification — delegated to shared module.
 

--- a/agent-365-lifecycle-governance/scripts/Deploy-LifecycleGovernance-Baseline.ps1
+++ b/agent-365-lifecycle-governance/scripts/Deploy-LifecycleGovernance-Baseline.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Az.Accounts
+﻿#Requires -Modules Az.Accounts
 
 <#
 .SYNOPSIS

--- a/agent-365-lifecycle-governance/scripts/Test-LifecycleCompliance.ps1
+++ b/agent-365-lifecycle-governance/scripts/Test-LifecycleCompliance.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Az.Accounts
+﻿#Requires -Modules Az.Accounts
 
 <#
 .SYNOPSIS

--- a/agent-access-monitor/scripts/Export-AgentAccessEvidence.ps1
+++ b/agent-access-monitor/scripts/Export-AgentAccessEvidence.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules MSAL.PS
 
 <#

--- a/agent-access-monitor/scripts/Test-AgentAccessCompliance.ps1
+++ b/agent-access-monitor/scripts/Test-AgentAccessCompliance.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Orchestrates agent access compliance scanning across Power Platform environments.
 

--- a/agent-access-monitor/scripts/Test-EvidenceIntegrity.ps1
+++ b/agent-access-monitor/scripts/Test-EvidenceIntegrity.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 
 <#
 .SYNOPSIS

--- a/agent-access-monitor/scripts/agent-access-monitor.psd1
+++ b/agent-access-monitor/scripts/agent-access-monitor.psd1
@@ -1,4 +1,4 @@
-@{
+﻿@{
     # Script module or binary module file associated with this manifest
     RootModule = 'private\AAMClient.psm1'
     

--- a/agent-access-monitor/scripts/private/AAMClient.psm1
+++ b/agent-access-monitor/scripts/private/AAMClient.psm1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Agent Access Monitor Dataverse client module.
 

--- a/agent-communication-restriction-detector/scripts/Export-CommViolationEvidence.ps1
+++ b/agent-communication-restriction-detector/scripts/Export-CommViolationEvidence.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 # Authentication uses Az.Accounts (Get-AzAccessToken). MSAL.PS was deprecated by
 # the maintainer and is no longer receiving security updates; ACRDClient.psm1 and
 # Connect-EnvironmentDataverse.ps1 already use Az.Accounts. Az.Accounts >= 2.17

--- a/agent-communication-restriction-detector/scripts/Get-CrossTenantAccessCorrelation.ps1
+++ b/agent-communication-restriction-detector/scripts/Get-CrossTenantAccessCorrelation.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Correlates cross-tenant agent communication findings with Microsoft Entra ID
     cross-tenant access policies.

--- a/agent-communication-restriction-detector/scripts/Start-CommRestrictionValidationRunbook.ps1
+++ b/agent-communication-restriction-detector/scripts/Start-CommRestrictionValidationRunbook.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 #Requires -PSEdition Desktop
 #Requires -Modules @{ ModuleName="MSAL.PS"; ModuleVersion="4.37.0" }
 

--- a/agent-communication-restriction-detector/scripts/Test-CommRestrictionCompliance.ps1
+++ b/agent-communication-restriction-detector/scripts/Test-CommRestrictionCompliance.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Validates agent-to-agent communication against zone-specific governance
     requirements for multi-agent orchestration limits.

--- a/agent-communication-restriction-detector/scripts/governance/Import-ApprovedCommRoutes.ps1
+++ b/agent-communication-restriction-detector/scripts/governance/Import-ApprovedCommRoutes.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 
 <#
 .SYNOPSIS

--- a/agent-communication-restriction-detector/scripts/private/ACRDClient.psm1
+++ b/agent-communication-restriction-detector/scripts/private/ACRDClient.psm1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Agent Communication Restriction Detector Dataverse client module.
 

--- a/agent-communication-restriction-detector/scripts/private/Get-ZoneClassification.ps1
+++ b/agent-communication-restriction-detector/scripts/private/Get-ZoneClassification.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 
 <#
 .SYNOPSIS

--- a/agent-intake/lab/Invoke-Deploy.ps1
+++ b/agent-intake/lab/Invoke-Deploy.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/agent-intake/scripts/deploy.ps1
+++ b/agent-intake/scripts/deploy.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules @{ ModuleName = 'Az.Accounts'; ModuleVersion = '2.0.0' }, @{ ModuleName = 'ExchangeOnlineManagement'; ModuleVersion = '3.2.0' }
 
 <#

--- a/agent-intake/scripts/provision_reviewer_app.ps1
+++ b/agent-intake/scripts/provision_reviewer_app.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/agent-intake/scripts/seed-test-data.ps1
+++ b/agent-intake/scripts/seed-test-data.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#!
 .SYNOPSIS

--- a/agent-intake/scripts/smoke_test.ps1
+++ b/agent-intake/scripts/smoke_test.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Extended smoke test for the agent-intake solution.
 

--- a/agent-knowledge-source-scanner/scripts/Get-KnowledgeSourceItemPermissions.ps1
+++ b/agent-knowledge-source-scanner/scripts/Get-KnowledgeSourceItemPermissions.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Enumerates item-level permissions in agent knowledge source SharePoint libraries.
 

--- a/agent-knowledge-source-scanner/scripts/Invoke-GraphPermissionScan.ps1
+++ b/agent-knowledge-source-scanner/scripts/Invoke-GraphPermissionScan.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Scans item-level permissions via Microsoft Graph v1.0 with JSON batching.
 

--- a/agent-observability-foundation/scripts/deploy-alerts.ps1
+++ b/agent-observability-foundation/scripts/deploy-alerts.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Deploy alert infrastructure for FSI Agent Observability Foundation.
 

--- a/agent-observability-foundation/scripts/deploy-workbooks.ps1
+++ b/agent-observability-foundation/scripts/deploy-workbooks.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Deploy Azure Monitor Workbook ARM templates for Agent Observability Foundation.
 

--- a/agent-registry-automation/scripts/Deploy-AgentRegistry-Baseline.ps1
+++ b/agent-registry-automation/scripts/Deploy-AgentRegistry-Baseline.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules @{ ModuleName = 'Az.Accounts'; ModuleVersion = '5.3.4' }
 
 <#

--- a/agent-registry-automation/scripts/Test-AgentRegistryCompliance.ps1
+++ b/agent-registry-automation/scripts/Test-AgentRegistryCompliance.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules @{ ModuleName = 'Az.Accounts'; ModuleVersion = '5.3.4' }
 
 <#

--- a/agent-sharing-access-restriction-detector/scripts/governance/Export-SharingComplianceEvidence.ps1
+++ b/agent-sharing-access-restriction-detector/scripts/governance/Export-SharingComplianceEvidence.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Exports ASARD sharing compliance evidence from Dataverse to JSON with SHA-256 integrity hashing.
 

--- a/agent-sharing-access-restriction-detector/scripts/governance/Get-ExpectedSharingPolicy.ps1
+++ b/agent-sharing-access-restriction-detector/scripts/governance/Get-ExpectedSharingPolicy.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Retrieves expected agent sharing policy for a governance zone.
 

--- a/agent-sharing-access-restriction-detector/scripts/governance/Invoke-SharingComplianceScan.ps1
+++ b/agent-sharing-access-restriction-detector/scripts/governance/Invoke-SharingComplianceScan.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Detects agents with sharing configurations that violate zone-based access policies.
 

--- a/agent-sharing-access-restriction-detector/scripts/governance/Test-AgentSharingCompliance.ps1
+++ b/agent-sharing-access-restriction-detector/scripts/governance/Test-AgentSharingCompliance.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Orchestrates a full agent sharing compliance scan and evaluates overall posture.
 

--- a/agent-sharing-access-restriction-detector/scripts/governance/Test-EvidenceIntegrity.ps1
+++ b/agent-sharing-access-restriction-detector/scripts/governance/Test-EvidenceIntegrity.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Verifies SHA-256 integrity of ASARD sharing compliance evidence files.
 

--- a/audit-compliance-manager/scripts/AuditComplianceHelpers.Tests.ps1
+++ b/audit-compliance-manager/scripts/AuditComplianceHelpers.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 #Requires -Modules @{ ModuleName="Pester"; ModuleVersion="5.0.0" }
 
 <#

--- a/audit-compliance-manager/scripts/AuditComplianceHelpers.psd1
+++ b/audit-compliance-manager/scripts/AuditComplianceHelpers.psd1
@@ -1,4 +1,4 @@
-@{
+﻿@{
     # Module manifest for AuditComplianceHelpers
     # Audit Logging Compliance Automation (ALCA) - Shared helper module
 

--- a/audit-compliance-manager/scripts/AuditComplianceHelpers.psm1
+++ b/audit-compliance-manager/scripts/AuditComplianceHelpers.psm1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 
 <#
 .SYNOPSIS

--- a/audit-compliance-manager/scripts/Enable-AuditLogging.ps1
+++ b/audit-compliance-manager/scripts/Enable-AuditLogging.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Microsoft.PowerApps.Administration.PowerShell'; ModuleVersion = '2.0.180' }
 #Requires -Modules @{ ModuleName = 'ExchangeOnlineManagement'; ModuleVersion = '3.0.0' }
 

--- a/audit-compliance-manager/scripts/Export-AuditValidationEvidence.ps1
+++ b/audit-compliance-manager/scripts/Export-AuditValidationEvidence.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 
 <#
 .SYNOPSIS

--- a/audit-compliance-manager/scripts/Invoke-EnvironmentAuditValidation.ps1
+++ b/audit-compliance-manager/scripts/Invoke-EnvironmentAuditValidation.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 #Requires -Modules @{ ModuleName="Microsoft.PowerApps.Administration.PowerShell"; ModuleVersion="2.0.180" }
 
 <#

--- a/audit-compliance-manager/scripts/Invoke-EnvironmentDiscovery.ps1
+++ b/audit-compliance-manager/scripts/Invoke-EnvironmentDiscovery.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 #Requires -Modules @{ ModuleName="Microsoft.PowerApps.Administration.PowerShell"; ModuleVersion="2.0.180" }
 
 <#

--- a/audit-compliance-manager/scripts/Invoke-TenantAuditValidation.ps1
+++ b/audit-compliance-manager/scripts/Invoke-TenantAuditValidation.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 #Requires -Modules @{ ModuleName="ExchangeOnlineManagement"; ModuleVersion="3.0.0" }
 
 <#

--- a/audit-compliance-manager/scripts/Set-SecurityRoles.ps1
+++ b/audit-compliance-manager/scripts/Set-SecurityRoles.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 
 <#
 .SYNOPSIS

--- a/audit-compliance-manager/scripts/Test-AuditLoggingCompliance.ps1
+++ b/audit-compliance-manager/scripts/Test-AuditLoggingCompliance.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 #Requires -Modules @{ ModuleName="Microsoft.PowerApps.Administration.PowerShell"; ModuleVersion="2.0.180" }
 #Requires -Modules @{ ModuleName="ExchangeOnlineManagement"; ModuleVersion="3.0.0" }
 

--- a/audit-compliance-manager/scripts/Test-EvidenceIntegrity.ps1
+++ b/audit-compliance-manager/scripts/Test-EvidenceIntegrity.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 
 <#
 .SYNOPSIS

--- a/audit-compliance-manager/scripts/Test-MailboxAudit.ps1
+++ b/audit-compliance-manager/scripts/Test-MailboxAudit.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 #Requires -Modules @{ ModuleName="ExchangeOnlineManagement"; ModuleVersion="3.0.0" }
 
 <#

--- a/audit-compliance-manager/scripts/Test-PurviewRetention.ps1
+++ b/audit-compliance-manager/scripts/Test-PurviewRetention.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 #Requires -Modules @{ ModuleName="ExchangeOnlineManagement"; ModuleVersion="3.0.0" }
 
 <#

--- a/audit-compliance-manager/scripts/private/Connect-PowerPlatform.ps1
+++ b/audit-compliance-manager/scripts/private/Connect-PowerPlatform.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 #Requires -Modules @{ ModuleName="Microsoft.PowerApps.Administration.PowerShell"; ModuleVersion="2.0.180" }
 # NOTE: MSAL.PS is archived and no longer maintained. Plan migration to
 # Az.Accounts (Get-AzAccessToken) or Microsoft.Identity.Client.

--- a/coi-testing/scripts/Get-CoiInventory.ps1
+++ b/coi-testing/scripts/Get-CoiInventory.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/compliance-dashboard/scripts/Get-ExchangeComplianceData.ps1
+++ b/compliance-dashboard/scripts/Get-ExchangeComplianceData.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Collects Exchange Online compliance signals via Microsoft Graph API.
 

--- a/conditional-access-automation/scripts/Deploy-CAPolicies.ps1
+++ b/conditional-access-automation/scripts/Deploy-CAPolicies.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Deploys Conditional Access policy templates for AI workloads.
 

--- a/conditional-access-automation/scripts/Export-CAAComplianceEvidence.ps1
+++ b/conditional-access-automation/scripts/Export-CAAComplianceEvidence.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Exports CA policy compliance evidence with SHA-256 integrity hashing.
 

--- a/conditional-access-automation/scripts/Export-PolicyBaseline.ps1
+++ b/conditional-access-automation/scripts/Export-PolicyBaseline.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Captures and exports a Conditional Access policy baseline snapshot to JSON.
 

--- a/conditional-access-automation/scripts/Register-ServicePrincipal.ps1
+++ b/conditional-access-automation/scripts/Register-ServicePrincipal.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Registers an Entra ID service principal for Conditional Access policy automation.
 

--- a/conditional-access-automation/scripts/Start-CAAValidationRunbook.ps1
+++ b/conditional-access-automation/scripts/Start-CAAValidationRunbook.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.1
+﻿#Requires -Version 7.1
 #Requires -Modules @{ ModuleName = "Microsoft.Graph.Identity.SignIns"; ModuleVersion = "2.0.0" }
 #Requires -Modules @{ ModuleName = "Az.Accounts"; ModuleVersion = "3.0.0" }
 

--- a/conditional-access-automation/scripts/Test-EvidenceIntegrity.ps1
+++ b/conditional-access-automation/scripts/Test-EvidenceIntegrity.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Verifies the SHA-256 integrity of a CAA compliance evidence file.
 

--- a/conditional-access-automation/scripts/Test-PolicyCompliance.ps1
+++ b/conditional-access-automation/scripts/Test-PolicyCompliance.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Tests Conditional Access policy compliance, coverage, and session controls.
 

--- a/conditional-access-automation/scripts/Watch-PolicyDrift.ps1
+++ b/conditional-access-automation/scripts/Watch-PolicyDrift.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Detects drift between a saved Conditional Access policy baseline and the
     current live tenant state.

--- a/conditional-access-automation/scripts/conditional-access-automation.psd1
+++ b/conditional-access-automation/scripts/conditional-access-automation.psd1
@@ -1,4 +1,4 @@
-@{
+﻿@{
     # Script module or binary module file associated with this manifest
     RootModule = 'conditional-access-automation.psm1'
     

--- a/conditional-access-automation/scripts/conditional-access-automation.psm1
+++ b/conditional-access-automation/scripts/conditional-access-automation.psm1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Root module for conditional-access-automation — loads private helpers.
 

--- a/conditional-access-automation/scripts/private/CAAClient.psm1
+++ b/conditional-access-automation/scripts/private/CAAClient.psm1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Conditional Access Automation Dataverse client module.
 

--- a/conditional-access-automation/scripts/private/Compare-PolicyBaseline.ps1
+++ b/conditional-access-automation/scripts/private/Compare-PolicyBaseline.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Compares two Conditional Access policy baseline snapshots to detect drift.
 

--- a/conditional-access-automation/scripts/private/Connect-GraphSession.ps1
+++ b/conditional-access-automation/scripts/private/Connect-GraphSession.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Establishes or reuses a Microsoft Graph session for Conditional Access operations.
 

--- a/conditional-access-automation/scripts/private/Get-CAAValidationResults.ps1
+++ b/conditional-access-automation/scripts/private/Get-CAAValidationResults.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Queries CAA validation data from Dataverse via OData Web API.
 

--- a/conditional-access-automation/scripts/private/Get-PolicyBaseline.ps1
+++ b/conditional-access-automation/scripts/private/Get-PolicyBaseline.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Retrieves a normalized baseline snapshot of Conditional Access policies
     matching FSI governance naming patterns.

--- a/conditional-access-automation/scripts/private/Get-ZoneClassification.ps1
+++ b/conditional-access-automation/scripts/private/Get-ZoneClassification.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Retrieves zone classification for a Power Platform environment.
 

--- a/conditional-access-automation/scripts/private/Test-ParameterValidation.ps1
+++ b/conditional-access-automation/scripts/private/Test-ParameterValidation.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Parameter validation helpers for Conditional Access Automation scripts.
 

--- a/content-moderation-monitor/scripts/Compare-ModerationCompliance.ps1
+++ b/content-moderation-monitor/scripts/Compare-ModerationCompliance.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Compares agent content moderation levels against zone-specific requirements.
 

--- a/content-moderation-monitor/scripts/Export-ContentModerationEvidence.ps1
+++ b/content-moderation-monitor/scripts/Export-ContentModerationEvidence.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules @{ ModuleName="MSAL.PS"; ModuleVersion="4.37.0" }
 
 <#

--- a/content-moderation-monitor/scripts/Get-AgentModerationSettings.ps1
+++ b/content-moderation-monitor/scripts/Get-AgentModerationSettings.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Retrieves content moderation settings for all Copilot Studio agents across
     Power Platform environments.

--- a/content-moderation-monitor/scripts/Invoke-ModerationBaselineCapture.ps1
+++ b/content-moderation-monitor/scripts/Invoke-ModerationBaselineCapture.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules @{ ModuleName="MSAL.PS"; ModuleVersion="4.37.0" }
 
 <#

--- a/content-moderation-monitor/scripts/Start-ModerationValidationRunbook.ps1
+++ b/content-moderation-monitor/scripts/Start-ModerationValidationRunbook.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.1
+﻿#Requires -Version 7.1
 #Requires -Modules @{ ModuleName="MSAL.PS"; ModuleVersion="4.37.0" }
 
 <#

--- a/content-moderation-monitor/scripts/Test-EvidenceIntegrity.ps1
+++ b/content-moderation-monitor/scripts/Test-EvidenceIntegrity.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 
 <#
 .SYNOPSIS

--- a/content-moderation-monitor/scripts/private/CMMClient.psm1
+++ b/content-moderation-monitor/scripts/private/CMMClient.psm1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Content Moderation Monitor Dataverse client module.
 

--- a/content-moderation-monitor/scripts/private/Connect-EnvironmentDataverse.ps1
+++ b/content-moderation-monitor/scripts/private/Connect-EnvironmentDataverse.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Per-environment Dataverse authentication helper.
 

--- a/content-moderation-monitor/scripts/private/Get-CMMValidationResults.ps1
+++ b/content-moderation-monitor/scripts/private/Get-CMMValidationResults.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 # Import CMMClient module for Invoke-DataverseRequest (retry/backoff on 429/5xx)
 Import-Module (Join-Path $PSScriptRoot 'CMMClient.psm1') -Force

--- a/credential-oversharing-detector/scripts/governance/Export-CredentialEvidence.ps1
+++ b/credential-oversharing-detector/scripts/governance/Export-CredentialEvidence.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules @{ ModuleName='MSAL.PS'; ModuleVersion='4.37.0.0' }
 
 <#

--- a/credential-oversharing-detector/scripts/governance/Test-CredentialCompliance.ps1
+++ b/credential-oversharing-detector/scripts/governance/Test-CredentialCompliance.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules @{ ModuleName='Az.Accounts'; ModuleVersion='2.17.0' }
 
 <#

--- a/credential-oversharing-detector/scripts/governance/Test-EvidenceIntegrity.ps1
+++ b/credential-oversharing-detector/scripts/governance/Test-EvidenceIntegrity.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/cross-solution-integration/scripts/powershell/Export-UnifiedComplianceEvidence.ps1
+++ b/cross-solution-integration/scripts/powershell/Export-UnifiedComplianceEvidence.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Exports unified compliance evidence (run-level history) from Tier 2
     governance solutions into a CSV bundle with a SHA-256 manifest.

--- a/cross-solution-integration/scripts/powershell/IntegrationConfig.psm1
+++ b/cross-solution-integration/scripts/powershell/IntegrationConfig.psm1
@@ -1,4 +1,4 @@
-# MSAL.PS is required only for Interactive and legacy ServicePrincipal authentication.
+﻿# MSAL.PS is required only for Interactive and legacy ServicePrincipal authentication.
 
 <#
 .SYNOPSIS

--- a/cross-solution-integration/scripts/powershell/Register-ProvisionedEnvironment.ps1
+++ b/cross-solution-integration/scripts/powershell/Register-ProvisionedEnvironment.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Registers a newly provisioned environment in ACV's environment registry.
 

--- a/cross-solution-integration/scripts/powershell/Sync-SolutionAssessments.ps1
+++ b/cross-solution-integration/scripts/powershell/Sync-SolutionAssessments.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Syncs Tier 2 governance solution validation results into Compliance Dashboard assessments.
 

--- a/cross-solution-integration/scripts/powershell/Test-UnifiedEvidenceIntegrity.ps1
+++ b/cross-solution-integration/scripts/powershell/Test-UnifiedEvidenceIntegrity.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Verifies the integrity of a unified compliance evidence export package.
 

--- a/cross-tenant-external-sharing-governance/scripts/governance/Deploy-CrossTenantBaseline.ps1
+++ b/cross-tenant-external-sharing-governance/scripts/governance/Deploy-CrossTenantBaseline.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules @{ ModuleName = 'Az.Accounts'; ModuleVersion = '2.17.0' }
 
 <#

--- a/cross-tenant-external-sharing-governance/scripts/governance/Scan-ManagedEnvBotSharingBaseline.ps1
+++ b/cross-tenant-external-sharing-governance/scripts/governance/Scan-ManagedEnvBotSharingBaseline.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules @{ ModuleName='Az.Accounts'; ModuleVersion='2.17.0' }
 
 <#

--- a/cross-tenant-external-sharing-governance/scripts/governance/Test-CrossTenantCompliance.ps1
+++ b/cross-tenant-external-sharing-governance/scripts/governance/Test-CrossTenantCompliance.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules @{ ModuleName = 'Az.Accounts'; ModuleVersion = '2.17.0' }
 
 <#

--- a/deny-event-correlation-report/scripts/Invoke-DailyDenyReport.ps1
+++ b/deny-event-correlation-report/scripts/Invoke-DailyDenyReport.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Orchestrates daily execution of all deny event extraction scripts.
 

--- a/dr-testing-framework/scripts/Invoke-DRTest.ps1
+++ b/dr-testing-framework/scripts/Invoke-DRTest.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Runs post-recovery validation checks against an AI agent's Dataverse environment and writes structured evidence to Dataverse.
 

--- a/file-upload-security/scripts/Export-FileUploadEvidence.ps1
+++ b/file-upload-security/scripts/Export-FileUploadEvidence.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.4
+﻿#Requires -Version 7.4
 
 <#
 .SYNOPSIS

--- a/file-upload-security/scripts/Invoke-FileUploadBaselineCapture.ps1
+++ b/file-upload-security/scripts/Invoke-FileUploadBaselineCapture.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.4
+﻿#Requires -Version 7.4
 
 <#
 .SYNOPSIS

--- a/file-upload-security/scripts/Start-FileUploadValidationRunbook.ps1
+++ b/file-upload-security/scripts/Start-FileUploadValidationRunbook.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.4
+﻿#Requires -Version 7.4
 #Requires -Modules @{ ModuleName="MSAL.PS"; ModuleVersion="4.37.0" }
 
 <#

--- a/file-upload-security/scripts/Test-FileUploadCompliance.ps1
+++ b/file-upload-security/scripts/Test-FileUploadCompliance.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.4
+﻿#Requires -Version 7.4
 
 <#
 .SYNOPSIS

--- a/generative-ai-config-auditor/scripts/Compare-GenAIConfigCompliance.ps1
+++ b/generative-ai-config-auditor/scripts/Compare-GenAIConfigCompliance.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Compares agent generative AI configuration against zone-specific policies.
 

--- a/generative-ai-config-auditor/scripts/Get-AgentGenAISettings.ps1
+++ b/generative-ai-config-auditor/scripts/Get-AgentGenAISettings.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Retrieves generative AI configuration settings for all Copilot Studio agents
     across Power Platform environments.

--- a/generative-ai-config-auditor/scripts/Get-PurviewDLPEvidence.ps1
+++ b/generative-ai-config-auditor/scripts/Get-PurviewDLPEvidence.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Collects Purview DLP and sensitivity label evidence for generative AI
     configurations.

--- a/generative-ai-config-auditor/scripts/Start-GenAIConfigValidationRunbook.ps1
+++ b/generative-ai-config-auditor/scripts/Start-GenAIConfigValidationRunbook.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.4
+﻿#Requires -Version 7.4
 #Requires -Modules @{ ModuleName="MSAL.PS"; ModuleVersion="4.37.0" }
 #Requires -Modules Microsoft.PowerApps.Administration.PowerShell
 

--- a/generative-ai-config-auditor/scripts/governance/Import-ApprovedAoaiConnections.ps1
+++ b/generative-ai-config-auditor/scripts/governance/Import-ApprovedAoaiConnections.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.4
+﻿#Requires -Version 7.4
 #Requires -Modules Az.Accounts
 
 <#

--- a/generative-ai-config-auditor/scripts/private/Get-ExpectedGenAIPolicy.ps1
+++ b/generative-ai-config-auditor/scripts/private/Get-ExpectedGenAIPolicy.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Retrieves expected generative AI policy and severity classification for a zone.
 

--- a/generative-ai-config-auditor/scripts/private/Get-GACValidationResults.ps1
+++ b/generative-ai-config-auditor/scripts/private/Get-GACValidationResults.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.4
+﻿#Requires -Version 7.4
 
 # Import GACClient module for Invoke-DataverseRequest (retry/backoff on 429/5xx)
 Import-Module (Join-Path $PSScriptRoot 'GACClient.psm1') -Force

--- a/hallucination-tracker/scripts/governance/Export-HallucinationEvidence.ps1
+++ b/hallucination-tracker/scripts/governance/Export-HallucinationEvidence.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules MSAL.PS
 
 <#

--- a/hallucination-tracker/scripts/governance/Get-HallucinationSummary.ps1
+++ b/hallucination-tracker/scripts/governance/Get-HallucinationSummary.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules MSAL.PS
 
 <#

--- a/hallucination-tracker/scripts/governance/Test-EvidenceIntegrity.ps1
+++ b/hallucination-tracker/scripts/governance/Test-EvidenceIntegrity.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/hitl-workflow-governance/scripts/Export-HitlGovernanceEvidence.ps1
+++ b/hitl-workflow-governance/scripts/Export-HitlGovernanceEvidence.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/hitl-workflow-governance/scripts/Get-AgentHitlSettings.ps1
+++ b/hitl-workflow-governance/scripts/Get-AgentHitlSettings.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Retrieves Human-in-the-Loop checkpoint configuration for all Copilot
     Studio agents across Power Platform environments.

--- a/hitl-workflow-governance/scripts/Start-HitlValidationRunbook.ps1
+++ b/hitl-workflow-governance/scripts/Start-HitlValidationRunbook.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules @{ ModuleName="MSAL.PS"; ModuleVersion="4.37.0" }
 
 <#

--- a/hitl-workflow-governance/scripts/Test-EvidenceIntegrity.ps1
+++ b/hitl-workflow-governance/scripts/Test-EvidenceIntegrity.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 
 <#
 .SYNOPSIS

--- a/hitl-workflow-governance/scripts/Test-HitlWorkflowCompliance.ps1
+++ b/hitl-workflow-governance/scripts/Test-HitlWorkflowCompliance.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Validates HITL checkpoint configuration for all Copilot Studio agents
     against zone-specific governance requirements.

--- a/hitl-workflow-governance/scripts/governance/Test-HitlCheckpointConfiguration.ps1
+++ b/hitl-workflow-governance/scripts/governance/Test-HitlCheckpointConfiguration.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Validates that Copilot Studio agent flows have proper HITL checkpoint
     configuration per zone governance requirements.

--- a/hitl-workflow-governance/scripts/private/Connect-EnvironmentDataverse.ps1
+++ b/hitl-workflow-governance/scripts/private/Connect-EnvironmentDataverse.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Per-environment Dataverse authentication helper.
 

--- a/hitl-workflow-governance/scripts/private/Get-ExpectedHitlPolicy.ps1
+++ b/hitl-workflow-governance/scripts/private/Get-ExpectedHitlPolicy.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Retrieves expected HITL checkpoint policy and severity for a zone.
 

--- a/hitl-workflow-governance/scripts/private/HWGClient.psm1
+++ b/hitl-workflow-governance/scripts/private/HWGClient.psm1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     HITL Workflow Governance Dataverse client module.
 

--- a/inactivity-timeout-enforcement/scripts/governance/Export-TimeoutComplianceEvidence.ps1
+++ b/inactivity-timeout-enforcement/scripts/governance/Export-TimeoutComplianceEvidence.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules @{ ModuleName='Az.Accounts'; ModuleVersion='2.17.0' }
 
 <#

--- a/inactivity-timeout-enforcement/scripts/governance/Test-EvidenceIntegrity.ps1
+++ b/inactivity-timeout-enforcement/scripts/governance/Test-EvidenceIntegrity.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/inactivity-timeout-enforcement/scripts/governance/Test-TimeoutCompliance.ps1
+++ b/inactivity-timeout-enforcement/scripts/governance/Test-TimeoutCompliance.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/message-center-monitor/lab/04_New-AppUser.ps1
+++ b/message-center-monitor/lab/04_New-AppUser.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 <#
 .SYNOPSIS
     Creates Dataverse Application User for the lab service principal and assigns a security role.

--- a/message-center-monitor/lab/06_Invoke-LabSmokeTest.ps1
+++ b/message-center-monitor/lab/06_Invoke-LabSmokeTest.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 <#
 .SYNOPSIS
     End-to-end smoke test orchestrator for message-center-monitor lab dry-run.

--- a/message-center-monitor/lab/Resume-LabState.ps1
+++ b/message-center-monitor/lab/Resume-LabState.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 <#
 .SYNOPSIS
     Rebuilds lab-state.json by detecting cloud resources that the lab scripts

--- a/message-center-monitor/scripts/governance/Export-MessageCenterEvidence.ps1
+++ b/message-center-monitor/scripts/governance/Export-MessageCenterEvidence.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules MSAL.PS
 
 <#

--- a/message-center-monitor/scripts/governance/Get-MessageCenterAssessmentStatus.ps1
+++ b/message-center-monitor/scripts/governance/Get-MessageCenterAssessmentStatus.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules MSAL.PS
 
 <#

--- a/message-center-monitor/scripts/governance/Invoke-MessageCenterSync.ps1
+++ b/message-center-monitor/scripts/governance/Invoke-MessageCenterSync.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules MSAL.PS
 
 <#

--- a/message-center-monitor/scripts/governance/Test-EvidenceIntegrity.ps1
+++ b/message-center-monitor/scripts/governance/Test-EvidenceIntegrity.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/message-center-monitor/scripts/governance/Test-McmPrerequisites.ps1
+++ b/message-center-monitor/scripts/governance/Test-McmPrerequisites.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules MSAL.PS, Az.KeyVault
 
 <#

--- a/message-center-monitor/scripts/governance/_Common.ps1
+++ b/message-center-monitor/scripts/governance/_Common.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Shared helpers for Message Center Monitor governance scripts.
 

--- a/message-center-monitor/tests/AssessmentStatus.Query.Tests.ps1
+++ b/message-center-monitor/tests/AssessmentStatus.Query.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 #Requires -Modules @{ ModuleName="Pester"; ModuleVersion="5.0.0" }
 
 <#

--- a/message-center-monitor/tests/EvidenceExport.Query.Tests.ps1
+++ b/message-center-monitor/tests/EvidenceExport.Query.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 #Requires -Modules @{ ModuleName="Pester"; ModuleVersion="5.0.0" }
 
 <#

--- a/model-risk-management-automation/scripts/Test-MRMCompliance.ps1
+++ b/model-risk-management-automation/scripts/Test-MRMCompliance.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Generates an examiner-facing MRM compliance posture report.
 

--- a/pipeline-governance-cleanup/scripts/Get-PipelineInventory.ps1
+++ b/pipeline-governance-cleanup/scripts/Get-PipelineInventory.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/pipeline-governance-cleanup/scripts/Send-OwnerNotifications.ps1
+++ b/pipeline-governance-cleanup/scripts/Send-OwnerNotifications.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules Microsoft.Graph.Authentication, Microsoft.Graph.Users.Actions
 
 <#

--- a/pipeline-governance-cleanup/scripts/Set-GovernanceConfig.ps1
+++ b/pipeline-governance-cleanup/scripts/Set-GovernanceConfig.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/rag-source-validator/scripts/Invoke-SourceValidation.ps1
+++ b/rag-source-validator/scripts/Invoke-SourceValidation.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Validates RAG knowledge source integrity.
 

--- a/rag-source-validator/scripts/governance/Export-ValidationEvidence.ps1
+++ b/rag-source-validator/scripts/governance/Export-ValidationEvidence.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/rag-source-validator/scripts/governance/Get-SourceValidationSummary.ps1
+++ b/rag-source-validator/scripts/governance/Get-SourceValidationSummary.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/rag-source-validator/scripts/governance/Test-EvidenceIntegrity.ps1
+++ b/rag-source-validator/scripts/governance/Test-EvidenceIntegrity.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/scripts/Invoke-CopilotStudioBenchmark.ps1
+++ b/scripts/Invoke-CopilotStudioBenchmark.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Runs 10 Copilot Studio governance benchmark checks and produces a unified report.
 

--- a/session-security-configurator/scripts/Deploy-StepUpPolicies.ps1
+++ b/session-security-configurator/scripts/Deploy-StepUpPolicies.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Deploys zone-specific step-up session security policies.
 

--- a/session-security-configurator/scripts/Export-SessionSecurityEvidence.ps1
+++ b/session-security-configurator/scripts/Export-SessionSecurityEvidence.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/session-security-configurator/scripts/Invoke-BaselineCapture.ps1
+++ b/session-security-configurator/scripts/Invoke-BaselineCapture.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.1
+﻿#Requires -Version 7.1
 #Requires -Modules Microsoft.Graph.Identity.SignIns, MSAL.PS
 
 <#

--- a/session-security-configurator/scripts/Start-SessionValidationRunbook.ps1
+++ b/session-security-configurator/scripts/Start-SessionValidationRunbook.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.1
+﻿#Requires -Version 7.1
 #Requires -Modules @{ ModuleName="Microsoft.Graph.Identity.SignIns"; ModuleVersion="2.0.0" }, @{ ModuleName="MSAL.PS"; ModuleVersion="4.37.0" }
 
 <#

--- a/session-security-configurator/scripts/Test-EvidenceIntegrity.ps1
+++ b/session-security-configurator/scripts/Test-EvidenceIntegrity.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 
 <#
 .SYNOPSIS

--- a/session-security-configurator/scripts/Test-SessionCompliance.ps1
+++ b/session-security-configurator/scripts/Test-SessionCompliance.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules Microsoft.Graph.Identity.SignIns
 
 <#

--- a/session-security-configurator/scripts/private/Compare-SessionBaseline.ps1
+++ b/session-security-configurator/scripts/private/Compare-SessionBaseline.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/session-security-configurator/scripts/private/Get-DataverseThreshold.ps1
+++ b/session-security-configurator/scripts/private/Get-DataverseThreshold.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/session-security-configurator/scripts/private/Get-SSCValidationResults.ps1
+++ b/session-security-configurator/scripts/private/Get-SSCValidationResults.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/session-security-configurator/scripts/private/Test-BreakGlassExclusion.ps1
+++ b/session-security-configurator/scripts/private/Test-BreakGlassExclusion.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/unrestricted-agent-sharing-detector/scripts/Restore-AgentSharingFromEvidence.ps1
+++ b/unrestricted-agent-sharing-detector/scripts/Restore-AgentSharingFromEvidence.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 
 <#
 .SYNOPSIS

--- a/unrestricted-agent-sharing-detector/scripts/governance/Deploy-DetectionFlow.ps1
+++ b/unrestricted-agent-sharing-detector/scripts/governance/Deploy-DetectionFlow.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules Az.Accounts
 
 <#

--- a/unrestricted-agent-sharing-detector/scripts/governance/Deploy-ExceptionApprovalFlow.ps1
+++ b/unrestricted-agent-sharing-detector/scripts/governance/Deploy-ExceptionApprovalFlow.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules Az.Accounts
 
 <#

--- a/unrestricted-agent-sharing-detector/scripts/governance/Deploy-ExpirationMonitorFlow.ps1
+++ b/unrestricted-agent-sharing-detector/scripts/governance/Deploy-ExpirationMonitorFlow.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules Az.Accounts
 
 <#

--- a/unrestricted-agent-sharing-detector/scripts/governance/Deploy-RemediationFlow.ps1
+++ b/unrestricted-agent-sharing-detector/scripts/governance/Deploy-RemediationFlow.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules Az.Accounts
 
 <#

--- a/unrestricted-agent-sharing-detector/scripts/governance/Get-ExpectedSharingPolicy.ps1
+++ b/unrestricted-agent-sharing-detector/scripts/governance/Get-ExpectedSharingPolicy.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Retrieves expected agent sharing policy and violation severity for a governance zone.
 

--- a/unrestricted-agent-sharing-detector/scripts/governance/Import-ApprovedSecurityGroups.ps1
+++ b/unrestricted-agent-sharing-detector/scripts/governance/Import-ApprovedSecurityGroups.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+﻿#Requires -Version 7.0
 #Requires -Modules Az.Accounts
 
 <#

--- a/unrestricted-agent-sharing-detector/scripts/governance/Test-AgentSharingCompliance.ps1
+++ b/unrestricted-agent-sharing-detector/scripts/governance/Test-AgentSharingCompliance.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Validates agent sharing configuration for all Copilot Studio agents against
     zone-specific governance requirements.


### PR DESCRIPTION
## Summary
- Re-encoded 155 PSSA-flagged PowerShell files from UTF-8 (no BOM) to UTF-8 with BOM for Wave 6 P2.
- Verified diff is BOM-only at line 1 across all changed files; no line-content drift.
- `PSUseBOMForUnicodeEncodedFile` hits: 155 -> 0; total PSSA baseline: 410 -> 255.

## Validation
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -ErrorAction SilentlyContinue`
- BOM-only diff verification over all `git diff --name-only` files

Reference: plan.md "Wave 6 — Tech-debt close-out / Phase 2".