### PR TITLE
chore(powershell): clear PSSA long-tail (14 hits across 7 rules) (Wave 6 P4f)

### DIFF
--- a/agent-communication-restriction-detector/CHANGELOG.md
+++ b/agent-communication-restriction-detector/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Agent Communication Restriction Detector are documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- `Get-CrossTenantAccessCorrelation.ps1` and `Test-ChildAgentPayloadSize.ps1` now honor `-WhatIf` by returning before Graph or Dataverse scan work when `ShouldProcess` declines the operation.
+
 ## [1.2.1] - 2026-05-23
 
 ### Fixed

--- a/agent-communication-restriction-detector/scripts/Get-CrossTenantAccessCorrelation.ps1
+++ b/agent-communication-restriction-detector/scripts/Get-CrossTenantAccessCorrelation.ps1
@@ -71,6 +71,10 @@ function Get-CrossTenantAccessCorrelation {
     }
 
     process {
+        if (-not $PSCmdlet.ShouldProcess($DataverseUrl, 'Read and correlate cross-tenant access findings')) {
+            return
+        }
+
         # ---------------------------------------------------------------
         # Step 1: Retrieve default cross-tenant access policy
         # ---------------------------------------------------------------

--- a/agent-communication-restriction-detector/scripts/Test-ChildAgentPayloadSize.ps1
+++ b/agent-communication-restriction-detector/scripts/Test-ChildAgentPayloadSize.ps1
@@ -90,6 +90,10 @@ function Test-ChildAgentPayloadSize {
     }
 
     process {
+        if (-not $PSCmdlet.ShouldProcess('Power Platform environments', 'Scan child-agent payload sizes')) {
+            return
+        }
+
         # ---------------------------------------------------------------
         # Step 1: Enumerate environments
         # ---------------------------------------------------------------

--- a/agent-intake/scripts/provision_solution_shell.ps1
+++ b/agent-intake/scripts/provision_solution_shell.ps1
@@ -656,7 +656,7 @@ function Get-ExistingEnvironmentVariableValue {
     return $null
 }
 
-function Upsert-EnvironmentVariable {
+function Sync-EnvironmentVariable {
     param(
         [Parameter(Mandatory = $true)][hashtable]$Definition,
         [Parameter(Mandatory = $true)][string]$Token
@@ -777,7 +777,7 @@ function Get-ExistingConnectionReference {
     return $null
 }
 
-function Upsert-ConnectionReference {
+function Sync-ConnectionReference {
     param(
         [Parameter(Mandatory = $true)][hashtable]$Definition,
         [Parameter(Mandatory = $true)][string]$Token
@@ -912,15 +912,15 @@ foreach ($optionSetName in $optionSetNames) {
 
 if (-not [string]::IsNullOrWhiteSpace($resolvedToken)) {
     foreach ($definition in $envVarDefinitions) {
-        Upsert-EnvironmentVariable -Definition $definition -Token $resolvedToken
+        Sync-EnvironmentVariable -Definition $definition -Token $resolvedToken
     }
 
     foreach ($definition in $connectionReferenceDefinitions) {
-        Upsert-ConnectionReference -Definition $definition -Token $resolvedToken
+        Sync-ConnectionReference -Definition $definition -Token $resolvedToken
     }
 
     if (-not [string]::IsNullOrWhiteSpace($GraphCustomConnectorApiId)) {
-        Upsert-ConnectionReference -Definition @{
+        Sync-ConnectionReference -Definition @{
             LogicalName  = 'fsi_cr_graph_agentintake'
             DisplayName  = 'Microsoft Graph - Agent Intake'
             ConnectorApiId = $GraphCustomConnectorApiId

--- a/agent-sharing-access-restriction-detector/CHANGELOG.md
+++ b/agent-sharing-access-restriction-detector/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Agent Sharing Access Restriction Detector are documen
 
 ## [Unreleased]
 
+### Changed
+
+- `Invoke-SharingComplianceScan.ps1 -ExcludeSandbox` now uses standard switch semantics (default `$false`); callers that want to omit sandbox environments should pass `-ExcludeSandbox`.
+
 ## [2.0.2] — 2026-05-23
 
 ### Fixed

--- a/agent-sharing-access-restriction-detector/scripts/governance/Invoke-SharingComplianceScan.ps1
+++ b/agent-sharing-access-restriction-detector/scripts/governance/Invoke-SharingComplianceScan.ps1
@@ -42,7 +42,7 @@
     When omitted, all accessible environments are scanned.
 
 .PARAMETER ExcludeSandbox
-    Exclude sandbox environments from scan. Default: $true.
+    Exclude sandbox environments from scan. Default: $false.
 
 .PARAMETER ExcludeTrial
     Exclude trial environments from scan. Default: $false.
@@ -106,7 +106,7 @@ function Invoke-SharingComplianceScan {
         [string[]]$EnvironmentFilter,
 
         [Parameter()]
-        [switch]$ExcludeSandbox = $true,
+        [switch]$ExcludeSandbox,
 
         [Parameter()]
         [switch]$ExcludeTrial,

--- a/audit-compliance-manager/CHANGELOG.md
+++ b/audit-compliance-manager/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `Compare-ValidationBaseline.ps1` now uses `$null -eq` baseline detection so array-shaped Dataverse responses are handled consistently.
+
 ## [1.0.5] - 2026-05-23
 
 ### Changed

--- a/audit-compliance-manager/scripts/private/Compare-ValidationBaseline.ps1
+++ b/audit-compliance-manager/scripts/private/Compare-ValidationBaseline.ps1
@@ -212,7 +212,7 @@ function Compare-ValidationBaseline {
 
         # Parse baseline result
         $baseline = $response.value | Select-Object -First 1
-        $isFirstRun = $baseline -eq $null
+        $isFirstRun = $null -eq $baseline
 
         if ($isFirstRun) {
             # No baseline exists - this is first run

--- a/conditional-access-automation/CHANGELOG.md
+++ b/conditional-access-automation/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Conditional Access Automation solution are documented
 
 ## [Unreleased]
 
+### Fixed
+
+- `Test-EvidenceIntegrity.ps1` now processes `ValueFromPipeline` evidence paths inside a `process {}` block so piped file lists are evaluated one item at a time.
+
 ## [2.0.2] - 2026-05-23
 
 ### Fixed

--- a/conditional-access-automation/scripts/Test-EvidenceIntegrity.ps1
+++ b/conditional-access-automation/scripts/Test-EvidenceIntegrity.ps1
@@ -62,71 +62,75 @@ param(
     [string]$EvidencePath
 )
 
-Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
+begin {
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
 
-# `exit` statements are correct for standalone CLI / CI usage but terminate
-# the host runspace when the script is dot-sourced or imported. Detect
-# dot-sourcing once up-front and route control via a small helper so callers
-# in module/automation contexts don't lose state.
-$invokedDotSourced = $MyInvocation.InvocationName -eq '.'
-function _LeaveScript([int]$Code) {
-    if ($script:invokedDotSourced) { return $Code } else { exit $Code }
+    # `exit` statements are correct for standalone CLI / CI usage but terminate
+    # the host runspace when the script is dot-sourced or imported. Detect
+    # dot-sourcing once up-front and route control via a small helper so callers
+    # in module/automation contexts don't lose state.
+    $invokedDotSourced = $MyInvocation.InvocationName -eq '.'
+    function _LeaveScript([int]$Code) {
+        if ($script:invokedDotSourced) { return $Code } else { exit $Code }
+    }
 }
 
-# Resolve full path
-$resolvedPath = Resolve-Path -Path $EvidencePath -ErrorAction Stop | Select-Object -ExpandProperty Path
+process {
+    # Resolve full path
+    $resolvedPath = Resolve-Path -Path $EvidencePath -ErrorAction Stop | Select-Object -ExpandProperty Path
 
-# Verify evidence file exists
-if (-not (Test-Path $resolvedPath -PathType Leaf)) {
-    Write-Error "Evidence file not found: $resolvedPath"
-    return (_LeaveScript 1)
-}
+    # Verify evidence file exists
+    if (-not (Test-Path $resolvedPath -PathType Leaf)) {
+        Write-Error "Evidence file not found: $resolvedPath"
+        return (_LeaveScript 1)
+    }
 
-# Locate companion hash file
-$hashFilePath = "$resolvedPath.sha256"
-if (-not (Test-Path $hashFilePath -PathType Leaf)) {
-    Write-Error "Companion SHA-256 hash file not found: $hashFilePath"
-    return (_LeaveScript 1)
-}
+    # Locate companion hash file
+    $hashFilePath = "$resolvedPath.sha256"
+    if (-not (Test-Path $hashFilePath -PathType Leaf)) {
+        Write-Error "Companion SHA-256 hash file not found: $hashFilePath"
+        return (_LeaveScript 1)
+    }
 
-# Read expected hash from companion file
-# Format: "{hash}  {filename}" (sha256sum-compatible, two-space separator)
-$hashContent = (Get-Content -Path $hashFilePath -Raw).Trim()
-$expectedHash = ($hashContent -split '\s{2}')[0].Trim().ToUpperInvariant()
+    # Read expected hash from companion file
+    # Format: "{hash}  {filename}" (sha256sum-compatible, two-space separator)
+    $hashContent = (Get-Content -Path $hashFilePath -Raw).Trim()
+    $expectedHash = ($hashContent -split '\s{2}')[0].Trim().ToUpperInvariant()
 
-if ([string]::IsNullOrWhiteSpace($expectedHash)) {
-    Write-Error "Could not parse hash from companion file: $hashFilePath"
-    return (_LeaveScript 1)
-}
+    if ([string]::IsNullOrWhiteSpace($expectedHash)) {
+        Write-Error "Could not parse hash from companion file: $hashFilePath"
+        return (_LeaveScript 1)
+    }
 
-# Compute actual hash
-$actualHash = (Get-FileHash -Path $resolvedPath -Algorithm SHA256).Hash.ToUpperInvariant()
+    # Compute actual hash
+    $actualHash = (Get-FileHash -Path $resolvedPath -Algorithm SHA256).Hash.ToUpperInvariant()
 
-# Compare (case-insensitive, both already uppercased)
-$isValid = $expectedHash -eq $actualHash
+    # Compare (case-insensitive, both already uppercased)
+    $isValid = $expectedHash -eq $actualHash
 
-# Build result
-$result = [PSCustomObject]@{
-    Path         = $resolvedPath
-    Valid        = $isValid
-    ExpectedHash = $expectedHash
-    ActualHash   = $actualHash
-}
+    # Build result
+    $result = [PSCustomObject]@{
+        Path         = $resolvedPath
+        Valid        = $isValid
+        ExpectedHash = $expectedHash
+        ActualHash   = $actualHash
+    }
 
-# Output result
-if ($isValid) {
-    Write-Host "PASS: Evidence integrity verified — $resolvedPath" -ForegroundColor Green
-}
-else {
-    Write-Warning "FAIL: Evidence integrity mismatch — $resolvedPath"
-    Write-Warning "  Expected: $expectedHash"
-    Write-Warning "  Actual:   $actualHash"
-}
+    # Output result
+    if ($isValid) {
+        Write-Host "PASS: Evidence integrity verified — $resolvedPath" -ForegroundColor Green
+    }
+    else {
+        Write-Warning "FAIL: Evidence integrity mismatch — $resolvedPath"
+        Write-Warning "  Expected: $expectedHash"
+        Write-Warning "  Actual:   $actualHash"
+    }
 
-$result
+    $result
 
-# Set exit code
-if (-not $isValid) {
-    return (_LeaveScript 1)
+    # Set exit code
+    if (-not $isValid) {
+        return (_LeaveScript 1)
+    }
 }

--- a/message-center-monitor/CHANGELOG.md
+++ b/message-center-monitor/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- `lab/07_Invoke-PocSmokeTest.ps1` listener job now passes capture-listener values with `$using:` scope so the background runspace receives the expected URL and capture file path.
 - `fsi_assessedby` column read as Lookup at 4 code sites (and described as Lookup in 2 comments) across `scripts/governance/Export-MessageCenterEvidence.ps1` and `scripts/governance/Get-MessageCenterAssessmentStatus.ps1`. The schema defines `fsi_AssessedBy` as a String column (`StringAttributeMetadata`, MaxLength 200); the `_fsi_assessedby_value` OData syntax that v2.4.0 introduced returns 400 Bad Request because that syntax is Lookup-only. Reverts the mistaken Lookup treatment introduced in v2.4.0 (see the correction note appended to the v2.4.0 entry below).
 - `scripts/governance/Export-MessageCenterEvidence.ps1` output object previously exposed two fields (`assessedBy` mapped to the `_<col>_value@OData.Community.Display.V1.FormattedValue` annotation and `assessedById` mapped to `_<col>_value`) that were both modeled on Lookup semantics. Collapsed to a single `assessedBy` String field and removed the dead `_fsi_assessedby_value@OData.Community.Display.V1.FormattedValue` annotation block (the annotation never appears on a String column).
 

--- a/message-center-monitor/lab/07_Invoke-PocSmokeTest.ps1
+++ b/message-center-monitor/lab/07_Invoke-PocSmokeTest.ps1
@@ -208,9 +208,10 @@ Write-LabLog -Level Info -Message "[Step 3/10] Starting local HTTP listener at $
 if (Test-Path -LiteralPath $captureFile) { Remove-Item -LiteralPath $captureFile -Force }
 try {
     $listenerJob = Start-Job -Name 'mcm-poc-smoke-listener' -ScriptBlock {
-        param($Url, $LogFile)
+        $jobListenerUrl = $using:listenerUrl
+        $jobLogFile = $using:captureFile
         $listener = [System.Net.HttpListener]::new()
-        $listener.Prefixes.Add($Url)
+        $listener.Prefixes.Add($jobListenerUrl)
         try {
             $listener.Start()
         } catch {
@@ -219,7 +220,7 @@ try {
             ([pscustomobject]@{
                 timestamp = (Get-Date).ToString('o')
                 listener_error = $_.Exception.Message
-            } | ConvertTo-Json -Compress) | Out-File -FilePath $LogFile -Append -Encoding utf8
+            } | ConvertTo-Json -Compress) | Out-File -FilePath $jobLogFile -Append -Encoding utf8
             return
         }
         while ($listener.IsListening) {
@@ -234,7 +235,7 @@ try {
                     path          = $context.Request.Url.AbsolutePath
                     contentLength = $context.Request.ContentLength64
                     body          = $body
-                } | ConvertTo-Json -Compress -Depth 5) | Out-File -FilePath $LogFile -Append -Encoding utf8
+                } | ConvertTo-Json -Compress -Depth 5) | Out-File -FilePath $jobLogFile -Append -Encoding utf8
                 $context.Response.StatusCode = 202
                 $context.Response.OutputStream.Close()
             } catch {
@@ -242,7 +243,7 @@ try {
             }
         }
         try { $listener.Stop(); $listener.Close() } catch {}
-    } -ArgumentList $listenerUrl, $captureFile
+    }
 
     # Give the listener a beat to bind
     Start-Sleep -Seconds 2

--- a/message-center-monitor/lab/99_Remove-LabDeployment.ps1
+++ b/message-center-monitor/lab/99_Remove-LabDeployment.ps1
@@ -63,7 +63,7 @@ if (Test-Path -LiteralPath $statePath) {
     }
 }
 
-function Try-Action([scriptblock]$action, [string]$desc) {
+function Invoke-LabTeardownAction([scriptblock]$action, [string]$desc) {
     if ($DryRun) {
         Write-LabLog -Level Info -Message "[DRY-RUN] $desc"
         return
@@ -110,18 +110,18 @@ if ($state.dataverse -or $ForceExternalResource) {
             foreach ($name in $envVarNames) {
                 $defs = Invoke-RestMethod -Uri "$api/environmentvariabledefinitions?`$filter=schemaname eq '$name'&`$select=environmentvariabledefinitionid" -Headers $hdr -Method Get -ErrorAction SilentlyContinue
                 foreach ($d in $defs.value) {
-                    Try-Action { Invoke-RestMethod -Uri "$api/environmentvariabledefinitions($($d.environmentvariabledefinitionid))" -Headers $hdr -Method Delete -ErrorAction Stop | Out-Null } "Delete env var def $name"
+                    Invoke-LabTeardownAction { Invoke-RestMethod -Uri "$api/environmentvariabledefinitions($($d.environmentvariabledefinitionid))" -Headers $hdr -Method Delete -ErrorAction Stop | Out-Null } "Delete env var def $name"
                 }
             }
 
             # Disable application user (cannot delete in Dataverse).
             if ($state.dataverse.applicationUserId) {
                 $userId = $state.dataverse.applicationUserId
-                Try-Action { Invoke-RestMethod -Uri "$api/systemusers($userId)" -Headers $hdr -Method Patch -Body (@{ isdisabled = $true } | ConvertTo-Json) -ErrorAction Stop | Out-Null } "Disable Dataverse application user $userId"
+                Invoke-LabTeardownAction { Invoke-RestMethod -Uri "$api/systemusers($userId)" -Headers $hdr -Method Patch -Body (@{ isdisabled = $true } | ConvertTo-Json) -ErrorAction Stop | Out-Null } "Disable Dataverse application user $userId"
             }
 
             # Drop the table.
-            Try-Action {
+            Invoke-LabTeardownAction {
                 $meta = Invoke-RestMethod -Uri "$api/EntityDefinitions(LogicalName='fsi_messagecenterlog')?`$select=MetadataId" -Headers $hdr -Method Get -ErrorAction Stop
                 Invoke-RestMethod -Uri "$api/EntityDefinitions($($meta.MetadataId))" -Headers $hdr -Method Delete -ErrorAction Stop | Out-Null
             } "Delete fsi_messagecenterlog table"
@@ -149,17 +149,17 @@ if ($state.appRegistration -or $ForceExternalResource) {
             # Remove appRoleAssignments + oauth2PermissionGrants tied to this SP.
             $assigns = Get-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $spObjId -ErrorAction SilentlyContinue
             foreach ($a in $assigns) {
-                Try-Action { Remove-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $spObjId -AppRoleAssignmentId $a.Id -ErrorAction Stop } "Remove appRoleAssignment $($a.Id)"
+                Invoke-LabTeardownAction { Remove-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $spObjId -AppRoleAssignmentId $a.Id -ErrorAction Stop } "Remove appRoleAssignment $($a.Id)"
             }
             $grants = Get-MgOauth2PermissionGrant -Filter "clientId eq '$spObjId'" -ErrorAction SilentlyContinue
             foreach ($g in $grants) {
-                Try-Action { Remove-MgOauth2PermissionGrant -OAuth2PermissionGrantId $g.Id -ErrorAction Stop } "Remove oauth2PermissionGrant $($g.Id)"
+                Invoke-LabTeardownAction { Remove-MgOauth2PermissionGrant -OAuth2PermissionGrantId $g.Id -ErrorAction Stop } "Remove oauth2PermissionGrant $($g.Id)"
             }
-            Try-Action { Remove-MgServicePrincipal -ServicePrincipalId $spObjId -ErrorAction Stop } "Remove service principal $spObjId"
+            Invoke-LabTeardownAction { Remove-MgServicePrincipal -ServicePrincipalId $spObjId -ErrorAction Stop } "Remove service principal $spObjId"
         }
 
         if ($appObjId) {
-            Try-Action { Remove-MgApplication -ApplicationId $appObjId -ErrorAction Stop } "Remove app registration $appObjId"
+            Invoke-LabTeardownAction { Remove-MgApplication -ApplicationId $appObjId -ErrorAction Stop } "Remove app registration $appObjId"
         }
     } finally {
         try { Disconnect-MgGraph -ErrorAction SilentlyContinue | Out-Null } catch {}
@@ -173,8 +173,8 @@ if (-not $KeepKeyVault -and ($state.keyVault -or $ForceExternalResource)) {
     if ($kvName) {
         try {
             Set-AzContext -SubscriptionId ($state.subscriptionId ?? $cfg.azure.subscriptionId) -ErrorAction Stop | Out-Null
-            Try-Action { Remove-AzKeyVault -VaultName $kvName -Force -ErrorAction Stop } "Soft-delete Key Vault $kvName"
-            Try-Action { Remove-AzKeyVault -VaultName $kvName -InRemovedState -Location ($state.azure.region ?? $cfg.azure.region) -Force -ErrorAction Stop } "Purge soft-deleted Key Vault $kvName"
+            Invoke-LabTeardownAction { Remove-AzKeyVault -VaultName $kvName -Force -ErrorAction Stop } "Soft-delete Key Vault $kvName"
+            Invoke-LabTeardownAction { Remove-AzKeyVault -VaultName $kvName -InRemovedState -Location ($state.azure.region ?? $cfg.azure.region) -Force -ErrorAction Stop } "Purge soft-deleted Key Vault $kvName"
         } catch {
             Write-LabLog -Level Warn -Message "Key Vault cleanup partial: $($_.Exception.Message)"
         }
@@ -196,7 +196,7 @@ if ($RemoveEnvironment) {
         Write-LabLog -Level Warn -Message "No powerPlatform.environmentId in lab-config.json. Nothing to delete."
     } else {
         Write-LabLog -Level Info -Message "Deleting Power Platform env $envIdToDelete..."
-        Try-Action {
+        Invoke-LabTeardownAction {
             $bapTok = az account get-access-token --resource 'https://api.bap.microsoft.com' --query accessToken -o tsv 2>$null
             if (-not $bapTok) { throw "az CLI not authenticated. Run: az login --tenant $($cfg.tenant.tenantId)" }
             $hdr = @{ Authorization = "Bearer $bapTok"; 'Content-Type' = 'application/json' }

--- a/pipeline-governance-cleanup/CHANGELOG.md
+++ b/pipeline-governance-cleanup/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `Send-OwnerNotifications.ps1` nested `Main` function now declares `SupportsShouldProcess`, preserving `-WhatIf` handling for live email sends.
+
 ## [1.2.1] - 2026-05-17
 
 ### Changed

--- a/pipeline-governance-cleanup/scripts/Send-OwnerNotifications.ps1
+++ b/pipeline-governance-cleanup/scripts/Send-OwnerNotifications.ps1
@@ -264,6 +264,9 @@ function Send-GraphEmail {
 
 # Main execution
 function Main {
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
+
     Write-Host "================================================" -ForegroundColor Cyan
     Write-Host "  Pipeline Governance Notification Script" -ForegroundColor Cyan
     Write-Host "  Version: 1.1.0 - April 2026" -ForegroundColor Cyan

--- a/rag-source-validator/scripts/Invoke-SourceValidation.ps1
+++ b/rag-source-validator/scripts/Invoke-SourceValidation.ps1
@@ -100,7 +100,7 @@ param(
 $ErrorActionPreference = "Stop"
 
 # File-based logging helper for scheduled/automated execution
-function Write-Log {
+function Write-ValidationLog {
     param([string]$Message, [string]$Level = "INFO")
     $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
     $entry = "$timestamp [$Level] $Message"
@@ -112,7 +112,7 @@ function Write-Log {
         try {
             $entry | Out-File -FilePath $LogFile -Append -Encoding utf8
         } catch {
-            Write-Warning "Write-Log: Failed to write to log file '$LogFile': $($_.Exception.Message)"
+            Write-Warning "Write-ValidationLog: Failed to write to log file '$LogFile': $($_.Exception.Message)"
         }
     }
 }
@@ -436,10 +436,10 @@ Write-Host "========================================" -ForegroundColor Cyan
 Write-Host "  RAG Source Validator" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
-Write-Log "RAG Source Validator started. Environment: $Environment"
+Write-ValidationLog "RAG Source Validator started. Environment: $Environment"
 
 if ($script:authMode -eq "ClientSecret" -and (-not $TenantId -or -not $ClientId -or -not $clientSecretPlain)) {
-    Write-Log "FATAL: Missing credentials for legacy client-secret fallback. Use -UseManagedIdentity in production Azure hosts, or set AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_CLIENT_SECRET for development." -Level "ERROR"
+    Write-ValidationLog "FATAL: Missing credentials for legacy client-secret fallback. Use -UseManagedIdentity in production Azure hosts, or set AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_CLIENT_SECRET for development." -Level "ERROR"
     Write-Error "Missing credentials for legacy client-secret fallback. Use -UseManagedIdentity in production Azure hosts, or set AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_CLIENT_SECRET for development."
 }
 
@@ -455,7 +455,7 @@ try {
     $graphTokenInfo = Get-TokenInfo -Resource $graphResource
     $dataverseTokenInfo = Get-TokenInfo -Resource $dataverseResource
 } catch {
-    Write-Log "FATAL: Authentication failed: $($_.Exception.Message)" -Level "ERROR"
+    Write-ValidationLog "FATAL: Authentication failed: $($_.Exception.Message)" -Level "ERROR"
     throw
 }
 $script:tokenCache[$graphResource] = $graphTokenInfo
@@ -474,11 +474,11 @@ Write-Host "  Found $($sources.Count) sources to validate"
 if ($sources.Count -eq 0) {
     if ($SourceId) {
         Write-Warning "Source '$SourceId' not found or not in Active status. Sources transition to non-Active status (Validation Failed, Stale) after failures and must be manually reset to Active (1) before they are included in validation runs."
-        Write-Log "WARNING: No active source found for SourceId '$SourceId'. Source may have non-Active status from a prior validation failure." -Level "WARN"
+        Write-ValidationLog "WARNING: No active source found for SourceId '$SourceId'. Source may have non-Active status from a prior validation failure." -Level "WARN"
         exit 2
     } else {
         Write-Warning "No active sources found. Sources with non-Active status (Validation Failed=3, Stale=4) are excluded from validation. Reset source status to Active (1) in the Dataverse model-driven app to re-include them."
-        Write-Log "WARNING: No active sources found. Check for sources with non-Active status that may need to be reset." -Level "WARN"
+        Write-ValidationLog "WARNING: No active sources found. Check for sources with non-Active status that may need to be reset." -Level "WARN"
         exit 2
     }
 }
@@ -517,7 +517,7 @@ foreach ($source in $sources) {
                 $result.fsi_currenthash = $null
                 $result.fsi_hashchanged = $false
                 Write-Host "  SKIPPED - Dataverse validation not yet implemented" -ForegroundColor Yellow
-                Write-Log "SKIPPED: $($source.fsi_sourcename) - Dataverse validation not yet implemented" -Level "WARN"
+                Write-ValidationLog "SKIPPED: $($source.fsi_sourcename) - Dataverse validation not yet implemented" -Level "WARN"
                 $skipped++
                 # Skip hash comparison for unsupported types
                 $content = $null
@@ -528,7 +528,7 @@ foreach ($source in $sources) {
                 $result.fsi_currenthash = $null
                 $result.fsi_hashchanged = $false
                 Write-Host "  SKIPPED - Source type $_ validation not yet implemented" -ForegroundColor Yellow
-                Write-Log "SKIPPED: $($source.fsi_sourcename) - source type $_ validation not yet implemented" -Level "WARN"
+                Write-ValidationLog "SKIPPED: $($source.fsi_sourcename) - source type $_ validation not yet implemented" -Level "WARN"
                 $skipped++
                 $content = $null
             }
@@ -538,7 +538,7 @@ foreach ($source in $sources) {
                 $result.fsi_currenthash = $null
                 $result.fsi_hashchanged = $false
                 Write-Host "  SKIPPED - Unsupported source type" -ForegroundColor Yellow
-                Write-Log "SKIPPED: $($source.fsi_sourcename) - unsupported source type $($source.fsi_sourcetype)" -Level "WARN"
+                Write-ValidationLog "SKIPPED: $($source.fsi_sourcename) - unsupported source type $($source.fsi_sourcetype)" -Level "WARN"
                 $skipped++
                 $content = $null
             }
@@ -555,14 +555,14 @@ foreach ($source in $sources) {
                     $result.fsi_result = 1  # Passed
                     $result.fsi_hashchanged = $false
                     Write-Host "  PASSED - Hash matches baseline" -ForegroundColor Green
-                    Write-Log "PASSED: $($source.fsi_sourcename) - hash matches baseline"
+                    Write-ValidationLog "PASSED: $($source.fsi_sourcename) - hash matches baseline"
                     $passed++
                 } else {
                     $result.fsi_result = 2  # Failed - Hash Mismatch
                     $result.fsi_hashchanged = $true
                     $result.fsi_changedetails = "Current hash '$currentHash' does not match baseline '$($source.fsi_baselinehash)'"
                     Write-Host "  CHANGED - Hash mismatch detected" -ForegroundColor Yellow
-                    Write-Log "CHANGED: $($source.fsi_sourcename) - hash mismatch" -Level "WARN"
+                    Write-ValidationLog "CHANGED: $($source.fsi_sourcename) - hash mismatch" -Level "WARN"
                     $changed++
 
                     # Record change in the fsi_sourcechange audit trail (skip if hash unchanged since last validation)
@@ -574,7 +574,7 @@ foreach ($source in $sources) {
                                 -ChangedBy "RAG Source Validator"
                         } catch {
                             Write-Warning "Failed to record source change for '$($source.fsi_sourcename)': $($_.Exception.Message)"
-                            Write-Log "AUDIT GAP: Source change record not created for '$($source.fsi_sourcename)'. Error: $($_.Exception.Message)" -Level "ERROR"
+                            Write-ValidationLog "AUDIT GAP: Source change record not created for '$($source.fsi_sourcename)'. Error: $($_.Exception.Message)" -Level "ERROR"
                         }
                     }
 
@@ -591,7 +591,7 @@ foreach ($source in $sources) {
                 $result.fsi_validationtype = 4  # Baseline Capture
                 $result.fsi_hashchanged = $false
                 Write-Host "  BASELINE CAPTURED (trust-on-first-use)" -ForegroundColor Cyan
-                Write-Log "BASELINE CAPTURED: $($source.fsi_sourcename) - trust-on-first-use, current hash set as baseline" -Level "WARN"
+                Write-ValidationLog "BASELINE CAPTURED: $($source.fsi_sourcename) - trust-on-first-use, current hash set as baseline" -Level "WARN"
                 $passed++
             }
 
@@ -602,7 +602,7 @@ foreach ($source in $sources) {
                 $daysSinceModified = ((Get-Date).ToUniversalTime() - ([datetime]$source.fsi_lastmodified).ToUniversalTime()).TotalDays
                 if ($daysSinceModified -gt $source.fsi_freshnessthreshold) {
                     Write-Host "  STALE - Last modified $([math]::Round($daysSinceModified)) days ago (threshold: $($source.fsi_freshnessthreshold) days)" -ForegroundColor Yellow
-                    Write-Log "STALE: $($source.fsi_sourcename) - last modified $([math]::Round($daysSinceModified)) days ago (threshold: $($source.fsi_freshnessthreshold) days)" -Level "WARN"
+                    Write-ValidationLog "STALE: $($source.fsi_sourcename) - last modified $([math]::Round($daysSinceModified)) days ago (threshold: $($source.fsi_freshnessthreshold) days)" -Level "WARN"
                     if ($result.fsi_result -eq 2) {
                         # Preserve hash-mismatch result -- integrity violations must not be
                         # reclassified as staleness (SEC Rule 17a-4, FINRA Rule 4511(a)).
@@ -628,7 +628,7 @@ foreach ($source in $sources) {
                 $sourceUpdated = $true
             } catch {
                 Write-Warning "Failed to update source hash for '$($source.fsi_sourcename)': $($_.Exception.Message)"
-                Write-Log "AUDIT GAP: Source hash update failed for '$($source.fsi_sourcename)' (hash=$currentHash). Error: $($_.Exception.Message)" -Level "ERROR"
+                Write-ValidationLog "AUDIT GAP: Source hash update failed for '$($source.fsi_sourcename)' (hash=$currentHash). Error: $($_.Exception.Message)" -Level "ERROR"
             }
         }
 
@@ -638,7 +638,7 @@ foreach ($source in $sources) {
             $daysSinceModified = ((Get-Date).ToUniversalTime() - ([datetime]$source.fsi_lastmodified).ToUniversalTime()).TotalDays
             if ($daysSinceModified -gt $source.fsi_freshnessthreshold) {
                 Write-Host "  STALE - Last modified $([math]::Round($daysSinceModified)) days ago (threshold: $($source.fsi_freshnessthreshold) days)" -ForegroundColor Yellow
-                Write-Log "STALE: $($source.fsi_sourcename) - last modified $([math]::Round($daysSinceModified)) days ago (threshold: $($source.fsi_freshnessthreshold) days)" -Level "WARN"
+                Write-ValidationLog "STALE: $($source.fsi_sourcename) - last modified $([math]::Round($daysSinceModified)) days ago (threshold: $($source.fsi_freshnessthreshold) days)" -Level "WARN"
                 $result.fsi_result = 4  # Failed - Stale Content
                 $stale++
                 $skipped--
@@ -650,14 +650,14 @@ foreach ($source in $sources) {
         $result.fsi_hashchanged = $false
         $result.fsi_errordetails = $_.Exception.Message
         Write-Host "  FAILED - Source unavailable: $($_.Exception.Message)" -ForegroundColor Red
-        Write-Log "FAILED: $($source.fsi_sourcename) - source unavailable: $($_.Exception.Message)" -Level "ERROR"
+        Write-ValidationLog "FAILED: $($source.fsi_sourcename) - source unavailable: $($_.Exception.Message)" -Level "ERROR"
         $failed++
     } catch {
         $result.fsi_result = 6  # Failed - Unexpected Error (generic)
         $result.fsi_hashchanged = $false
         $result.fsi_errordetails = "Unexpected error ($($_.Exception.GetType().Name)): $($_.Exception.Message)"
         Write-Host "  FAILED - $($result.fsi_errordetails)" -ForegroundColor Red
-        Write-Log "FAILED: $($source.fsi_sourcename) - $($result.fsi_errordetails)" -Level "ERROR"
+        Write-ValidationLog "FAILED: $($source.fsi_sourcename) - $($result.fsi_errordetails)" -Level "ERROR"
         $failed++
     }
 
@@ -672,7 +672,7 @@ foreach ($source in $sources) {
                 Update-SourceStatus -Environment $Environment -Token (Get-ValidToken -Resource $dataverseResource) -SourceId $source.fsi_knowledgesourceid -Status $newStatus
             } catch {
                 Write-Warning "Failed to update source status for '$($source.fsi_sourcename)': $($_.Exception.Message)"
-                Write-Log "AUDIT GAP: Source status update failed for '$($source.fsi_sourcename)' (status=$newStatus). Error: $($_.Exception.Message)" -Level "ERROR"
+                Write-ValidationLog "AUDIT GAP: Source status update failed for '$($source.fsi_sourcename)' (status=$newStatus). Error: $($_.Exception.Message)" -Level "ERROR"
             }
         }
     }
@@ -682,7 +682,7 @@ foreach ($source in $sources) {
         New-ValidationResult -Environment $Environment -Token (Get-ValidToken -Resource $dataverseResource) -Result $result
     } catch {
         Write-Warning "Failed to record validation result for '$($source.fsi_sourcename)': $($_.Exception.Message)"
-        Write-Log "AUDIT GAP: Validation result record not created for '$($source.fsi_sourcename)' (result=$($result.fsi_result)). Status was updated but no fsi_validationresult exists. Error: $($_.Exception.Message)" -Level "ERROR"
+        Write-ValidationLog "AUDIT GAP: Validation result record not created for '$($source.fsi_sourcename)' (result=$($result.fsi_result)). Status was updated but no fsi_validationresult exists. Error: $($_.Exception.Message)" -Level "ERROR"
     }
 }
 
@@ -697,7 +697,7 @@ Write-Host "Changed: $changed"
 Write-Host "Stale:   $stale"
 Write-Host "Failed:  $failed"
 Write-Host "Skipped: $skipped"
-Write-Log "Validation complete. Passed=$passed Changed=$changed Stale=$stale Failed=$failed Skipped=$skipped"
+Write-ValidationLog "Validation complete. Passed=$passed Changed=$changed Stale=$stale Failed=$failed Skipped=$skipped"
 
 # Exit with non-zero code when any validation failures are detected.
 # Allows CI/CD pipelines and scheduled automation to distinguish

--- a/unrestricted-agent-sharing-detector/CHANGELOG.md
+++ b/unrestricted-agent-sharing-detector/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to the Unrestricted Agent Sharing Detector are documented he
 
 ## [Unreleased]
 
-- No unreleased changes.
+### Fixed
+
+- `Restore-AgentSharingFromEvidence.ps1` nested `Restore-AgentSharing` helper now declares `SupportsShouldProcess`, preserving `-WhatIf` handling for live sharing restore calls.
 
 ## [2.0.1] — 2026-05-04
 

--- a/unrestricted-agent-sharing-detector/scripts/Restore-AgentSharingFromEvidence.ps1
+++ b/unrestricted-agent-sharing-detector/scripts/Restore-AgentSharingFromEvidence.ps1
@@ -224,7 +224,7 @@ function Read-EvidenceFile {
 # ── Restore sharing via Dataverse Web API ─────────────────────────────────
 
 function Restore-AgentSharing {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]$AccessToken,
         [PSObject]$Agent


### PR DESCRIPTION
## Summary

Clears the Wave 6 Phase 4f PSScriptAnalyzer long tail: 14 findings across 7 rules, all fixed with no suppressions.

## Per-rule disposition

| Rule | Fixed | Suppressed | Notes |
| --- | ---: | ---: | --- |
| PSShouldProcess | 4 | 0 | Added missing ShouldProcess guards/support declarations for WhatIf-aware operations. |
| PSUseApprovedVerbs | 3 | 0 | Renamed internal helpers to approved verbs and updated callers. |
| PSUseProcessBlockForPipelineCommand | 2 | 0 | Added a process {} block for pipeline evidence-path handling. |
| PSUseUsingScopeModifierInNewRunspaces | 2 | 0 | Passed listener job values with $using: scope. |
| PSAvoidOverwritingBuiltInCmdlets | 1 | 0 | Renamed the script-local Write-Log helper. |
| PSAvoidDefaultValueSwitchParameter | 1 | 0 | Removed the default $true switch value and documented the changed default. |
| PSPossibleIncorrectComparisonWithNull | 1 | 0 | Swapped operands to $null -eq .... |

## CHANGELOG entries

Added entries for behavior-affecting fixes in ACRD, ASARD, Audit Compliance Manager, CAA, Message Center Monitor, Pipeline Governance Cleanup, and UASD.

## Validation

- Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -ErrorAction SilentlyContinue
- Targeted 7 rules: 0 findings
- Total findings: 396 (from 410, delta -14)