### PR TITLE
chore(powershell): suppress 27 ConvertTo-SecureString warnings in dev/lab/test code (Wave 6 P3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,6 +369,9 @@ All scripts that authenticate to Microsoft Graph, Power Platform, or Dataverse M
 
 `scripts/shared/dataverse_client.py` is the canonical example: it accepts an MSAL token from any source, so callers can pick the strongest auth method available in their environment without changing the client.
 
+**Suppressing `PSAvoidUsingConvertToSecureStringWithPlainText`:**
+When a code path legitimately requires `ConvertTo-SecureString ... -AsPlainText -Force` (dev-only legacy auth helpers, lab provisioning scripts, Pester test fixtures), suppress the warning at the function or script level with `[Diagnostics.CodeAnalysis.SuppressMessageAttribute(...)]` and include a `Justification` explaining why the dev-only path is acceptable. Production code paths must use managed identity — never accept a plaintext secret. Wave 6 P3 (PR #211) suppressed 27 such occurrences.
+
 ### PowerShell Scripts
 - Use `#Requires -Modules` for dependencies
 - Include `.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER`, `.EXAMPLE` in comment-based help

--- a/agent-sharing-access-restriction-detector/scripts/governance/Invoke-SharingComplianceScan.ps1
+++ b/agent-sharing-access-restriction-detector/scripts/governance/Invoke-SharingComplianceScan.ps1
@@ -91,6 +91,10 @@
 #Requires -Modules Microsoft.PowerApps.Administration.PowerShell
 
 function Invoke-SharingComplianceScan {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+        Justification = 'Dev-only legacy auth path. Production deployments use managed identity via scripts/shared/dataverse_client.py per AGENTS.md "Authentication standard". Plaintext secret here is wrapped immediately into SecureString and never persisted.'
+    )]
     [CmdletBinding()]
     param(
         [Parameter()]

--- a/audit-compliance-manager/scripts/Start-EnvironmentValidationRunbook.ps1
+++ b/audit-compliance-manager/scripts/Start-EnvironmentValidationRunbook.ps1
@@ -94,6 +94,10 @@
     Azure Automation Account and configure with certificate-based authentication.
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Dev-only legacy auth path. Production deployments use managed identity via scripts/shared/dataverse_client.py per AGENTS.md "Authentication standard". Plaintext secret here is wrapped immediately into SecureString and never persisted.'
+)]
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]

--- a/audit-compliance-manager/scripts/private/Connect-PowerPlatform.ps1
+++ b/audit-compliance-manager/scripts/private/Connect-PowerPlatform.ps1
@@ -71,6 +71,10 @@
     - AuthMethod (string): "Interactive", "ServicePrincipal-Secret", or "ServicePrincipal-Certificate"
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Dev-only legacy auth path. Production deployments use managed identity via scripts/shared/dataverse_client.py per AGENTS.md "Authentication standard". Plaintext secret here is wrapped immediately into SecureString and never persisted.'
+)]
 [CmdletBinding(DefaultParameterSetName = 'Interactive')]
 param(
     [Parameter(Mandatory = $true)]

--- a/conditional-access-automation/scripts/Register-ServicePrincipal.ps1
+++ b/conditional-access-automation/scripts/Register-ServicePrincipal.ps1
@@ -59,6 +59,10 @@
     auditable, least-privilege service identities for CA automation.
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Dev-only credential bootstrap path. Values are wrapped immediately for Set-AzKeyVaultSecret and persisted only in Key Vault; production automation should use managed identity or certificate auth per AGENTS.md "Authentication standard".'
+)]
 [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = 'Secret')]
 param(
     [Parameter(Mandatory = $true)]

--- a/credential-oversharing-detector/scripts/governance/Get-AgentConnectorScope.ps1
+++ b/credential-oversharing-detector/scripts/governance/Get-AgentConnectorScope.ps1
@@ -84,6 +84,10 @@
     Part of FSI Agent Governance Framework
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Dev-only legacy auth path. Production deployments use managed identity via scripts/shared/dataverse_client.py per AGENTS.md "Authentication standard". Plaintext secret here is wrapped immediately into SecureString and never persisted.'
+)]
 [CmdletBinding()]
 param(
     [Parameter()]

--- a/credential-oversharing-detector/scripts/governance/Invoke-CredentialScan.ps1
+++ b/credential-oversharing-detector/scripts/governance/Invoke-CredentialScan.ps1
@@ -102,6 +102,10 @@
     Part of FSI Agent Governance Framework
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Dev-only legacy auth path. Production deployments use managed identity via scripts/shared/dataverse_client.py per AGENTS.md "Authentication standard". Plaintext secret here is wrapped immediately into SecureString and never persisted.'
+)]
 [CmdletBinding()]
 param(
     [Parameter()]

--- a/dr-testing-framework/scripts/Export-DREvidence.ps1
+++ b/dr-testing-framework/scripts/Export-DREvidence.ps1
@@ -25,6 +25,10 @@
     .\Export-DREvidence.ps1 -Environment "https://contoso.crm.dynamics.com" -OutputDir "./evidence"
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Dev-only legacy auth path. Production deployments use managed identity via scripts/shared/dataverse_client.py per AGENTS.md "Authentication standard". Plaintext secret here is wrapped immediately into SecureString and never persisted.'
+)]
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]

--- a/dr-testing-framework/scripts/Invoke-DRTest.Tests.ps1
+++ b/dr-testing-framework/scripts/Invoke-DRTest.Tests.ps1
@@ -9,6 +9,12 @@
     error handling logic.
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Pester test fixture credential — never used against production. Required to exercise SecureString-accepting code paths.'
+)]
+param()
+
 BeforeAll {
     $scriptPath = Join-Path $PSScriptRoot 'Invoke-DRTest.ps1'
     $scriptContent = Get-Content -Path $scriptPath -Raw

--- a/dr-testing-framework/scripts/Invoke-DRTest.ps1
+++ b/dr-testing-framework/scripts/Invoke-DRTest.ps1
@@ -24,6 +24,10 @@
     .\Invoke-DRTest.ps1 -TestType "AgentReadinessCheck" -AgentId "00000000-0000-0000-0000-000000000000" -Environment "https://your-org.crm.dynamics.com" -TenantId $tid -ClientId $cid -ClientSecret $sec
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Dev-only legacy auth path. Production deployments use managed identity via scripts/shared/dataverse_client.py per AGENTS.md "Authentication standard". Plaintext secret here is wrapped immediately into SecureString and never persisted.'
+)]
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]

--- a/file-upload-security/scripts/Invoke-FileUploadBaselineCapture.ps1
+++ b/file-upload-security/scripts/Invoke-FileUploadBaselineCapture.ps1
@@ -64,6 +64,10 @@
     Control: 1.14 - Data Minimization and Agent Scope Control
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Dev-only legacy auth path. Production deployments use managed identity via scripts/shared/dataverse_client.py per AGENTS.md "Authentication standard". Plaintext secret here is wrapped immediately into SecureString and never persisted.'
+)]
 [CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter(Mandatory)]

--- a/hitl-workflow-governance/scripts/Export-HitlGovernanceEvidence.ps1
+++ b/hitl-workflow-governance/scripts/Export-HitlGovernanceEvidence.ps1
@@ -105,6 +105,10 @@
     - manifest.json
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Dev-only legacy auth path. Production deployments use managed identity via scripts/shared/dataverse_client.py per AGENTS.md "Authentication standard". Plaintext secret here is wrapped immediately into SecureString and never persisted.'
+)]
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]

--- a/message-center-monitor/lab/01_New-AppRegistration.ps1
+++ b/message-center-monitor/lab/01_New-AppRegistration.ps1
@@ -33,6 +33,10 @@
     Application Administrator (or Global Administrator) for admin consent.
     Solution: message-center-monitor v2.5.0+
 #>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Lab provisioning script run interactively by tenant admin. Operator pastes a temporary secret for one-time setup; not invoked in production.'
+)]
 [CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter()] [string] $ConfigPath,

--- a/message-center-monitor/lab/02_New-KeyVault.ps1
+++ b/message-center-monitor/lab/02_New-KeyVault.ps1
@@ -21,6 +21,10 @@
 .NOTES
     Lab dry-run step 2 of 7. Solution: message-center-monitor v2.5.0+
 #>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Lab provisioning script run interactively by tenant admin. Operator pastes a temporary secret for one-time setup; not invoked in production.'
+)]
 [CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter()] [string] $ConfigPath,

--- a/message-center-monitor/lab/03_Deploy-Schema.ps1
+++ b/message-center-monitor/lab/03_Deploy-Schema.ps1
@@ -30,6 +30,10 @@
 .NOTES
     Lab dry-run step 3 of 7. Solution: message-center-monitor v2.5.0+
 #>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Lab provisioning script run interactively by tenant admin. Operator pastes a temporary secret for one-time setup; not invoked in production.'
+)]
 [CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter()] [string] $ConfigPath,

--- a/message-center-monitor/lab/04_New-AppUser.ps1
+++ b/message-center-monitor/lab/04_New-AppUser.ps1
@@ -28,6 +28,10 @@
 .NOTES
     Lab dry-run step 4 of 7. Solution: message-center-monitor v2.5.0+
 #>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Lab provisioning script run interactively by tenant admin. Operator pastes a temporary secret for one-time setup; not invoked in production.'
+)]
 [CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter()] [string] $ConfigPath,

--- a/message-center-monitor/lab/05_Set-EnvVarValues.ps1
+++ b/message-center-monitor/lab/05_Set-EnvVarValues.ps1
@@ -16,6 +16,10 @@
 .NOTES
     Lab dry-run step 5 of 7. Solution: message-center-monitor v2.5.0+
 #>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Lab provisioning script run interactively by tenant admin. Operator pastes a temporary secret for one-time setup; not invoked in production.'
+)]
 [CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter()] [string] $ConfigPath,

--- a/message-center-monitor/lab/06_Invoke-LabSmokeTest.ps1
+++ b/message-center-monitor/lab/06_Invoke-LabSmokeTest.ps1
@@ -46,6 +46,10 @@
       H2 -> Steps 3+4 (real network; retry exercised under throttling)
       Schema alt-key -> Step 3 (sync uses the alt-key URL)
 #>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Lab provisioning script run interactively by tenant admin. Operator pastes a temporary secret for one-time setup; not invoked in production.'
+)]
 [CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter()] [string] $ConfigPath,

--- a/message-center-monitor/lab/07_Invoke-PocSmokeTest.ps1
+++ b/message-center-monitor/lab/07_Invoke-PocSmokeTest.ps1
@@ -74,6 +74,10 @@
     the same URL prefix via dotnet's cross-platform HttpListener
     implementation.
 #>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Lab provisioning script run interactively by tenant admin. Operator pastes a temporary secret for one-time setup; not invoked in production.'
+)]
 [CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter()] [string] $ConfigPath,

--- a/message-center-monitor/scripts/governance/Test-McmPrerequisites.ps1
+++ b/message-center-monitor/scripts/governance/Test-McmPrerequisites.ps1
@@ -121,6 +121,10 @@
     - 1  One or more FAIL
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Dev-only preflight fallback. Production deployments use managed identity via scripts/shared/dataverse_client.py per AGENTS.md "Authentication standard". Plaintext secret is read from Key Vault, wrapped immediately into SecureString, and not logged.'
+)]
 [CmdletBinding()]
 param(
     [Parameter(Mandatory=$false)] [string]$TenantId = $env:AZURE_TENANT_ID,

--- a/message-center-monitor/tests/Common.Tests.ps1
+++ b/message-center-monitor/tests/Common.Tests.ps1
@@ -21,6 +21,12 @@
     Run with: Invoke-Pester -Path .\Common.Tests.ps1 -Output Detailed
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Pester test fixture credential — never used against production. Required to exercise SecureString-accepting code paths.'
+)]
+param()
+
 BeforeAll {
     . (Join-Path $PSScriptRoot '..' 'scripts' 'governance' '_Common.ps1')
 

--- a/rag-source-validator/scripts/Invoke-SourceValidation.ps1
+++ b/rag-source-validator/scripts/Invoke-SourceValidation.ps1
@@ -48,6 +48,10 @@
     .\Invoke-SourceValidation.ps1 -Environment "https://contoso.crm.dynamics.com"
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Dev-only legacy auth path. Production deployments use managed identity via scripts/shared/dataverse_client.py per AGENTS.md "Authentication standard". Plaintext secret here is wrapped immediately into SecureString and never persisted.'
+)]
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]

--- a/scope-drift-monitor/scripts/Invoke-DriftScan.ps1
+++ b/scope-drift-monitor/scripts/Invoke-DriftScan.ps1
@@ -45,6 +45,10 @@
     - Microsoft 365 E5 or E5 Compliance license for CopilotInteraction events
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Dev-only legacy auth path. Production deployments use managed identity via scripts/shared/dataverse_client.py per AGENTS.md "Authentication standard". Plaintext secret here is wrapped immediately into SecureString and never persisted.'
+)]
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]

--- a/scope-drift-monitor/scripts/New-AgentBaseline.ps1
+++ b/scope-drift-monitor/scripts/New-AgentBaseline.ps1
@@ -52,6 +52,10 @@
     - Microsoft 365 E5 or E5 Compliance license for CopilotInteraction events
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Dev-only legacy auth path. Production deployments use managed identity via scripts/shared/dataverse_client.py per AGENTS.md "Authentication standard". Plaintext secret here is wrapped immediately into SecureString and never persisted.'
+)]
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]


### PR DESCRIPTION
## Summary
- Suppresses all 27 `PSAvoidUsingConvertToSecureStringWithPlainText` Error-severity findings with documented `SuppressMessageAttribute` justifications.
- Leaves the existing `ConvertTo-SecureString ... -AsPlainText -Force` calls intact.
- Updates `AGENTS.md` with the formal dev/lab/test suppression policy.

## Category counts
- Connect-helper / dev legacy auth paths: 18 findings across 14 files
- Lab provisioning scripts: 7 findings across 7 files
- Pester test fixtures: 2 findings across 2 files

## Validation
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1`: Error-severity findings = 0
- `PSAvoidUsingConvertToSecureStringWithPlainText` findings = 0
- Total PSSA findings: 385 (local PSScriptAnalyzer 1.24/1.25; baseline noted as 410)