### PR TITLE
chore(powershell): add ShouldProcess + rename automatic vars (Wave 6 P4a)

### DIFF
--- a/agent-intake/CHANGELOG.md
+++ b/agent-intake/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **Operator ergonomics (Wave 6 P4a):** State-changing scripts now support `-WhatIf` and `-Confirm` switches via `SupportsShouldProcess`. Existing callers see no behavior change unless they explicitly pass `-WhatIf`.
 - **Medium**: Added a code comment to `scripts/create_fsi_intake_dataverse_schema.py` `fsi_intake_auditeventtype` definition clarifying that the option set is an intentional reference catalog and is NOT deployed by `deploy.ps1` because the backing `fsi_eventtype` column is a String (not Picklist) to permit customer extension. (council review M-1)
 - **Medium**: Added a `_comment` field to `scripts/seed-test-data/request-cross-border-deny.json` `expectedClassification` documenting that `pathUsed = Standard` depends on the default `audience_to_zone` mapping in `templates/policy-lookup-tables.yaml`; if a customer remaps `My team` to Zone 1, the classifier routes the fixture to Full instead. (council review M-5)
 - **Minor**: Added a code comment to `tests/validators/validate_question_catalogs.py` `EXPECTED_QUESTION_COUNTS` documenting the derivation (one entry per `| <ID>` row in the corresponding `docs/intake-questions-<path>.md`) and the maintenance contract. (council review L-4)

--- a/agent-intake/scripts/provision_reviewer_app.ps1
+++ b/agent-intake/scripts/provision_reviewer_app.ps1
@@ -228,7 +228,7 @@ function Resolve-AccessToken {
     return $null
 }
 
-function Update-DataverseToken {
+function Get-RefreshedDataverseToken {
     param([Parameter(Mandatory = $true)][string]$ResolvedEnvironmentUrl)
 
     $az = Get-Command az -ErrorAction SilentlyContinue
@@ -326,7 +326,7 @@ function Invoke-DataverseRequest {
     $response = Invoke-WebRequest -Uri $uri -Method $Method -Headers $headers -Body $bodyJson -UseBasicParsing -SkipHttpErrorCheck
     if ($response.StatusCode -eq 401) {
         Write-Info "Dataverse token rejected (HTTP 401); refreshing via Azure CLI and retrying $Method $RelativeUri."
-        $refreshed = Update-DataverseToken -ResolvedEnvironmentUrl $EnvironmentUrl
+        $refreshed = Get-RefreshedDataverseToken -ResolvedEnvironmentUrl $EnvironmentUrl
         if ($refreshed) {
             $headers = Get-DataverseHeaders -Token $refreshed -SolutionUniqueName $SolutionUniqueName
             if ($Body) {
@@ -483,6 +483,7 @@ function Get-ExistingPublisher {
 }
 
 function New-PublisherRecord {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [Parameter(Mandatory = $true)][hashtable]$Spec,
         [Parameter(Mandatory = $true)][string]$Token
@@ -495,6 +496,15 @@ function New-PublisherRecord {
         customizationoptionvalueprefix = [int]$Spec.publisher.customizationOptionValuePrefix
         description                    = $Spec.publisher.description
         supportingwebsiteurl           = 'https://judeper.github.io/FSI-AgentGov-Solutions/'
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($Spec.publisher.uniqueName, 'Create Dataverse publisher')) {
+        return @{
+            publisherid         = '00000000-0000-0000-0000-000000000001'
+            uniquename          = $Spec.publisher.uniqueName
+            friendlyname        = $Spec.publisher.name
+            customizationprefix = $Spec.publisher.prefix
+        }
     }
 
     $response = Invoke-DataverseRequest -Method POST -Token $Token -RelativeUri 'publishers' -Body $body
@@ -548,6 +558,7 @@ function Get-ExistingSolution {
 }
 
 function New-SolutionRecord {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [Parameter(Mandatory = $true)][hashtable]$Spec,
         [Parameter(Mandatory = $true)][string]$Token,
@@ -560,6 +571,15 @@ function New-SolutionRecord {
         version                 = $Spec.solutionVersion
         description             = 'Reviewer model-driven app and reviewer queue metadata for agent-intake Standard and Full routing.'
         'publisherid@odata.bind' = "/publishers($PublisherId)"
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($Spec.solutionName, 'Create Dataverse solution')) {
+        return @{
+            solutionid   = '00000000-0000-0000-0000-000000000002'
+            uniquename   = $Spec.solutionName
+            friendlyname = $Spec.solutionDisplayName
+            version      = $Spec.solutionVersion
+        }
     }
 
     $response = Invoke-DataverseRequest -Method POST -Token $Token -RelativeUri 'solutions' -Body $body
@@ -629,7 +649,12 @@ function Get-ExistingAppRecord {
 }
 
 function New-AppRecord {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param([Parameter(Mandatory = $true)][hashtable]$Spec)
+
+    if (-not $PSCmdlet.ShouldProcess($Spec.appDisplayName, 'Create reviewer model-driven app')) {
+        return
+    }
 
     Invoke-PacCommand -Arguments @(
         'model',
@@ -768,6 +793,7 @@ function ConvertTo-ViewLayoutXml {
 }
 
 function Set-ReviewerView {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [Parameter(Mandatory = $true)][hashtable]$ViewSpec,
         [Parameter(Mandatory = $true)][hashtable]$Spec,
@@ -792,12 +818,16 @@ function Set-ReviewerView {
 
     $existing = Get-ExistingViewRecord -ViewSpec $ViewSpec -Token $Token
     if ($null -eq $existing) {
-        Invoke-DataverseRequest -Method POST -Token $Token -RelativeUri 'savedqueries' -Body $payload -SolutionUniqueName $Spec.solutionName | Out-Null
-        Write-Info "Created system view '$($ViewSpec.name)'."
+        if ($PSCmdlet.ShouldProcess($ViewSpec.name, 'Create reviewer system view')) {
+            Invoke-DataverseRequest -Method POST -Token $Token -RelativeUri 'savedqueries' -Body $payload -SolutionUniqueName $Spec.solutionName | Out-Null
+            Write-Info "Created system view '$($ViewSpec.name)'."
+        }
     }
     else {
-        Invoke-DataverseRequest -Method PATCH -Token $Token -RelativeUri ("savedqueries({0})" -f $existing.savedqueryid) -Body $payload | Out-Null
-        Write-Info "Updated system view '$($ViewSpec.name)'."
+        if ($PSCmdlet.ShouldProcess($ViewSpec.name, 'Update reviewer system view')) {
+            Invoke-DataverseRequest -Method PATCH -Token $Token -RelativeUri ("savedqueries({0})" -f $existing.savedqueryid) -Body $payload | Out-Null
+            Write-Info "Updated system view '$($ViewSpec.name)'."
+        }
     }
 
     if (-not $script:ProvisionedViews.Contains($ViewSpec.name)) {
@@ -826,6 +856,7 @@ function Get-ExistingRoleRecord {
 }
 
 function New-RoleRecord {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [Parameter(Mandatory = $true)][hashtable]$RoleSpec,
         [Parameter(Mandatory = $true)][hashtable]$Spec,
@@ -837,6 +868,15 @@ function New-RoleRecord {
         name                        = $RoleSpec.name
         description                 = $RoleSpec.description
         'businessunitid@odata.bind' = "/businessunits($BusinessUnitId)"
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($RoleSpec.name, 'Create reviewer security role')) {
+        return @{
+            roleid                     = '00000000-0000-0000-0000-000000000003'
+            name                       = $RoleSpec.name
+            '_businessunitid_value'    = $BusinessUnitId
+            roleprivileges_association = @()
+        }
     }
 
     $response = Invoke-DataverseRequest -Method POST -Token $Token -RelativeUri 'roles' -Body $body -SolutionUniqueName $Spec.solutionName

--- a/agent-intake/scripts/provision_solution_shell.ps1
+++ b/agent-intake/scripts/provision_solution_shell.ps1
@@ -372,7 +372,7 @@ function Resolve-AccessToken {
     return $null
 }
 
-function Update-DataverseToken {
+function Get-RefreshedDataverseToken {
     param([Parameter(Mandatory = $true)][string]$ResolvedEnvironmentUrl)
 
     $az = Get-Command az -ErrorAction SilentlyContinue
@@ -441,7 +441,7 @@ function Invoke-DataverseRequest {
     $response = Invoke-WebRequest -Uri $uri -Method $Method -Headers $headers -Body $bodyJson -UseBasicParsing -SkipHttpErrorCheck
     if ($response.StatusCode -eq 401) {
         Write-Info "Dataverse token rejected (HTTP 401); refreshing via Azure CLI and retrying $Method $RelativeUri."
-        $refreshed = Update-DataverseToken -ResolvedEnvironmentUrl $EnvironmentUrl
+        $refreshed = Get-RefreshedDataverseToken -ResolvedEnvironmentUrl $EnvironmentUrl
         if ($refreshed) {
             $headers = Get-DataverseHeaders -Token $refreshed
             $response = Invoke-WebRequest -Uri $uri -Method $Method -Headers $headers -Body $bodyJson -UseBasicParsing -SkipHttpErrorCheck
@@ -487,6 +487,7 @@ function Get-ExistingPublisher {
 }
 
 function New-PublisherRecord {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param([Parameter(Mandatory = $true)][string]$Token)
 
     $body = @{
@@ -500,6 +501,16 @@ function New-PublisherRecord {
 
     if ($DryRun) {
         Write-Info "[DRY RUN] Would create publisher '$PublisherName'."
+        return @{
+            publisherid                    = '00000000-0000-0000-0000-000000000001'
+            friendlyname                   = $PublisherName
+            uniquename                     = $PublisherName
+            customizationprefix            = $PublisherPrefix
+            customizationoptionvalueprefix = $PublisherOptionValuePrefix
+        }
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($PublisherName, 'Create Dataverse publisher')) {
         return @{
             publisherid                    = '00000000-0000-0000-0000-000000000001'
             friendlyname                   = $PublisherName
@@ -558,6 +569,7 @@ function Get-ExistingSolution {
 }
 
 function New-SolutionRecord {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [Parameter(Mandatory = $true)][string]$Token,
         [Parameter(Mandatory = $true)][string]$PublisherId
@@ -573,6 +585,15 @@ function New-SolutionRecord {
 
     if ($DryRun) {
         Write-Info "[DRY RUN] Would create solution '$SolutionName'."
+        return @{
+            solutionid   = '00000000-0000-0000-0000-000000000002'
+            friendlyname = $SolutionDisplayName
+            uniquename   = $SolutionName
+            version      = $SolutionVersion
+        }
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($SolutionName, 'Create Dataverse solution')) {
         return @{
             solutionid   = '00000000-0000-0000-0000-000000000002'
             friendlyname = $SolutionDisplayName

--- a/agent-intake/scripts/setup_purview_retention_label.ps1
+++ b/agent-intake/scripts/setup_purview_retention_label.ps1
@@ -143,7 +143,7 @@ function Get-ResolvedAdminUpn {
     return $enteredUpn.Trim()
 }
 
-function New-ComplianceTagCommandText {
+function Get-ComplianceTagCommandText {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
@@ -200,7 +200,7 @@ function Add-RetentionLabelResult {
         }
     }
 
-    $commandText = New-ComplianceTagCommandText -Name $Name -RetentionDuration $RetentionDays -Comment $Comment -IsRecordLabel $IsRecordLabel
+    $commandText = Get-ComplianceTagCommandText -Name $Name -RetentionDuration $RetentionDays -Comment $Comment -IsRecordLabel $IsRecordLabel
     if ($DryRun.IsPresent) {
         Write-Host ("[DRY RUN] {0}" -f $commandText)
         return [pscustomobject]@{

--- a/audit-compliance-manager/CHANGELOG.md
+++ b/audit-compliance-manager/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Operator ergonomics (Wave 6 P4a):** State-changing scripts now support `-WhatIf` and `-Confirm` switches via `SupportsShouldProcess`. Existing callers see no behavior change unless they explicitly pass `-WhatIf`.
+
 ### Fixed
 
 - `Compare-ValidationBaseline.ps1` now uses `$null -eq` baseline detection so array-shaped Dataverse responses are handled consistently.

--- a/audit-compliance-manager/scripts/Validators.Tests.ps1
+++ b/audit-compliance-manager/scripts/Validators.Tests.ps1
@@ -97,11 +97,11 @@ Describe "Validator Confidence value consistency" {
         $content = Get-Content -LiteralPath $Path -Raw
 
         # Find all Confidence assignments (code lines, not comments/docstrings)
-        $matches = [regex]::Matches($content, '(?:Confidence\s*=\s*"([^"]+)"|\$confidence\s*=\s*"([^"]+)")')
+        $confidenceMatches = [regex]::Matches($content, '(?:Confidence\s*=\s*"([^"]+)"|\$confidence\s*=\s*"([^"]+)")')
 
-        $matches.Count | Should -BeGreaterThan 0 -Because "$Name should contain Confidence assignments"
+        $confidenceMatches.Count | Should -BeGreaterThan 0 -Because "$Name should contain Confidence assignments"
 
-        foreach ($match in $matches) {
+        foreach ($match in $confidenceMatches) {
             $value = if ($match.Groups[1].Success) { $match.Groups[1].Value } else { $match.Groups[2].Value }
             ($script:validConfidenceValues -ccontains $value) | Should -BeTrue -Because "Confidence value '$value' in $Name must be title-case (High, Medium, or N/A)"
         }

--- a/audit-compliance-manager/scripts/private/New-CanaryEvent.ps1
+++ b/audit-compliance-manager/scripts/private/New-CanaryEvent.ps1
@@ -76,7 +76,7 @@ param(
 $ErrorActionPreference = "Stop"
 
 function New-CanaryEvent {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [Parameter(Mandatory = $false)]
         [string]$CanaryId = [Guid]::NewGuid().ToString(),
@@ -115,6 +115,17 @@ function New-CanaryEvent {
 
         # Set canary value
         $canaryValue = "ACV-Canary-$CanaryId"
+        if (-not $PSCmdlet.ShouldProcess($MailboxIdentity, "Set canary mailbox attribute to '$canaryValue'")) {
+            return [PSCustomObject]@{
+                CanaryId     = $CanaryId
+                Timestamp    = Get-Date -Format "o"
+                Operation    = "Set-Mailbox"
+                Target       = $MailboxIdentity
+                Status       = "Skipped"
+                ErrorMessage = $null
+            }
+        }
+
         Set-Mailbox -Identity $MailboxIdentity -CustomAttribute15 $canaryValue -ErrorAction Stop
 
         Write-Host "Canary event generated successfully." -ForegroundColor Green
@@ -126,13 +137,17 @@ function New-CanaryEvent {
         # Revert to original value (unless SkipRevert is specified)
         if (-not $SkipRevert) {
             if ($originalValue) {
-                Set-Mailbox -Identity $MailboxIdentity -CustomAttribute15 $originalValue -ErrorAction Stop
-                Write-Host "CustomAttribute15 reverted to original value: $originalValue" -ForegroundColor Gray
+                if ($PSCmdlet.ShouldProcess($MailboxIdentity, 'Revert canary mailbox attribute')) {
+                    Set-Mailbox -Identity $MailboxIdentity -CustomAttribute15 $originalValue -ErrorAction Stop
+                    Write-Host "CustomAttribute15 reverted to original value: $originalValue" -ForegroundColor Gray
+                }
             }
             else {
                 # Clear the attribute if it was originally empty
-                Set-Mailbox -Identity $MailboxIdentity -CustomAttribute15 $null -ErrorAction Stop
-                Write-Host "CustomAttribute15 cleared (was originally empty)." -ForegroundColor Gray
+                if ($PSCmdlet.ShouldProcess($MailboxIdentity, 'Clear canary mailbox attribute')) {
+                    Set-Mailbox -Identity $MailboxIdentity -CustomAttribute15 $null -ErrorAction Stop
+                    Write-Host "CustomAttribute15 cleared (was originally empty)." -ForegroundColor Gray
+                }
             }
         }
 

--- a/credential-oversharing-detector/scripts/governance/Test-AgentAuthMethod.ps1
+++ b/credential-oversharing-detector/scripts/governance/Test-AgentAuthMethod.ps1
@@ -162,13 +162,13 @@ function Test-AgentAuthMethod {
 
             # Check for client secrets (password credentials)
             if ($sp.PasswordCredentials) {
-                foreach ($pwd in $sp.PasswordCredentials) {
-                    $isExpired = $pwd.EndDateTime -lt (Get-Date)
+                foreach ($passwordCredential in $sp.PasswordCredentials) {
+                    $isExpired = $passwordCredential.EndDateTime -lt (Get-Date)
                     $authMethods.Add([PSCustomObject]@{
                         Type       = 'ClientSecret'
-                        KeyId      = $pwd.KeyId
-                        StartDate  = $pwd.StartDateTime
-                        EndDate    = $pwd.EndDateTime
+                        KeyId      = $passwordCredential.KeyId
+                        StartDate  = $passwordCredential.StartDateTime
+                        EndDate    = $passwordCredential.EndDateTime
                         IsExpired  = $isExpired
                     })
                     if ($primaryMethod -eq 'Unknown') {

--- a/cross-solution-integration/CHANGELOG.md
+++ b/cross-solution-integration/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this solution will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- **Operator ergonomics (Wave 6 P4a):** State-changing scripts now support `-WhatIf` and `-Confirm` switches via `SupportsShouldProcess`. Existing callers see no behavior change unless they explicitly pass `-WhatIf`.
+
+---
 
 ## [Unreleased]
 

--- a/cross-solution-integration/scripts/powershell/Sync-SolutionAssessments.ps1
+++ b/cross-solution-integration/scripts/powershell/Sync-SolutionAssessments.ps1
@@ -193,6 +193,7 @@ function Invoke-DataverseQuery {
 }
 
 function New-DataverseRecord {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [hashtable]$Connection,
         [string]$EntitySet,
@@ -202,6 +203,10 @@ function New-DataverseRecord {
     $url = "$($Connection.BaseUrl)/$EntitySet"
     $body = $Record | ConvertTo-Json -Depth 10
     Write-Verbose "POST $url"
+
+    if (-not $PSCmdlet.ShouldProcess($EntitySet, 'Create Dataverse record')) {
+        return $null
+    }
 
     $maxRetries = 3
     $retryCount = 0
@@ -224,6 +229,7 @@ function New-DataverseRecord {
 }
 
 function Update-DataverseRecord {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [hashtable]$Connection,
         [string]$EntitySet,
@@ -234,6 +240,10 @@ function Update-DataverseRecord {
     $url = "$($Connection.BaseUrl)/$EntitySet($RecordId)"
     $body = $Record | ConvertTo-Json -Depth 10
     Write-Verbose "PATCH $url"
+
+    if (-not $PSCmdlet.ShouldProcess("$EntitySet/$RecordId", 'Update Dataverse record')) {
+        return
+    }
 
     $maxRetries = 3
     $retryCount = 0

--- a/message-center-monitor/CHANGELOG.md
+++ b/message-center-monitor/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `docs/graph-powershell-snippet.md` — companion to the removed script above.
 
 ### Changed
+- **Operator ergonomics (Wave 6 P4a):** State-changing scripts now support `-WhatIf` and `-Confirm` switches via `SupportsShouldProcess`. Existing callers see no behavior change unless they explicitly pass `-WhatIf`.
 - `README.md` — added a top-of-doc fork between the **POC path** (Phase 1, the customer success bar), the **Operationalize path** (Phase 2, Status/Export/Assess), and the **Production flow path** (Phase 3, Power Automate). Each path points at its own runbook.
 - `docs/flow-configuration.md` — added a Phase 3 banner at the top emphasizing that the Power Automate flow is **mutually exclusive** with the Phase 1 PowerShell webhook (run one, not both). Concrete `Remove-Item env:` step included for the migration.
 - `templates/teams-notification-card.json` — updated `_comment` to document that the template is rendered by both the Phase 1 PowerShell sync (via `Send-McmTeamsWebhook`) and the Phase 3 Power Automate flow. Do not rename tokens or restructure the body without coordinating both paths.

--- a/message-center-monitor/lab/Resume-LabState.ps1
+++ b/message-center-monitor/lab/Resume-LabState.ps1
@@ -170,18 +170,18 @@ $bapTok = Get-AccessTokenForResource -Resource 'https://api.bap.microsoft.com'
 $bapHdr = @{ Authorization = "Bearer $bapTok"; Accept = 'application/json' }
 $bapList = Invoke-RestMethod -Uri "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments?api-version=2023-06-01" -Headers $bapHdr -Method Get -ErrorAction Stop
 $envUrlNorm = $cfg.powerPlatform.environmentUrl.TrimEnd('/')
-$matches = @($bapList.value | Where-Object {
+$matchingEnvironments = @($bapList.value | Where-Object {
     $linked = $_.properties.linkedEnvironmentMetadata
     $linked -and $linked.instanceUrl -and ($linked.instanceUrl.TrimEnd('/') -eq $envUrlNorm)
 })
-if ($matches.Count -eq 0) {
+if ($matchingEnvironments.Count -eq 0) {
     Write-LabLog -Level Error -Message "No Power Platform environment found with Dataverse URL '$envUrlNorm'. Run lab/00b_New-PaygEnvironment.ps1, or update lab-config.json.powerPlatform.environmentUrl." -Throw
 }
-if ($matches.Count -gt 1) {
-    $ids = ($matches | ForEach-Object { $_.name }) -join ', '
-    Write-LabLog -Level Error -Message "Found $($matches.Count) environments with that Dataverse URL ($ids). This should be impossible; check tenant state manually." -Throw
+if ($matchingEnvironments.Count -gt 1) {
+    $ids = ($matchingEnvironments | ForEach-Object { $_.name }) -join ', '
+    Write-LabLog -Level Error -Message "Found $($matchingEnvironments.Count) environments with that Dataverse URL ($ids). This should be impossible; check tenant state manually." -Throw
 }
-$envObj = $matches[0]
+$envObj = $matchingEnvironments[0]
 $environmentId = $envObj.name
 Write-LabLog -Level Info -Message "  environmentId = $environmentId"
 

--- a/message-center-monitor/lab/lib/Write-LabLog.ps1
+++ b/message-center-monitor/lab/lib/Write-LabLog.ps1
@@ -189,12 +189,15 @@ function Set-LabHandoffSecret {
         secret to 02 across pwsh process boundaries when Key Vault does not
         yet exist.
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [Parameter(Mandatory)] [string] $SecretValue
     )
     $labRoot = Split-Path -Parent $PSScriptRoot
     $path    = Join-Path $labRoot '.secret-handoff'
+    if (-not $PSCmdlet.ShouldProcess($path, 'Write lab handoff secret')) {
+        return
+    }
     Set-Content -LiteralPath $path -Value $SecretValue -Encoding utf8NoBOM -NoNewline
     if ($IsWindows -or $env:OS -eq 'Windows_NT') {
         # Restrict ACL: owner full control, no inherited perms.

--- a/message-center-monitor/scripts/governance/Test-McmPrerequisites.ps1
+++ b/message-center-monitor/scripts/governance/Test-McmPrerequisites.ps1
@@ -168,7 +168,7 @@ $script:dvBaseUrl  = $null
 
 #region Local script helpers
 
-function New-McmCheckResult {
+function Get-McmCheckResult {
     param(
         [Parameter(Mandatory)] [string]$Name,
         [Parameter(Mandatory)] [ValidateSet('PASS','WARN','FAIL','SKIP')] [string]$Status,
@@ -241,16 +241,16 @@ $checkName = 'PowerShell 7.2+'
 try {
     $psVer = $PSVersionTable.PSVersion
     if ($psVer -ge [version]'7.2') {
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'PASS' -Detail "v$psVer"))
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'PASS' -Detail "v$psVer"))
     }
     else {
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
             -Hint 'Install PowerShell 7.2 or later: winget install Microsoft.PowerShell' `
             -Detail "Installed: v$psVer"))
     }
 }
 catch {
-    $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' -Hint $_.Exception.Message))
+    $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' -Hint $_.Exception.Message))
 }
 
 #endregion
@@ -266,20 +266,20 @@ try {
     $azkeyOk = $null -ne $azkeyMod
 
     if ($msalOk -and $azkeyOk) {
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'PASS' `
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'PASS' `
             -Detail "MSAL.PS $($msalMod.Version); Az.KeyVault $($azkeyMod.Version)"))
     }
     else {
         $missing = [System.Collections.Generic.List[string]]::new()
         if (-not $msalOk)  { $missing.Add('MSAL.PS >= 4.37.0') }
         if (-not $azkeyOk) { $missing.Add('Az.KeyVault') }
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
             -Hint 'Install-Module MSAL.PS -MinimumVersion 4.37.0 -Scope CurrentUser -Force; Install-Module Az.KeyVault -Scope CurrentUser -Force' `
             -Detail "Missing: $($missing -join ', ')"))
     }
 }
 catch {
-    $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' -Hint $_.Exception.Message))
+    $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' -Hint $_.Exception.Message))
 }
 
 #endregion
@@ -289,16 +289,16 @@ catch {
 $checkName = 'Key Vault reachable'
 try {
     if (-not $KeyVaultName) {
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'SKIP' `
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'SKIP' `
             -Hint 'Supply -KeyVaultName to validate'))
     }
     else {
         Get-AzKeyVault -VaultName $KeyVaultName -ErrorAction Stop | Out-Null
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'PASS' -Detail $KeyVaultName))
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'PASS' -Detail $KeyVaultName))
     }
 }
 catch {
-    $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+    $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
         -Hint 'Run Connect-AzAccount with credentials that have Reader access to the Key Vault' `
         -Detail $_.Exception.Message))
 }
@@ -316,25 +316,25 @@ try {
         else {
             'Supply -KeyVaultSecretName to validate'
         }
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'SKIP' -Hint $skipHint))
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'SKIP' -Hint $skipHint))
     }
     else {
         $secretPlainText = Get-AzKeyVaultSecret -VaultName $KeyVaultName `
             -Name $KeyVaultSecretName -AsPlainText -ErrorAction Stop
         if ($secretPlainText) {
             $ClientSecret = ConvertTo-SecureString -String $secretPlainText -AsPlainText -Force
-            $results.Add((New-McmCheckResult -Name $checkName -Status 'PASS' `
+            $results.Add((Get-McmCheckResult -Name $checkName -Status 'PASS' `
                 -Detail "Secret '$KeyVaultSecretName' retrieved and applied to -ClientSecret"))
         }
         else {
-            $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+            $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
                 -Hint "Secret '$KeyVaultSecretName' exists but returned an empty value. Verify the secret has a current non-empty version." `
                 -Detail "Vault: $KeyVaultName"))
         }
     }
 }
 catch {
-    $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+    $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
         -Hint 'Run Connect-AzAccount with credentials that have Get access to Key Vault secrets' `
         -Detail $_.Exception.Message))
 }
@@ -348,11 +348,11 @@ try {
     $script:graphToken = Get-McmAccessToken -AuthMode $AuthMode `
         -Scope 'https://graph.microsoft.com/.default' `
         -TenantId $TenantId -ClientId $ClientId -ClientSecret $ClientSecret
-    $results.Add((New-McmCheckResult -Name $checkName -Status 'PASS' `
+    $results.Add((Get-McmCheckResult -Name $checkName -Status 'PASS' `
         -Detail "Token acquired (expires: $($script:graphToken.ExpiresOn))"))
 }
 catch {
-    $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+    $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
         -Hint 'Verify TenantId/ClientId/ClientSecret are correct and the app exists in the tenant' `
         -Detail $_.Exception.Message))
 }
@@ -364,7 +364,7 @@ catch {
 $checkName = 'ServiceMessage.Read.All consented'
 try {
     if (-not $script:graphToken) {
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'SKIP' `
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'SKIP' `
             -Hint 'Graph token unavailable — check 5 (Graph token acquisition) must PASS first'))
     }
     else {
@@ -374,13 +374,13 @@ try {
         }
         $graphUri = 'https://graph.microsoft.com/v1.0/admin/serviceAnnouncement/messages?$top=1'
         Invoke-McmRest -Uri $graphUri -Headers $graphHeaders -Method Get | Out-Null
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'PASS'))
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'PASS'))
     }
 }
 catch {
     $errMsg = $_.Exception.Message
     if ($errMsg -match 'status=403') {
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
             -Hint ('Grant admin consent for ServiceMessage.Read.All in Entra portal: ' +
                    'https://entra.microsoft.com → Applications → App registrations → <your app> ' +
                    '→ API permissions → Add Microsoft Graph → Application permissions → ' +
@@ -388,12 +388,12 @@ catch {
             -Detail $errMsg))
     }
     elseif ($errMsg -match 'status=401') {
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
             -Hint 'Token was acquired but Graph rejected it (401). Verify the token audience and app registration.' `
             -Detail $errMsg))
     }
     else {
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
             -Hint 'Graph API call failed. Verify connectivity and app registration configuration.' `
             -Detail $errMsg))
     }
@@ -411,11 +411,11 @@ try {
         -TenantId $TenantId -ClientId $ClientId -ClientSecret $ClientSecret
     $metadataUri = "$($script:dvBaseUrl)/`$metadata"
     Invoke-McmRest -Uri $metadataUri -Headers $script:dvHeaders -Method Get | Out-Null
-    $results.Add((New-McmCheckResult -Name $checkName -Status 'PASS' -Detail $DataverseUrl))
+    $results.Add((Get-McmCheckResult -Name $checkName -Status 'PASS' -Detail $DataverseUrl))
 }
 catch {
     $script:dvHeaders = $null
-    $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+    $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
         -Hint 'Verify DataverseUrl is the environment URL (e.g., https://org.crm.dynamics.com — no trailing /api/data/...)' `
         -Detail $_.Exception.Message))
 }
@@ -427,30 +427,30 @@ catch {
 $checkName = 'fsi_messagecenterlogs entity accessible'
 try {
     if (-not $script:dvHeaders) {
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'SKIP' `
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'SKIP' `
             -Hint 'Dataverse connection unavailable — check 7 (Dataverse reachable) must PASS first'))
     }
     else {
         $entityUri = "$($script:dvBaseUrl)/fsi_messagecenterlogs?`$top=1&`$select=fsi_messagecenterid"
         Invoke-McmRest -Uri $entityUri -Headers $script:dvHeaders -Method Get | Out-Null
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'PASS'))
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'PASS'))
     }
 }
 catch {
     $errMsg = $_.Exception.Message
     if ($errMsg -match 'status=404') {
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
             -Hint 'Run python scripts/create_mcm_dataverse_schema.py — the table is missing' `
             -Detail $errMsg))
     }
     elseif ($errMsg -match 'status=401' -or $errMsg -match 'status=403') {
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
             -Hint ("The app registration is not a Dataverse Application User with read access to " +
                    "fsi_messagecenterlog. See README Section 5 'Dataverse Application User'") `
             -Detail $errMsg))
     }
     else {
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
             -Hint 'Unexpected error accessing fsi_messagecenterlogs entity set.' `
             -Detail $errMsg))
     }
@@ -463,7 +463,7 @@ catch {
 $checkName = 'Alt-key fsi_MessageCenterIdKey Active'
 try {
     if (-not $script:dvHeaders) {
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'SKIP' `
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'SKIP' `
             -Hint 'Dataverse connection unavailable — check 7 (Dataverse reachable) must PASS first'))
     }
     else {
@@ -477,7 +477,7 @@ try {
         }
 
         if (-not $altKey) {
-            $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+            $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
                 -Hint 'Alt-key not found; re-run create_mcm_dataverse_schema.py'))
         }
         else {
@@ -495,24 +495,24 @@ try {
             }
             switch ($statusLabel) {
                 'Active' {
-                    $results.Add((New-McmCheckResult -Name $checkName -Status 'PASS' `
+                    $results.Add((Get-McmCheckResult -Name $checkName -Status 'PASS' `
                         -Detail "EntityKeyIndexStatus: Active"))
                     break
                 }
                 { $_ -eq 'Pending' -or $_ -eq 'InProgress' } {
-                    $results.Add((New-McmCheckResult -Name $checkName -Status 'WARN' `
+                    $results.Add((Get-McmCheckResult -Name $checkName -Status 'WARN' `
                         -Hint 'Alt-key activation in progress — wait 60s and re-run preflight; OR see docs/poc-quickstart.md Step 1.3 wait gate' `
                         -Detail "EntityKeyIndexStatus: $statusLabel"))
                     break
                 }
                 'Failed' {
-                    $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+                    $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
                         -Hint 'Alt-key activation FAILED — open the table in Power Apps maker portal → Keys → inspect; re-run create_mcm_dataverse_schema.py' `
                         -Detail "EntityKeyIndexStatus: Failed"))
                     break
                 }
                 default {
-                    $results.Add((New-McmCheckResult -Name $checkName -Status 'WARN' `
+                    $results.Add((Get-McmCheckResult -Name $checkName -Status 'WARN' `
                         -Hint "Unknown EntityKeyIndexStatus value: $statusLabel. Validate manually in Power Apps maker portal." `
                         -Detail "EntityKeyIndexStatus: $statusLabel"))
                 }
@@ -521,7 +521,7 @@ try {
     }
 }
 catch {
-    $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+    $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
         -Hint 'Failed to query entity key definitions. Verify Dataverse connectivity and app permissions.' `
         -Detail $_.Exception.Message))
 }
@@ -533,7 +533,7 @@ catch {
 $checkName = 'Teams webhook URL'
 try {
     if (-not $TeamsWebhookUrl) {
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'SKIP' `
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'SKIP' `
             -Hint 'Supply -TeamsWebhookUrl or set $env:MCM_TEAMS_WEBHOOK_URL to validate'))
     }
     else {
@@ -542,7 +542,7 @@ try {
         $isHttps         = ($webhookUri.Scheme -eq 'https')
         $isLoopbackHttp  = ($webhookUri.Scheme -eq 'http' -and $webhookUri.IsLoopback)
         if (-not $isHttps -and -not $isLoopbackHttp) {
-            $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+            $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
                 -Hint "Webhook URL scheme is '$($webhookUri.Scheme)'; must be 'https' (or 'http' for loopback testing via lab/07)." `
                 -Detail $safeWebhookHost))
         }
@@ -553,13 +553,13 @@ try {
 
             if (-not $PostTestMessage) {
                 $status = if ($isLoopbackHttp) { 'WARN' } else { 'PASS' }
-                $results.Add((New-McmCheckResult -Name $checkName -Status $status `
+                $results.Add((Get-McmCheckResult -Name $checkName -Status $status `
                     -Hint "URL parsed and DNS resolved$loopbackNote; supply -PostTestMessage to also POST a test card" `
                     -Detail $safeWebhookHost))
             }
             else {
                 if (-not (Test-Path -LiteralPath $TeamsCardTemplatePath)) {
-                    $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+                    $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
                         -Hint "Adaptive card template not found at: $TeamsCardTemplatePath. Verify -TeamsCardTemplatePath or run from the correct working directory."))
                 }
                 else {
@@ -600,7 +600,7 @@ try {
                         Invoke-McmRest -Uri $TeamsWebhookUrl -Headers $webhookHeaders `
                             -Method Post -Body $payloadJson | Out-Null
                         $status = if ($isLoopbackHttp) { 'WARN' } else { 'PASS' }
-                        $results.Add((New-McmCheckResult -Name $checkName -Status $status `
+                        $results.Add((Get-McmCheckResult -Name $checkName -Status $status `
                             -Hint "URL parsed, DNS resolved, and test card POSTed successfully$loopbackNote." `
                             -Detail $safeWebhookHost))
                     }
@@ -611,7 +611,7 @@ try {
                         $postErr     = $_.Exception.Message
                         $statusMatch = $postErr -match 'status=(\d+)'
                         $statusCode  = if ($statusMatch) { $Matches[1] } else { 'unknown' }
-                        $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+                        $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
                             -Hint "Webhook URL was created in Teams Workflows but the POST returned $statusCode; verify the workflow is enabled" `
                             -Detail "host=$safeWebhookHost http=$statusCode"))
                     }
@@ -627,7 +627,7 @@ catch {
     $statusMatch = $errMsg -match 'status=(\d+)'
     $statusCode  = if ($statusMatch) { $Matches[1] } else { 'unknown' }
     $safeHost    = try { ([uri]$TeamsWebhookUrl).Host } catch { '<unparseable>' }
-    $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+    $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
         -Hint "Teams webhook check failed (HTTP $statusCode); verify the URL is reachable and the workflow is enabled." `
         -Detail "host=$safeHost http=$statusCode"))
 }
@@ -659,7 +659,7 @@ try {
         # short-circuited to PASS. The switch still bypasses the Dataverse
         # query (its purpose), but the operator now sees an explicit
         # incomplete-check banner instead of a false all-clear.
-        $results.Add((New-McmCheckResult -Name $checkName -Status 'WARN' `
+        $results.Add((Get-McmCheckResult -Name $checkName -Status 'WARN' `
             -Hint ("-AssumePhase1Only skipped the Dataverse query for the Phase 3 " +
                    "environment-variable binding. If Phase 3 is actually deployed in " +
                    "this environment, duplicate Teams alerts will fire on every sync. " +
@@ -707,7 +707,7 @@ try {
         $phase3Stale  = ($phase3DefExists -and -not $phase3HasValue)
 
         if ($phase1Active -and $phase3Active) {
-            $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+            $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
                 -Hint ("Both Phase 1 webhook (`$env:MCM_TEAMS_WEBHOOK_URL set) AND Phase 3 flow " +
                        "(environment variable $Phase3EnvVarLogicalName has a bound value) are " +
                        "configured. Duplicate Teams alerts will fire. Choose ONE path: clear " +
@@ -716,7 +716,7 @@ try {
                 -Detail 'Both Phase 1 and Phase 3 notification paths active'))
         }
         elseif ($phase1Active -and $phase3Stale) {
-            $results.Add((New-McmCheckResult -Name $checkName -Status 'WARN' `
+            $results.Add((Get-McmCheckResult -Name $checkName -Status 'WARN' `
                 -Hint ("Phase 1 webhook active AND a stale Phase 3 env-var DEFINITION " +
                        "($Phase3EnvVarLogicalName) exists in Dataverse, but with no VALUE " +
                        "bound. This is most likely leftover from a prior lab/03 run or a " +
@@ -726,23 +726,23 @@ try {
                 -Detail 'Phase 3 env-var definition leftover (no value bound)'))
         }
         elseif (-not $phase1Active -and -not $phase3Active) {
-            $results.Add((New-McmCheckResult -Name $checkName -Status 'WARN' `
+            $results.Add((Get-McmCheckResult -Name $checkName -Status 'WARN' `
                 -Hint ("No notification path configured. Set `$env:MCM_TEAMS_WEBHOOK_URL for Phase 1 " +
                        "OR deploy Phase 3 flow + env vars per docs/flow-configuration.md.") `
                 -Detail 'No notification path active'))
         }
         elseif ($phase1Active) {
-            $results.Add((New-McmCheckResult -Name $checkName -Status 'PASS' `
+            $results.Add((Get-McmCheckResult -Name $checkName -Status 'PASS' `
                 -Detail 'Phase 1 webhook active; Phase 3 flow not deployed'))
         }
         else {
-            $results.Add((New-McmCheckResult -Name $checkName -Status 'PASS' `
+            $results.Add((Get-McmCheckResult -Name $checkName -Status 'PASS' `
                 -Detail 'Phase 3 flow active; Phase 1 webhook not configured'))
         }
     }
 }
 catch {
-    $results.Add((New-McmCheckResult -Name $checkName -Status 'FAIL' `
+    $results.Add((Get-McmCheckResult -Name $checkName -Status 'FAIL' `
         -Hint 'Failed to query environment variable definitions/values. Verify Dataverse connectivity, or re-run with -AssumePhase1Only to skip this check.' `
         -Detail $_.Exception.Message))
 }

--- a/message-center-monitor/tests/Common.Tests.ps1
+++ b/message-center-monitor/tests/Common.Tests.ps1
@@ -34,7 +34,7 @@ param()
 BeforeAll {
     . (Join-Path $PSScriptRoot '..' 'scripts' 'governance' '_Common.ps1')
 
-    function New-McmFakeException {
+    function Get-McmFakeException {
         param(
             [int]$Status,
             [hashtable]$ResponseHeaders = @{}
@@ -203,7 +203,7 @@ Describe 'Invoke-McmRest - retry behaviour (H2/H3)' {
             Mock -CommandName Start-Sleep -MockWith { }
             Mock -CommandName Invoke-RestMethod -MockWith {
                 $script:n++
-                if ($script:n -lt 3) { throw (New-McmFakeException -Status 429 -ResponseHeaders @{ 'Retry-After' = '1' }) }
+                if ($script:n -lt 3) { throw (Get-McmFakeException -Status 429 -ResponseHeaders @{ 'Retry-After' = '1' }) }
                 return @{ value = 'ok' }
             }
             $r = Invoke-McmRest -Uri 'https://x' -Headers @{} -Method Get -BaseDelaySeconds 1 -MaxDelaySeconds 1
@@ -218,7 +218,7 @@ Describe 'Invoke-McmRest - retry behaviour (H2/H3)' {
             Mock -CommandName Start-Sleep -MockWith { }
             Mock -CommandName Invoke-RestMethod -MockWith {
                 $script:n++
-                if ($script:n -eq 1) { throw (New-McmFakeException -Status 503) }
+                if ($script:n -eq 1) { throw (Get-McmFakeException -Status 503) }
                 return @{ value = 'ok' }
             }
             Invoke-McmRest -Uri 'https://x' -Headers @{} -Method Get -BaseDelaySeconds 1 -MaxDelaySeconds 1 | Out-Null
@@ -229,7 +229,7 @@ Describe 'Invoke-McmRest - retry behaviour (H2/H3)' {
             Mock -CommandName Start-Sleep -MockWith { }
             Mock -CommandName Invoke-RestMethod -MockWith {
                 $script:n++
-                if ($script:n -eq 1) { throw (New-McmFakeException -Status 502) }
+                if ($script:n -eq 1) { throw (Get-McmFakeException -Status 502) }
                 return @{ ok = $true }
             }
             Invoke-McmRest -Uri 'https://x' -Headers @{} -Method Get -BaseDelaySeconds 1 -MaxDelaySeconds 1 | Out-Null
@@ -239,17 +239,17 @@ Describe 'Invoke-McmRest - retry behaviour (H2/H3)' {
 
     Context 'no retry on non-retryable status' {
         It 'does not retry on 400' {
-            Mock -CommandName Invoke-RestMethod -MockWith { throw (New-McmFakeException -Status 400) }
+            Mock -CommandName Invoke-RestMethod -MockWith { throw (Get-McmFakeException -Status 400) }
             { Invoke-McmRest -Uri 'https://x' -Headers @{} -Method Get } | Should -Throw
             Should -Invoke Invoke-RestMethod -Times 1 -Exactly
         }
         It 'does not retry on 404' {
-            Mock -CommandName Invoke-RestMethod -MockWith { throw (New-McmFakeException -Status 404) }
+            Mock -CommandName Invoke-RestMethod -MockWith { throw (Get-McmFakeException -Status 404) }
             { Invoke-McmRest -Uri 'https://x' -Headers @{} -Method Get } | Should -Throw
             Should -Invoke Invoke-RestMethod -Times 1 -Exactly
         }
         It 'does not retry on 401' {
-            Mock -CommandName Invoke-RestMethod -MockWith { throw (New-McmFakeException -Status 401) }
+            Mock -CommandName Invoke-RestMethod -MockWith { throw (Get-McmFakeException -Status 401) }
             { Invoke-McmRest -Uri 'https://x' -Headers @{} -Method Get } | Should -Throw
             Should -Invoke Invoke-RestMethod -Times 1 -Exactly
         }
@@ -258,13 +258,13 @@ Describe 'Invoke-McmRest - retry behaviour (H2/H3)' {
     Context 'max-retry termination' {
         It 'gives up after MaxRetries+1 attempts' {
             Mock -CommandName Start-Sleep -MockWith { }
-            Mock -CommandName Invoke-RestMethod -MockWith { throw (New-McmFakeException -Status 503) }
+            Mock -CommandName Invoke-RestMethod -MockWith { throw (Get-McmFakeException -Status 503) }
             { Invoke-McmRest -Uri 'https://x' -Headers @{} -Method Get -MaxRetries 2 -BaseDelaySeconds 1 -MaxDelaySeconds 1 } | Should -Throw
             # The retry loop attempts MaxRetries+1 times (initial + MaxRetries retries)
             Should -Invoke Invoke-RestMethod -Times 3 -Exactly
         }
         It 'final error message contains the status code' {
-            Mock -CommandName Invoke-RestMethod -MockWith { throw (New-McmFakeException -Status 503) }
+            Mock -CommandName Invoke-RestMethod -MockWith { throw (Get-McmFakeException -Status 503) }
             { Invoke-McmRest -Uri 'https://x' -Headers @{} -Method Get -MaxRetries 0 } | Should -Throw -ExpectedMessage '*status=503*'
         }
     }
@@ -281,7 +281,7 @@ Describe 'Invoke-McmRest - retry behaviour (H2/H3)' {
             Mock -CommandName Start-Sleep -MockWith { $script:slept = $Seconds }
             Mock -CommandName Invoke-RestMethod -MockWith {
                 $script:n++
-                if ($script:n -eq 1) { throw (New-McmFakeException -Status 429 -ResponseHeaders @{ 'Retry-After' = '7' }) }
+                if ($script:n -eq 1) { throw (Get-McmFakeException -Status 429 -ResponseHeaders @{ 'Retry-After' = '7' }) }
                 return @{ ok = $true }
             }
             Invoke-McmRest -Uri 'https://x' -Headers @{} -Method Get -BaseDelaySeconds 1 | Out-Null
@@ -293,7 +293,7 @@ Describe 'Invoke-McmRest - retry behaviour (H2/H3)' {
             Mock -CommandName Start-Sleep -MockWith { $script:slept = $Seconds }
             Mock -CommandName Invoke-RestMethod -MockWith {
                 $script:n++
-                if ($script:n -eq 1) { throw (New-McmFakeException -Status 503) }
+                if ($script:n -eq 1) { throw (Get-McmFakeException -Status 503) }
                 return @{ ok = $true }
             }
             Invoke-McmRest -Uri 'https://x' -Headers @{} -Method Get -BaseDelaySeconds 3 -MaxDelaySeconds 60 | Out-Null

--- a/message-center-monitor/tests/TeamsWebhook.Tests.ps1
+++ b/message-center-monitor/tests/TeamsWebhook.Tests.ps1
@@ -33,7 +33,7 @@ BeforeAll {
 
     $script:cardPath = Join-Path $PSScriptRoot '..' 'templates' 'teams-notification-card.json'
 
-    function New-StandardTokens {
+    function Get-StandardTokens {
         @{
             severity                 = 'High'
             title                    = 'Test message'
@@ -187,7 +187,7 @@ Describe 'Send-McmTeamsWebhook - happy path' {
 
     It 'returns Success=$true on a successful POST' {
         $result = Send-McmTeamsWebhook -WebhookUrl 'https://outlook.office.com/webhook/x' `
-            -CardTokens (New-StandardTokens) `
+            -CardTokens (Get-StandardTokens) `
             -AdaptiveCardTemplatePath $script:cardPath
         $result.Success | Should -BeTrue
         $result.Error | Should -BeNullOrEmpty
@@ -195,7 +195,7 @@ Describe 'Send-McmTeamsWebhook - happy path' {
 
     It 'sends exactly one POST' {
         Send-McmTeamsWebhook -WebhookUrl 'https://outlook.office.com/webhook/x' `
-            -CardTokens (New-StandardTokens) `
+            -CardTokens (Get-StandardTokens) `
             -AdaptiveCardTemplatePath $script:cardPath | Out-Null
         $script:capturedCalls.Count | Should -Be 1
         $script:capturedCalls[0].Method | Should -Be 'Post'
@@ -204,14 +204,14 @@ Describe 'Send-McmTeamsWebhook - happy path' {
     It 'posts to the supplied webhook URL' {
         $url = 'https://outlook.office.com/webhook/abcdef'
         Send-McmTeamsWebhook -WebhookUrl $url `
-            -CardTokens (New-StandardTokens) `
+            -CardTokens (Get-StandardTokens) `
             -AdaptiveCardTemplatePath $script:cardPath | Out-Null
         $script:capturedCalls[0].Uri | Should -Be $url
     }
 
     It 'sends application/json Content-Type header' {
         Send-McmTeamsWebhook -WebhookUrl 'https://outlook.office.com/webhook/x' `
-            -CardTokens (New-StandardTokens) `
+            -CardTokens (Get-StandardTokens) `
             -AdaptiveCardTemplatePath $script:cardPath | Out-Null
         $script:capturedCalls[0].Headers['Content-Type'] | Should -Match 'application/json'
     }
@@ -231,7 +231,7 @@ Describe 'Send-McmTeamsWebhook - payload shape' {
 
     It 'wraps the card in Teams Workflows envelope (type=message, attachments[])' {
         Send-McmTeamsWebhook -WebhookUrl 'https://x' `
-            -CardTokens (New-StandardTokens) `
+            -CardTokens (Get-StandardTokens) `
             -AdaptiveCardTemplatePath $script:cardPath | Out-Null
 
         $body = $script:capturedCalls[0].Body | ConvertFrom-Json
@@ -245,7 +245,7 @@ Describe 'Send-McmTeamsWebhook - payload shape' {
 
     It 'strips the _comment field from the card body' {
         Send-McmTeamsWebhook -WebhookUrl 'https://x' `
-            -CardTokens (New-StandardTokens) `
+            -CardTokens (Get-StandardTokens) `
             -AdaptiveCardTemplatePath $script:cardPath | Out-Null
 
         $body = $script:capturedCalls[0].Body | ConvertFrom-Json
@@ -256,7 +256,7 @@ Describe 'Send-McmTeamsWebhook - payload shape' {
 
     It 'substitutes standard tokens into the rendered card body' {
         Send-McmTeamsWebhook -WebhookUrl 'https://x' `
-            -CardTokens (New-StandardTokens) `
+            -CardTokens (Get-StandardTokens) `
             -AdaptiveCardTemplatePath $script:cardPath | Out-Null
 
         $script:capturedCalls[0].Body | ConvertFrom-Json | Out-Null
@@ -268,14 +268,14 @@ Describe 'Send-McmTeamsWebhook - payload shape' {
         $rawBody | Should -Match 'MC123456'
         $rawBody | Should -Match '11111111-2222-3333-4444-555555555555'
 
-        foreach ($tokenName in (New-StandardTokens).Keys) {
+        foreach ($tokenName in (Get-StandardTokens).Keys) {
             $rawBody | Should -Not -Match ('\{' + [regex]::Escape($tokenName) + '\}') `
                 -Because "token '{$tokenName}' must be substituted in the rendered payload"
         }
     }
 
     It 'handles a title with embedded double quotes safely' {
-        $tokens = New-StandardTokens
+        $tokens = Get-StandardTokens
         $tokens.title = 'Action required: "MC123" outage'
         Send-McmTeamsWebhook -WebhookUrl 'https://x' `
             -CardTokens $tokens `
@@ -293,7 +293,7 @@ Describe 'Send-McmTeamsWebhook - payload shape' {
     }
 
     It 'handles a title with embedded newlines safely' {
-        $tokens = New-StandardTokens
+        $tokens = Get-StandardTokens
         $tokens.title = "Line A`nLine B"
         Send-McmTeamsWebhook -WebhookUrl 'https://x' `
             -CardTokens $tokens `
@@ -318,7 +318,7 @@ Describe 'Send-McmTeamsWebhook - failure handling (no-throw contract)' {
         $result = $null
         try {
             $result = Send-McmTeamsWebhook -WebhookUrl 'https://x' `
-                -CardTokens (New-StandardTokens) `
+                -CardTokens (Get-StandardTokens) `
                 -AdaptiveCardTemplatePath $script:cardPath
         } catch {
             $threw = $true
@@ -340,7 +340,7 @@ Describe 'Send-McmTeamsWebhook - failure handling (no-throw contract)' {
         $result = $null
         try {
             $result = Send-McmTeamsWebhook -WebhookUrl 'https://x' `
-                -CardTokens (New-StandardTokens) `
+                -CardTokens (Get-StandardTokens) `
                 -AdaptiveCardTemplatePath $script:cardPath
         } catch {
             $threw = $true
@@ -359,7 +359,7 @@ Describe 'Send-McmTeamsWebhook - hard failures (throw)' {
         Mock -CommandName Invoke-McmRest -MockWith { return $null }
         $missing = Join-Path $PSScriptRoot 'definitely-not-a-real-template.json'
         { Send-McmTeamsWebhook -WebhookUrl 'https://x' `
-                -CardTokens (New-StandardTokens) `
+                -CardTokens (Get-StandardTokens) `
                 -AdaptiveCardTemplatePath $missing } | Should -Throw
     }
 }

--- a/message-center-monitor/tests/Upsert.Tests.ps1
+++ b/message-center-monitor/tests/Upsert.Tests.ps1
@@ -47,7 +47,7 @@ BeforeAll {
         'fsi_hasattachments'
     )
 
-    function New-FakeRecord {
+    function Get-FakeRecord {
         # Mirrors the $record hashtable built in Invoke-MessageCenterSync.ps1.
         # Deliberately EXCLUDES admin-owned columns - the function under test
         # relies on this contract.
@@ -66,7 +66,7 @@ BeforeAll {
         }
     }
 
-    function New-FakeHeaders {
+    function Get-FakeHeaders {
         @{
             Authorization      = 'Bearer fake'
             'Content-Type'     = 'application/json'
@@ -76,7 +76,7 @@ BeforeAll {
         }
     }
 
-    function New-McmHttpException {
+    function Get-McmHttpException {
         param([int]$Status, [string]$Message)
         # The function under test inspects the exception MESSAGE for status
         # tokens because Invoke-McmRest rethrows wrapped errors with text like
@@ -104,8 +104,8 @@ Describe 'Invoke-McmDvUpsertMessage - create branch (row does not exist)' {
         $r = Invoke-McmDvUpsertMessage `
             -DataverseBaseUrl 'https://x.crm.dynamics.com/api/data/v9.2' `
             -MessageId 'MC123456' `
-            -Record (New-FakeRecord) `
-            -DataverseHeaders (New-FakeHeaders) `
+            -Record (Get-FakeRecord) `
+            -DataverseHeaders (Get-FakeHeaders) `
             -AssessmentNotAssessedValue 100000000
 
         $r.Action | Should -Be 'Created'
@@ -119,8 +119,8 @@ Describe 'Invoke-McmDvUpsertMessage - create branch (row does not exist)' {
         Invoke-McmDvUpsertMessage `
             -DataverseBaseUrl 'https://x.crm.dynamics.com/api/data/v9.2' `
             -MessageId 'MC123456' `
-            -Record (New-FakeRecord) `
-            -DataverseHeaders (New-FakeHeaders) `
+            -Record (Get-FakeRecord) `
+            -DataverseHeaders (Get-FakeHeaders) `
             -AssessmentNotAssessedValue 100000000 | Out-Null
 
         $body = $script:capturedCalls[0].Body | ConvertFrom-Json -AsHashtable
@@ -131,8 +131,8 @@ Describe 'Invoke-McmDvUpsertMessage - create branch (row does not exist)' {
         Invoke-McmDvUpsertMessage `
             -DataverseBaseUrl 'https://x.crm.dynamics.com/api/data/v9.2' `
             -MessageId 'MC123456' `
-            -Record (New-FakeRecord) `
-            -DataverseHeaders (New-FakeHeaders) `
+            -Record (Get-FakeRecord) `
+            -DataverseHeaders (Get-FakeHeaders) `
             -AssessmentNotAssessedValue 100000000 | Out-Null
 
         $body = $script:capturedCalls[0].Body | ConvertFrom-Json -AsHashtable
@@ -143,26 +143,26 @@ Describe 'Invoke-McmDvUpsertMessage - create branch (row does not exist)' {
 
     It 'URL uses alternate-key OData syntax with single-quote-escaped id' {
         $tricky = "MC'one"
-        $rec = New-FakeRecord
+        $rec = Get-FakeRecord
         $rec.fsi_messagecenterid = $tricky
         Invoke-McmDvUpsertMessage `
             -DataverseBaseUrl 'https://x.crm.dynamics.com/api/data/v9.2' `
             -MessageId $tricky `
             -Record $rec `
-            -DataverseHeaders (New-FakeHeaders) `
+            -DataverseHeaders (Get-FakeHeaders) `
             -AssessmentNotAssessedValue 100000000 | Out-Null
 
         $script:capturedCalls[0].Uri | Should -Match "fsi_messagecenterlogs\(fsi_messagecenterid='MC''one'\)"
     }
 
     It 'does not mutate the caller-provided $Record hashtable' {
-        $rec = New-FakeRecord
+        $rec = Get-FakeRecord
         $beforeKeys = ($rec.Keys | Sort-Object) -join ','
         Invoke-McmDvUpsertMessage `
             -DataverseBaseUrl 'https://x.crm.dynamics.com/api/data/v9.2' `
             -MessageId 'MC123456' `
             -Record $rec `
-            -DataverseHeaders (New-FakeHeaders) `
+            -DataverseHeaders (Get-FakeHeaders) `
             -AssessmentNotAssessedValue 100000000 | Out-Null
 
         $afterKeys = ($rec.Keys | Sort-Object) -join ','
@@ -185,7 +185,7 @@ Describe 'Invoke-McmDvUpsertMessage - update branch (row exists, 412)' {
                 Body    = $Body
             })
             if ($script:invocation -eq 1) {
-                throw (New-McmHttpException -Status 412 -Message 'PreconditionFailed')
+                throw (Get-McmHttpException -Status 412 -Message 'PreconditionFailed')
             }
             return $null
         }
@@ -195,8 +195,8 @@ Describe 'Invoke-McmDvUpsertMessage - update branch (row exists, 412)' {
         $r = Invoke-McmDvUpsertMessage `
             -DataverseBaseUrl 'https://x.crm.dynamics.com/api/data/v9.2' `
             -MessageId 'MC123456' `
-            -Record (New-FakeRecord) `
-            -DataverseHeaders (New-FakeHeaders) `
+            -Record (Get-FakeRecord) `
+            -DataverseHeaders (Get-FakeHeaders) `
             -AssessmentNotAssessedValue 100000000
 
         $r.Action | Should -Be 'Updated'
@@ -207,8 +207,8 @@ Describe 'Invoke-McmDvUpsertMessage - update branch (row exists, 412)' {
         Invoke-McmDvUpsertMessage `
             -DataverseBaseUrl 'https://x.crm.dynamics.com/api/data/v9.2' `
             -MessageId 'MC123456' `
-            -Record (New-FakeRecord) `
-            -DataverseHeaders (New-FakeHeaders) `
+            -Record (Get-FakeRecord) `
+            -DataverseHeaders (Get-FakeHeaders) `
             -AssessmentNotAssessedValue 100000000 | Out-Null
 
         $script:capturedCalls[1].Headers.ContainsKey('If-None-Match') | Should -BeFalse `
@@ -219,8 +219,8 @@ Describe 'Invoke-McmDvUpsertMessage - update branch (row exists, 412)' {
         Invoke-McmDvUpsertMessage `
             -DataverseBaseUrl 'https://x.crm.dynamics.com/api/data/v9.2' `
             -MessageId 'MC123456' `
-            -Record (New-FakeRecord) `
-            -DataverseHeaders (New-FakeHeaders) `
+            -Record (Get-FakeRecord) `
+            -DataverseHeaders (Get-FakeHeaders) `
             -AssessmentNotAssessedValue 100000000 | Out-Null
 
         $body = $script:capturedCalls[1].Body | ConvertFrom-Json -AsHashtable
@@ -235,8 +235,8 @@ Describe 'Invoke-McmDvUpsertMessage - update branch (row exists, 412)' {
         Invoke-McmDvUpsertMessage `
             -DataverseBaseUrl 'https://x.crm.dynamics.com/api/data/v9.2' `
             -MessageId 'MC123456' `
-            -Record (New-FakeRecord) `
-            -DataverseHeaders (New-FakeHeaders) `
+            -Record (Get-FakeRecord) `
+            -DataverseHeaders (Get-FakeHeaders) `
             -AssessmentNotAssessedValue 100000000 | Out-Null
 
         $body = $script:capturedCalls[1].Body | ConvertFrom-Json -AsHashtable
@@ -249,8 +249,8 @@ Describe 'Invoke-McmDvUpsertMessage - update branch (row exists, 412)' {
         Invoke-McmDvUpsertMessage `
             -DataverseBaseUrl 'https://x.crm.dynamics.com/api/data/v9.2' `
             -MessageId 'MC123456' `
-            -Record (New-FakeRecord) `
-            -DataverseHeaders (New-FakeHeaders) `
+            -Record (Get-FakeRecord) `
+            -DataverseHeaders (Get-FakeHeaders) `
             -AssessmentNotAssessedValue 100000000 | Out-Null
 
         $script:capturedCalls[0].Uri | Should -Be $script:capturedCalls[1].Uri
@@ -261,30 +261,30 @@ Describe 'Invoke-McmDvUpsertMessage - failure paths' {
 
     It 'throws a helpful error when alternate key is missing (404)' {
         Mock -CommandName Invoke-McmRest -MockWith {
-            throw (New-McmHttpException -Status 404 -Message 'Resource not found for the segment')
+            throw (Get-McmHttpException -Status 404 -Message 'Resource not found for the segment')
         }
 
         {
             Invoke-McmDvUpsertMessage `
                 -DataverseBaseUrl 'https://x.crm.dynamics.com/api/data/v9.2' `
                 -MessageId 'MC123456' `
-                -Record (New-FakeRecord) `
-                -DataverseHeaders (New-FakeHeaders) `
+                -Record (Get-FakeRecord) `
+                -DataverseHeaders (Get-FakeHeaders) `
                 -AssessmentNotAssessedValue 100000000
         } | Should -Throw -ExpectedMessage '*Alternate key fsi_MessageCenterIdKey not found*'
     }
 
     It 'rethrows on non-412/404 create failures' {
         Mock -CommandName Invoke-McmRest -MockWith {
-            throw (New-McmHttpException -Status 500 -Message 'Internal server error')
+            throw (Get-McmHttpException -Status 500 -Message 'Internal server error')
         }
 
         {
             Invoke-McmDvUpsertMessage `
                 -DataverseBaseUrl 'https://x.crm.dynamics.com/api/data/v9.2' `
                 -MessageId 'MC123456' `
-                -Record (New-FakeRecord) `
-                -DataverseHeaders (New-FakeHeaders) `
+                -Record (Get-FakeRecord) `
+                -DataverseHeaders (Get-FakeHeaders) `
                 -AssessmentNotAssessedValue 100000000
         } | Should -Throw -ExpectedMessage '*Create failed for MC123456*'
     }
@@ -294,17 +294,17 @@ Describe 'Invoke-McmDvUpsertMessage - failure paths' {
         Mock -CommandName Invoke-McmRest -MockWith {
             $script:invocation++
             if ($script:invocation -eq 1) {
-                throw (New-McmHttpException -Status 412 -Message 'PreconditionFailed')
+                throw (Get-McmHttpException -Status 412 -Message 'PreconditionFailed')
             }
-            throw (New-McmHttpException -Status 500 -Message 'Internal server error')
+            throw (Get-McmHttpException -Status 500 -Message 'Internal server error')
         }
 
         {
             Invoke-McmDvUpsertMessage `
                 -DataverseBaseUrl 'https://x.crm.dynamics.com/api/data/v9.2' `
                 -MessageId 'MC123456' `
-                -Record (New-FakeRecord) `
-                -DataverseHeaders (New-FakeHeaders) `
+                -Record (Get-FakeRecord) `
+                -DataverseHeaders (Get-FakeHeaders) `
                 -AssessmentNotAssessedValue 100000000
         } | Should -Throw -ExpectedMessage '*Update failed for MC123456*'
     }

--- a/pipeline-governance-cleanup/scripts/Send-OwnerNotifications.ps1
+++ b/pipeline-governance-cleanup/scripts/Send-OwnerNotifications.ps1
@@ -226,7 +226,7 @@ function Send-GraphEmail {
         [string]$To,
         [string]$Subject,
         [string]$Body,
-        [string]$Sender = ""
+        [string]$SenderAddress = ""
     )
 
     $message = @{
@@ -250,7 +250,7 @@ function Send-GraphEmail {
     # Determine UserId: explicit sender for application permissions; signed-in account for delegated.
     # Send-MgUserMail does NOT accept the literal "me" alias — the underlying Graph route is
     # /users/{id|upn}/sendMail, which rejects "me". Fall back to the authenticated principal.
-    if ([string]::IsNullOrEmpty($Sender)) {
+    if ([string]::IsNullOrEmpty($SenderAddress)) {
         $ctx = Get-MgContext
         if ($null -eq $ctx -or [string]::IsNullOrEmpty($ctx.Account)) {
             Write-Error "No -SenderEmail provided and no signed-in delegated account on Microsoft Graph context."
@@ -259,7 +259,7 @@ function Send-GraphEmail {
         $userId = $ctx.Account
     }
     else {
-        $userId = $Sender
+        $userId = $SenderAddress
     }
 
     $maxRetries = 3
@@ -457,7 +457,7 @@ You may need to manually add owner information to your inventory before sending 
             }
             else {
                 if ($PSCmdlet.ShouldProcess($record.OwnerEmail, "Send notification email")) {
-                    $success = Send-GraphEmail -To $record.OwnerEmail -Subject $subject -Body $body -Sender $SenderEmail
+                    $success = Send-GraphEmail -To $record.OwnerEmail -Subject $subject -Body $body -SenderAddress $SenderEmail
                     if ($success) {
                         $sent++
                         $status = "Sent"

--- a/rag-source-validator/CHANGELOG.md
+++ b/rag-source-validator/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the RAG Source Validator.
 
 ## [Unreleased]
 
+### Changed
+
+- **Operator ergonomics (Wave 6 P4a):** State-changing scripts now support `-WhatIf` and `-Confirm` switches via `SupportsShouldProcess`. Existing callers see no behavior change unless they explicitly pass `-WhatIf`.
+
 ## [1.3.1] - 2026-05-23
 
 ### Council Review -- Production-Readiness Fixes

--- a/rag-source-validator/scripts/Invoke-SourceValidation.ps1
+++ b/rag-source-validator/scripts/Invoke-SourceValidation.ps1
@@ -338,6 +338,7 @@ function Get-KnowledgeSources {
 }
 
 function New-ValidationResult {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param([string]$Environment, [string]$Token, [hashtable]$Result)
 
     $headers = @{
@@ -349,11 +350,15 @@ function New-ValidationResult {
 
     $uri = "$Environment/api/data/v9.2/fsi_validationresults"
     $body = $Result | ConvertTo-Json -Depth 5
+    $target = if ($Result.ContainsKey('fsi_name')) { $Result.fsi_name } else { 'fsi_validationresults' }
 
-    Invoke-RestMethod -Uri $uri -Headers $headers -Method Post -Body $body -MaximumRetryCount 3 -RetryIntervalSec 5 | Out-Null
+    if ($PSCmdlet.ShouldProcess($target, 'Create validation result')) {
+        Invoke-RestMethod -Uri $uri -Headers $headers -Method Post -Body $body -MaximumRetryCount 3 -RetryIntervalSec 5 | Out-Null
+    }
 }
 
 function Update-SourceHash {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [string]$Environment,
         [string]$Token,
@@ -383,10 +388,13 @@ function Update-SourceHash {
     }
     $body = $update | ConvertTo-Json
 
-    Invoke-RestMethod -Uri $uri -Headers $headers -Method Patch -Body $body -MaximumRetryCount 3 -RetryIntervalSec 5 | Out-Null
+    if ($PSCmdlet.ShouldProcess($SourceId, 'Update source hash')) {
+        Invoke-RestMethod -Uri $uri -Headers $headers -Method Patch -Body $body -MaximumRetryCount 3 -RetryIntervalSec 5 | Out-Null
+    }
 }
 
 function Update-SourceStatus {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [string]$Environment,
         [string]$Token,
@@ -407,10 +415,13 @@ function Update-SourceStatus {
         fsi_lastvalidated = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
     } | ConvertTo-Json
 
-    Invoke-RestMethod -Uri $uri -Headers $headers -Method Patch -Body $body -MaximumRetryCount 3 -RetryIntervalSec 5 | Out-Null
+    if ($PSCmdlet.ShouldProcess($SourceId, 'Update source status')) {
+        Invoke-RestMethod -Uri $uri -Headers $headers -Method Patch -Body $body -MaximumRetryCount 3 -RetryIntervalSec 5 | Out-Null
+    }
 }
 
 function New-SourceChange {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [string]$Environment,
         [string]$Token,
@@ -444,7 +455,9 @@ function New-SourceChange {
     $uri = "$Environment/api/data/v9.2/fsi_sourcechanges"
     $body = $change | ConvertTo-Json -Depth 5
 
-    Invoke-RestMethod -Uri $uri -Headers $headers -Method Post -Body $body -MaximumRetryCount 3 -RetryIntervalSec 5 | Out-Null
+    if ($PSCmdlet.ShouldProcess($SourceId, 'Create source change record')) {
+        Invoke-RestMethod -Uri $uri -Headers $headers -Method Post -Body $body -MaximumRetryCount 3 -RetryIntervalSec 5 | Out-Null
+    }
 }
 
 # Main script

--- a/scope-drift-monitor/CHANGELOG.md
+++ b/scope-drift-monitor/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the Scope Drift Monitor.
 
 ## [Unreleased]
 
+### Changed
+
+- **Operator ergonomics (Wave 6 P4a):** State-changing scripts now support `-WhatIf` and `-Confirm` switches via `SupportsShouldProcess`. Existing callers see no behavior change unless they explicitly pass `-WhatIf`.
+
 ## [1.2.2] - 2026-05-23
 
 ### Fixed

--- a/scope-drift-monitor/scripts/Invoke-DriftScan.ps1
+++ b/scope-drift-monitor/scripts/Invoke-DriftScan.ps1
@@ -666,6 +666,7 @@ function New-ViolationRecord {
     .SYNOPSIS
         Creates a violation record in Dataverse.
     #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
         'PSReviewUnusedParameter', '',
         Justification = 'PSScriptAnalyzer requires this rule suppression on the function param block; individual compatibility parameters carry specific justifications.'
@@ -742,6 +743,11 @@ function New-ViolationRecord {
 
     $uri = "$Environment/api/data/v9.2/fsi_scopeviolations"
     $body = $violationRecord | ConvertTo-Json -Depth 5
+    $target = if ($Violation.Resource) { $Violation.Resource } else { 'fsi_scopeviolations' }
+
+    if (-not $PSCmdlet.ShouldProcess($target, 'Create scope violation record')) {
+        return $null
+    }
 
     try {
         $response = Invoke-RestMethod -Uri $uri -Headers $headers -Method Post -Body $body
@@ -834,9 +840,9 @@ $totalViolations = 0
 $violationResults = @()
 $agentsScanned = @{}
 
-foreach ($event in $events) {
-    $eventData = Get-CopilotEventData -Event $event
-    $eventAgentId = Get-CopilotAgentId -Event $event
+foreach ($auditEvent in $events) {
+    $eventData = Get-CopilotEventData -Event $auditEvent
+    $eventAgentId = Get-CopilotAgentId -Event $auditEvent
 
     # Skip if we're filtering for a specific agent and this isn't it.
     if ($AgentId -and -not (Test-AgentIdMatch -EventAgentId $eventAgentId -ExpectedAgentId $AgentId)) {
@@ -852,16 +858,16 @@ foreach ($event in $events) {
     $agentsScanned[$eventAgentId] = $true
 
     # Get scope for this agent; blank EnvironmentId acts as wildcard.
-    $eventEnvId = if ($event.EnvironmentId) { $event.EnvironmentId } elseif ($eventData.EnvironmentId) { $eventData.EnvironmentId } else { $null }
+    $eventEnvId = if ($auditEvent.EnvironmentId) { $auditEvent.EnvironmentId } elseif ($eventData.EnvironmentId) { $eventData.EnvironmentId } else { $null }
     $scope = Get-MatchingScope -Scopes $scopes -EventAgentId $eventAgentId -EventEnvironmentId $eventEnvId
 
     # Compare scope vs actual access
-    $violations = Compare-ScopeVsActual -Event $event -Scope $scope
+    $violations = Compare-ScopeVsActual -Event $auditEvent -Scope $scope
 
     # Create violation records
     foreach ($violation in $violations) {
         $scopeId = if ($scope) { $scope.fsi_agentscopeid } else { $null }
-        $auditRecordId = $event.Id
+        $auditRecordId = $auditEvent.Id
 
         $result = New-ViolationRecord `
             -Environment $Environment `
@@ -869,7 +875,7 @@ foreach ($event in $events) {
             -Violation $violation `
             -ScopeId $scopeId `
             -AuditRecordId $auditRecordId `
-            -UserId $event.UserId
+            -UserId $auditEvent.UserId
 
         if ($result) {
             $totalViolations++

--- a/scope-drift-monitor/scripts/New-AgentBaseline.ps1
+++ b/scope-drift-monitor/scripts/New-AgentBaseline.ps1
@@ -464,8 +464,8 @@ function Get-AccessedResources {
         APIs       = @()
     }
 
-    foreach ($event in $Events) {
-        $eventData = Get-CopilotEventData -Event $event
+    foreach ($auditEvent in $Events) {
+        $eventData = Get-CopilotEventData -Event $auditEvent
 
         # Extract connectors from AISystemPlugin array
         if ($eventData.AISystemPlugin) {
@@ -524,7 +524,7 @@ function Get-AccessedResources {
     return $resources
 }
 
-function New-ScopeFromHistory {
+function Get-ScopeFromHistory {
     <#
     .SYNOPSIS
         Aggregates unique resources from analysis window into scope definition.
@@ -571,6 +571,7 @@ function New-ScopeFromHistory {
 }
 
 function New-ScopeDefinition {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [Parameter(Mandatory = $true)]
         [string]$Environment,
@@ -591,6 +592,11 @@ function New-ScopeDefinition {
 
     $uri = "$Environment/api/data/v9.2/fsi_agentscopes"
     $body = $Scope | ConvertTo-Json -Depth 5
+    $target = if ($Scope.fsi_agentid) { $Scope.fsi_agentid } else { 'fsi_agentscopes' }
+
+    if (-not $PSCmdlet.ShouldProcess($target, 'Create agent scope definition')) {
+        return $null
+    }
 
     try {
         $response = Invoke-RestMethod -Uri $uri -Headers $headers -Method Post -Body $body
@@ -662,7 +668,7 @@ Write-Host "  External APIs: $($resources.APIs.Count) unique"
 # Build scope definition
 Write-Host ""
 Write-Host "Building scope definition..." -ForegroundColor Gray
-$scopeDefinition = New-ScopeFromHistory -Resources $resources -AgentId $AgentId -EnvironmentId $EnvironmentId -OwnerId $OwnerId -Zone $Zone
+$scopeDefinition = Get-ScopeFromHistory -Resources $resources -AgentId $AgentId -EnvironmentId $EnvironmentId -OwnerId $OwnerId -Zone $Zone
 
 if ($events.Count -eq 0) {
     Write-Host "  No audit events found - creating empty baseline" -ForegroundColor Yellow

--- a/segregation-detector/CHANGELOG.md
+++ b/segregation-detector/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Segregation of Duties Detector.
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **Operator ergonomics (Wave 6 P4a):** State-changing scripts now support `-WhatIf` and `-Confirm` switches via `SupportsShouldProcess`. Existing callers see no behavior change unless they explicitly pass `-WhatIf`.
+
+---
+
 ## [1.2.1] - 2026-05-23
 
 ### Fixed

--- a/segregation-detector/scripts/Invoke-SoDScan.ps1
+++ b/segregation-detector/scripts/Invoke-SoDScan.ps1
@@ -345,6 +345,7 @@ function Get-ExistingViolations {
 }
 
 function New-Violation {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [string]$Environment,
         [string]$Token,
@@ -360,6 +361,11 @@ function New-Violation {
 
     $uri = "$Environment/api/data/v9.2/fsi_sodviolations"
     $body = $Violation | ConvertTo-Json -Depth 5
+    $target = if ($Violation.fsi_name) { $Violation.fsi_name } else { 'fsi_sodviolations' }
+
+    if (-not $PSCmdlet.ShouldProcess($target, 'Create SoD violation record')) {
+        return $null
+    }
 
     $response = Invoke-WithRetry { Invoke-RestMethod -Uri $uri -Headers $headers -Method Post -Body $body }
     return $response


### PR DESCRIPTION
## Summary
- Drives `PSUseShouldProcessForStateChangingFunctions` from 28 -> 0 and `PSAvoidAssignmentToAutomaticVariable` from 6 -> 0.
- Adds `SupportsShouldProcess` plus `$PSCmdlet.ShouldProcess(...)` guards around real mutations.
- Renames automatic-variable bindings and non-mutating helper factories that used state-changing verbs.

## ShouldProcess disposition
- Fixed with guarded mutations (18): `New-PublisherRecord` (2), `New-SolutionRecord` (2), `New-AppRecord`, `Set-ReviewerView`, `New-RoleRecord`, `New-CanaryEvent`, `New-DataverseRecord`, `Update-DataverseRecord`, `Set-LabHandoffSecret`, `New-ValidationResult`, `Update-SourceHash`, `Update-SourceStatus`, `New-SourceChange`, `New-ViolationRecord`, `New-ScopeDefinition`, `New-Violation`.
- Renamed non-mutating false-positive helpers (10): token refresh, command text, check-result/test fixtures, scope-payload builder.
- Suppressions: 0.

## ConfirmImpact
- Medium: 18
- High: 0
- Low: 0

## Changelog entries
- agent-intake
- audit-compliance-manager
- cross-solution-integration
- message-center-monitor
- rag-source-validator
- scope-drift-monitor
- segregation-detector

## Validation
- Target PSSA rules remaining: 0
- Full PSSA total: 215 -> 181
- Targeted Pester: `message-center-monitor` Common/TeamsWebhook/Upsert tests, 84 passed