### PR TITLE
chore(powershell): remove 50 dead-store assignments (Wave 6 P4d)

### DIFF
--- a/action-confirmation-auditor/scripts/Get-AgentActionSettings.ps1
+++ b/action-confirmation-auditor/scripts/Get-AgentActionSettings.ps1
@@ -270,7 +270,7 @@ function Get-AgentActionSettings {
                     $contentStr = $component.content
 
                     try {
-                        $componentJson = $contentStr | ConvertFrom-Json -ErrorAction Stop
+                        $contentStr | ConvertFrom-Json -ErrorAction Stop | Out-Null
                     } catch {
                         Write-Verbose "Failed to parse botcomponent content for '$topicName' in bot '$($Bot.name)'"
                         continue
@@ -351,8 +351,6 @@ function Get-AgentActionSettings {
                         }
 
                         # Check for confirmation/approval patterns BEFORE the action node
-                        $precedingText = $contentStr.Substring(0, $actionNode.Position)
-
                         # Look for confirmation patterns in the preceding 2000 characters
                         $lookbackStart = [Math]::Max(0, $actionNode.Position - 2000)
                         $precedingWindow = $contentStr.Substring($lookbackStart, $actionNode.Position - $lookbackStart)

--- a/action-confirmation-auditor/scripts/Start-ActionConfirmationRunbook-MI.ps1
+++ b/action-confirmation-auditor/scripts/Start-ActionConfirmationRunbook-MI.ps1
@@ -133,7 +133,7 @@ try {
     $graphTokenResult = Get-AzAccessToken -ResourceUrl 'https://graph.microsoft.com'
     $dvTokenResult    = Get-AzAccessToken -ResourceUrl $DataverseUrl.TrimEnd('/')
     $graphToken = ConvertFrom-AzAccessTokenValue -TokenValue $graphTokenResult.Token
-    $dvToken    = ConvertFrom-AzAccessTokenValue -TokenValue $dvTokenResult.Token
+    ConvertFrom-AzAccessTokenValue -TokenValue $dvTokenResult.Token | Out-Null
 } catch {
     $errorOutput = @{
         Status   = 'Error'

--- a/action-confirmation-auditor/scripts/Start-ActionConfirmationValidationRunbook.ps1
+++ b/action-confirmation-auditor/scripts/Start-ActionConfirmationValidationRunbook.ps1
@@ -226,9 +226,7 @@ try {
     $environmentNameList = ($scanResult | Select-Object -Property EnvironmentDisplayName -Unique |
         ForEach-Object { $_.EnvironmentDisplayName }) -join ', '
     $violationResults = @($scanResult | Where-Object { -not $_.IsCompliant })
-    $compliantResults = @($scanResult | Where-Object { $_.IsCompliant })
     $violationCount = $violationResults.Count
-    $compliantCount = $compliantResults.Count
 
     # Calculate action totals
     $totalActions = ($scanResult | Measure-Object -Property TotalActions -Sum).Sum

--- a/agent-communication-restriction-detector/scripts/Export-CommViolationEvidence.ps1
+++ b/agent-communication-restriction-detector/scripts/Export-CommViolationEvidence.ps1
@@ -226,8 +226,6 @@ if (-not (Test-Path -Path $OutputDirectory)) {
 
 Write-Host "Authenticating to Dataverse..." -ForegroundColor Cyan
 
-$dataverseScope = "$($DataverseUrl.TrimEnd('/'))/.default"
-
 # Helper to unwrap a token that Az.Accounts >= 2.17 returns as a SecureString.
 # Concatenating a SecureString into a Bearer header produces literal
 # 'Bearer System.Security.SecureString' which Dataverse rejects with HTTP 401.

--- a/agent-communication-restriction-detector/scripts/Start-CommRestrictionValidationRunbook.ps1
+++ b/agent-communication-restriction-detector/scripts/Start-CommRestrictionValidationRunbook.ps1
@@ -328,9 +328,7 @@ try {
     $environmentNameList = ($scanResult | Select-Object -Property EnvironmentDisplayName -Unique |
         ForEach-Object { $_.EnvironmentDisplayName }) -join ', '
     $violationResults = @($scanResult | Where-Object { -not $_.IsCompliant })
-    $compliantResults = @($scanResult | Where-Object { $_.IsCompliant })
     $violationCount = $violationResults.Count
-    $compliantCount = $compliantResults.Count
 
     # Determine overall status from violations
     $criticalCount = @($violationResults | Where-Object { $_.Severity -eq 'Critical' }).Count

--- a/agent-intake/scripts/provision_power_pages.ps1
+++ b/agent-intake/scripts/provision_power_pages.ps1
@@ -59,7 +59,6 @@ $ErrorActionPreference = 'Stop'
 
 $pagesReference = 'https://learn.microsoft.com/en-us/power-platform/developer/cli/reference/pages'
 $authReference = 'https://learn.microsoft.com/en-us/power-platform/developer/cli/reference/auth'
-$powerPagesCliOverview = 'https://learn.microsoft.com/en-us/power-pages/configure/power-platform-cli'
 $solutionRoot = Split-Path $PSScriptRoot -Parent
 $portalDocPath = Join-Path $solutionRoot 'docs\portal-configuration.md'
 $progressiveDocPath = Join-Path $solutionRoot 'docs\maker-form-progressive-disclosure.md'

--- a/agent-intake/scripts/provision_solution_shell.ps1
+++ b/agent-intake/scripts/provision_solution_shell.ps1
@@ -295,7 +295,7 @@ function Test-PacAuthentication {
         return
     }
 
-    $raw = & pac auth who --json 2>&1
+    $null = & pac auth who --json 2>&1
     if ($LASTEXITCODE -eq 0) {
         return
     }

--- a/agent-observability-foundation/scripts/deploy-workbooks.ps1
+++ b/agent-observability-foundation/scripts/deploy-workbooks.ps1
@@ -80,7 +80,6 @@ $ErrorActionPreference = "Stop"
 $SCRIPT_VERSION = "1.0.0"
 
 # ANSI color codes for terminal output
-$COLOR_CYAN = "`e[36m"
 $COLOR_GREEN = "`e[32m"
 $COLOR_RED = "`e[31m"
 $COLOR_YELLOW = "`e[33m"
@@ -195,7 +194,7 @@ function Test-Prerequisites {
     # Check 4: Resource group exists
     Write-Host "  Checking resource group..." -ForegroundColor White
     try {
-        $rg = az group show --name $ResourceGroup 2>$null | ConvertFrom-Json
+        az group show --name $ResourceGroup 2>$null | ConvertFrom-Json | Out-Null
         if ($LASTEXITCODE -ne 0) {
             Write-Host "    ${COLOR_RED}✗ Resource group '$ResourceGroup' not found${COLOR_RESET}"
             Write-Host "    Create: az group create --name $ResourceGroup --location <location>" -ForegroundColor Yellow
@@ -218,7 +217,7 @@ function Test-Prerequisites {
             $aiName = $Matches[3]
             $aiResourceGroup = $Matches[2]
 
-            $appInsights = az monitor app-insights component show --app $aiName --resource-group $aiResourceGroup 2>$null | ConvertFrom-Json
+            az monitor app-insights component show --app $aiName --resource-group $aiResourceGroup 2>$null | ConvertFrom-Json | Out-Null
             if ($LASTEXITCODE -ne 0) {
                 Write-Host "    ${COLOR_RED}✗ Application Insights '$aiName' not found${COLOR_RESET}"
                 Write-Host "    Verify resource ID: $ApplicationInsightsId" -ForegroundColor Yellow

--- a/agent-sharing-access-restriction-detector/scripts/governance/Invoke-SharingComplianceScan.ps1
+++ b/agent-sharing-access-restriction-detector/scripts/governance/Invoke-SharingComplianceScan.ps1
@@ -187,14 +187,13 @@ function Invoke-SharingComplianceScan {
         scope         = 'https://service.powerapps.com/.default'
     }
     try {
-        $tokenResponse = Invoke-RestMethod `
+        Invoke-RestMethod `
             -Uri "https://login.microsoftonline.com/$TenantId/oauth2/v2.0/token" `
             -Method Post `
             -ContentType 'application/x-www-form-urlencoded' `
             -Body $tokenBody `
-            -ErrorAction Stop
+            -ErrorAction Stop | Out-Null
 
-        $accessToken = $tokenResponse.access_token
         Write-Host "  Authentication successful." -ForegroundColor Green
     }
     catch {

--- a/audit-compliance-manager/scripts/AuditComplianceHelpers.Tests.ps1
+++ b/audit-compliance-manager/scripts/AuditComplianceHelpers.Tests.ps1
@@ -13,6 +13,16 @@
     Run with: Invoke-Pester -Path .\AuditComplianceHelpers.Tests.ps1 -Output Detailed
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', 'originalEndpoint',
+    Justification = 'Variable is restored in the AfterEach child scriptblock at line 278; PSSA static analysis misses Pester cross-scope reads.'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', 'originalHeader',
+    Justification = 'Variable is restored in the AfterEach child scriptblock at line 279; PSSA static analysis misses Pester cross-scope reads.'
+)]
+param()
+
 BeforeAll {
     # Import the module under test
     $modulePath = Join-Path $PSScriptRoot 'AuditComplianceHelpers.psm1'

--- a/audit-compliance-manager/scripts/Validators.Tests.ps1
+++ b/audit-compliance-manager/scripts/Validators.Tests.ps1
@@ -14,6 +14,36 @@
     Run with: Invoke-Pester -Path .\Validators.Tests.ps1 -Output Detailed
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', 'validatorFiles',
+    Justification = 'Variable feeds Pester -ForEach discovery at line 65; PSSA static analysis misses Pester discovery scriptblock reads.'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', 'environmentRetentionValidator',
+    Justification = 'Variable feeds Pester -ForEach discovery at line 82; PSSA static analysis misses Pester discovery scriptblock reads.'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', 'unifiedAuditLogValidator',
+    Justification = 'Variable feeds Pester -ForEach discovery at line 91; PSSA static analysis misses Pester discovery scriptblock reads.'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', 'purviewRetentionValidator',
+    Justification = 'Variable feeds Pester -ForEach discovery at line 100; PSSA static analysis misses Pester discovery scriptblock reads.'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', 'mailboxAuditValidator',
+    Justification = 'Variable feeds Pester -ForEach discovery at line 109; PSSA static analysis misses Pester discovery scriptblock reads.'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', 'tenantValidators',
+    Justification = 'Variable feeds Pester -ForEach discovery at line 120; PSSA static analysis misses Pester discovery scriptblock reads.'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', 'privateScripts',
+    Justification = 'Variable feeds Pester -ForEach discovery at line 129; PSSA static analysis misses Pester discovery scriptblock reads.'
+)]
+param()
+
 BeforeDiscovery {
     $validatorRoot = $PSScriptRoot
 

--- a/conditional-access-automation/scripts/Start-CAAValidationRunbook.ps1
+++ b/conditional-access-automation/scripts/Start-CAAValidationRunbook.ps1
@@ -107,6 +107,10 @@
     'PSReviewUnusedParameter', '',
     Justification = 'PSScriptAnalyzer honors this rule at script or function scope; flagged compatibility parameters below include individual justifications.'
 )]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', 'h',
+    Justification = 'Variable is initialized in ForEach-Object -Begin and read in -Process/-End at line 354; PSSA static analysis misses child scriptblock reads.'
+)]
 param(
     [Parameter(Mandatory)]
     [string]$TenantId,

--- a/conditional-access-automation/scripts/Test-PolicyCompliance.ps1
+++ b/conditional-access-automation/scripts/Test-PolicyCompliance.ps1
@@ -303,7 +303,6 @@ foreach ($policy in $fsiPolicies) {
 
     $isEnabled = $policy.State -eq "enabled"
     $isReportOnly = $policy.State -eq "enabledForReportingButNotEnforced"
-    $isDisabled = $policy.State -eq "disabled"
 
     if ($isEnabled -or ($IncludeReportOnly -and $isReportOnly)) {
         $complianceResults.checksPassed++

--- a/content-moderation-monitor/scripts/Start-ModerationValidationRunbook.ps1
+++ b/content-moderation-monitor/scripts/Start-ModerationValidationRunbook.ps1
@@ -266,9 +266,7 @@ try {
     $totalAgents = $scanResult.Count
     $uniqueEnvs = ($scanResult | Select-Object -Property EnvironmentId -Unique).Count
     $violationResults = @($scanResult | Where-Object { -not $_.IsCompliant })
-    $compliantResults = @($scanResult | Where-Object { $_.IsCompliant })
     $violationCount = $violationResults.Count
-    $compliantCount = $compliantResults.Count
 
     # Determine overall status from violations
     $criticalCount = @($violationResults | Where-Object { $_.Severity -eq 'Critical' }).Count
@@ -378,7 +376,6 @@ try {
 
     $driftedAgents = @($driftDetails | Where-Object { $_.HasDrift })
     $hasDrift = $driftedAgents.Count -gt 0
-    $hasAnyFirstRun = @($driftDetails | Where-Object { $_.IsFirstRun }).Count -gt 0
 
     Write-Verbose "Drift detection complete. Agents with drift: $($driftedAgents.Count)"
 

--- a/credential-oversharing-detector/scripts/governance/Export-CredentialEvidence.ps1
+++ b/credential-oversharing-detector/scripts/governance/Export-CredentialEvidence.ps1
@@ -303,8 +303,6 @@ Write-Host "`n  Building evidence package..." -ForegroundColor Cyan
 $exportTimestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 
 # Compute summary statistics
-$severityLabels = @{ 100000000 = 'Critical'; 100000001 = 'High'; 100000002 = 'Medium'; 100000003 = 'Low'; 100000004 = 'Informational' }
-
 $totalViolations = $violations.Count
 $criticalCount = @($violations | Where-Object { $_.fsi_severity -eq 100000000 }).Count
 $highCount = @($violations | Where-Object { $_.fsi_severity -eq 100000001 }).Count

--- a/credential-oversharing-detector/scripts/governance/Get-AgentConnectorScope.ps1
+++ b/credential-oversharing-detector/scripts/governance/Get-AgentConnectorScope.ps1
@@ -193,13 +193,8 @@ if (-not $ClientSecret) { throw "ClientSecret is required. Provide -ClientSecret
 
 Write-Host "  Resolving environment Dataverse URL..." -ForegroundColor Cyan
 
-$ppToken = Get-AccessToken -TenantId $TenantId -ClientId $ClientId `
-    -ClientSecret $ClientSecret -Resource $cloudConfig.PowerPlatform
-
-$ppHeaders = @{
-    "Authorization" = "Bearer $ppToken"
-    "Content-Type"  = "application/json"
-}
+Get-AccessToken -TenantId $TenantId -ClientId $ClientId `
+    -ClientSecret $ClientSecret -Resource $cloudConfig.PowerPlatform | Out-Null
 
 # Authenticate the Power Apps Administration module so Get-AdminPowerAppEnvironment
 # resolves under unattended (service principal) execution.

--- a/credential-oversharing-detector/scripts/governance/Invoke-CredentialScan.ps1
+++ b/credential-oversharing-detector/scripts/governance/Invoke-CredentialScan.ps1
@@ -238,13 +238,8 @@ if (-not (Test-Path $policyScriptPath)) {
 
 Write-Host "`n  Authenticating to Power Platform Admin API..." -ForegroundColor Cyan
 
-$ppToken = Get-AccessToken -TenantId $TenantId -ClientId $ClientId `
-    -ClientSecret $ClientSecret -Resource $cloudConfig.PowerPlatform
-
-$ppHeaders = @{
-    "Authorization" = "Bearer $ppToken"
-    "Content-Type"  = "application/json"
-}
+Get-AccessToken -TenantId $TenantId -ClientId $ClientId `
+    -ClientSecret $ClientSecret -Resource $cloudConfig.PowerPlatform | Out-Null
 
 # Authenticate the Power Apps Administration module so Get-AdminPowerAppEnvironment
 # works in unattended (service principal) mode. Without this the cmdlet falls back

--- a/deny-event-correlation-report/scripts/Export-DlpCopilotEvents.ps1
+++ b/deny-event-correlation-report/scripts/Export-DlpCopilotEvents.ps1
@@ -198,7 +198,6 @@ function ConvertTo-CopilotDlpEvent {
                 $policyNames = ($auditData.PolicyDetails | ForEach-Object { $_.PolicyName }) -join "; "
                 $ruleNames = ($auditData.PolicyDetails.Rules | ForEach-Object { $_.RuleName }) -join "; "
                 $actions = ($auditData.PolicyDetails.Rules | ForEach-Object { $_.Actions } | Select-Object -Unique) -join "; "
-                $severities = ($auditData.PolicyDetails.Rules | ForEach-Object { $_.Severity } | Select-Object -Unique) -join "; "
 
                 # Extract sensitive information types
                 $sitMatches = ($auditData.SensitiveInfoTypeData | ForEach-Object {

--- a/dr-testing-framework/scripts/Export-DREvidence.ps1
+++ b/dr-testing-framework/scripts/Export-DREvidence.ps1
@@ -233,11 +233,6 @@ if ($HasDataverseAuth) {
                 }
             })
 
-            # Test-type names accept both v1.x legacy values and v2.0.0 names
-            $allTestTypes = @(
-                "AgentReadinessCheck","EnvironmentReachabilityCheck","DataverseAccessCheck","FullValidation",
-                "AgentRestore","EnvironmentFailover","DataRecovery","FullDR"
-            )
             $executedTypes = @($testResults | ForEach-Object { $_.TestType } | Sort-Object -Unique)
             # Collapse legacy names to their v2 equivalents for "missing" detection
             $aliasMap = @{

--- a/dr-testing-framework/scripts/Invoke-DRTest.Tests.ps1
+++ b/dr-testing-framework/scripts/Invoke-DRTest.Tests.ps1
@@ -12,6 +12,10 @@
     'PSReviewUnusedParameter', '',
     Justification = 'Pester test doubles in this file mirror mocked command signatures; unused parameters satisfy the signature contract, not the test body.'
 )]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', 'scriptContent',
+    Justification = 'Variable is initialized in Pester BeforeAll and referenced by child It scriptblocks starting at line 441; PSSA static analysis misses Pester cross-scope reads.'
+)]
 param()
 
 <#

--- a/dr-testing-framework/scripts/Invoke-DRTest.ps1
+++ b/dr-testing-framework/scripts/Invoke-DRTest.ps1
@@ -448,7 +448,7 @@ function Test-EnvironmentReachability {
                 Write-AuditLog "Dataverse connectivity confirmed (Org: $orgId)"
                 $result.ValidationChecks += @{Check = "Environment Accessible"; Status = "PASS"; Detail = "Dataverse WhoAmI succeeded (OrgId: $orgId)"}
             } else {
-                $sdResp = Invoke-WebRequest -Uri "$Environment/api/data/v9.2/" -UseBasicParsing -TimeoutSec 15 -ErrorAction Stop
+                Invoke-WebRequest -Uri "$Environment/api/data/v9.2/" -UseBasicParsing -TimeoutSec 15 -ErrorAction Stop | Out-Null
                 $result.ValidationChecks += @{Check = "Environment Accessible"; Status = "PASS"; Detail = "OData service document reachable (full check requires credentials)"}
             }
         } catch {
@@ -588,7 +588,7 @@ function Test-DataverseAccess {
             if ($dvHeaders) {
                 # Confirm the DR test results table is queryable
                 $dataUri = "$Environment/api/data/v9.2/fsi_drtestresults?`$select=fsi_drtestresultid&`$top=1"
-                $dataResp = Invoke-RestMethod -Uri $dataUri -Headers $dvHeaders -Method Get -ContentType "application/json" -TimeoutSec 30
+                Invoke-RestMethod -Uri $dataUri -Headers $dvHeaders -Method Get -ContentType "application/json" -TimeoutSec 30 | Out-Null
                 $dataAvailMs = [math]::Round(((Get-Date) - $startTime).TotalMilliseconds, 0)
                 Write-AuditLog "Data table accessible in ${dataAvailMs}ms"
                 $result.ValidationChecks += @{Check = "Evidence Table Accessible"; Status = "PASS"; Detail = "DR results table accessible (${dataAvailMs}ms)"}

--- a/file-upload-security/scripts/Start-FileUploadValidationRunbook.ps1
+++ b/file-upload-security/scripts/Start-FileUploadValidationRunbook.ps1
@@ -244,7 +244,6 @@ try {
     $uniqueEnvs = ($scanResult | Select-Object -Property EnvironmentId -Unique).Count
     $fileUploadEnabledCount = @($scanResult | Where-Object { $_.FileUploadEnabled -eq $true }).Count
     $violationResults = @($scanResult | Where-Object { -not $_.IsCompliant })
-    $compliantResults = @($scanResult | Where-Object { $_.IsCompliant })
     $violationCount = $violationResults.Count
 
     # Determine overall status from violations

--- a/file-upload-security/scripts/private/FUSClient.psm1
+++ b/file-upload-security/scripts/private/FUSClient.psm1
@@ -528,6 +528,10 @@ function Save-FUSBaseline {
     .SYNOPSIS
         Saves a file upload baseline record to Dataverse.
     #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSReviewUnusedParameter', 'RawJson',
+        Justification = 'Parameter is retained for backward-compatible callers; the current Dataverse baseline schema does not persist raw JSON.'
+    )]
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]
@@ -590,7 +594,6 @@ function Save-FUSBaseline {
         # Create new active baseline
         $timestamp = (Get-Date).ToUniversalTime().ToString('o')
         $capturedByValue = if ($CapturedBy) { $CapturedBy } else { "System" }
-        $rawJsonValue = if ($RawJson) { $RawJson } else { "" }
 
         $record = @{
             fsi_name                  = "$AgentName-$Zone-$timestamp"

--- a/generative-ai-config-auditor/scripts/Start-GenAIConfigValidationRunbook.ps1
+++ b/generative-ai-config-auditor/scripts/Start-GenAIConfigValidationRunbook.ps1
@@ -394,9 +394,7 @@ try {
     $environmentNameList = ($scanResult | Select-Object -Property EnvironmentDisplayName -Unique |
         ForEach-Object { $_.EnvironmentDisplayName }) -join ', '
     $violationResults = @($scanResult | Where-Object { -not $_.IsCompliant })
-    $compliantResults = @($scanResult | Where-Object { $_.IsCompliant })
     $violationCount = $violationResults.Count
-    $compliantCount = $compliantResults.Count
 
     # Determine overall status from violations
     $criticalCount = @($violationResults | Where-Object { $_.Severity -eq 'Critical' }).Count
@@ -530,7 +528,6 @@ try {
 
     $driftedAgents = @($driftDetails | Where-Object { $_.HasDrift })
     $hasDrift = $driftedAgents.Count -gt 0
-    $hasAnyFirstRun = @($driftDetails | Where-Object { $_.IsFirstRun }).Count -gt 0
 
     Write-Verbose "Drift detection complete. Agents with drift: $($driftedAgents.Count)"
 

--- a/hitl-workflow-governance/scripts/Get-AgentHitlSettings.ps1
+++ b/hitl-workflow-governance/scripts/Get-AgentHitlSettings.ps1
@@ -268,7 +268,7 @@ function Get-AgentHitlSettings {
                     $contentStr = $component.content
 
                     try {
-                        $componentJson = $contentStr | ConvertFrom-Json -ErrorAction Stop
+                        $contentStr | ConvertFrom-Json -ErrorAction Stop | Out-Null
                     } catch {
                         Write-Verbose "Failed to parse botcomponent content for '$flowName' in bot '$($Bot.name)'"
                         continue

--- a/hitl-workflow-governance/scripts/Start-HitlValidationRunbook.ps1
+++ b/hitl-workflow-governance/scripts/Start-HitlValidationRunbook.ps1
@@ -225,13 +225,10 @@ try {
     $environmentNameList = ($scanResult | Select-Object -Property EnvironmentName -Unique |
         ForEach-Object { $_.EnvironmentName }) -join ', '
     $violationResults = @($scanResult | Where-Object { -not $_.IsCompliant })
-    $compliantResults = @($scanResult | Where-Object { $_.IsCompliant })
     $violationCount = $violationResults.Count
-    $compliantCount = $compliantResults.Count
 
     # Calculate flow totals
     $totalFlows = ($scanResult | Measure-Object -Property TotalFlows -Sum).Sum
-    $totalMissingHitl = ($scanResult | Measure-Object -Property FlowsMissingHitl -Sum).Sum
 
     # Determine overall status from violations
     $criticalCount = @($violationResults | Where-Object { $_.Severity -eq 'Critical' }).Count
@@ -261,7 +258,6 @@ try {
 
     $driftDetails = @()
     $globalIsFirstRun = $false
-    $previousScanFailed = $false
     $auditControlBypass = $false
 
     # Query the most recent scan run from Dataverse
@@ -315,7 +311,6 @@ try {
         # Fail closed on previous-scan query failure to surface AuditControlBypass
         # rather than silently skipping drift detection.
         Write-Warning "Previous scan query failed: $($_.Exception.Message). Marking run as Inconclusive (drift detection unavailable)."
-        $previousScanFailed = $true
         $globalIsFirstRun = $true
         $auditControlBypass = $true
     }

--- a/hitl-workflow-governance/scripts/governance/Test-HitlCheckpointConfiguration.ps1
+++ b/hitl-workflow-governance/scripts/governance/Test-HitlCheckpointConfiguration.ps1
@@ -629,7 +629,6 @@ function Test-HitlCheckpointConfiguration {
 
     $compliantAgents = @($results | Where-Object { $_.IsCompliant })
     $violationAgents = @($results | Where-Object { -not $_.IsCompliant })
-    $advisoryAgents = @($results | Where-Object { $_.IsCompliant -and $_.ViolationType -like 'Advisory*' })
 
     $criticalCount = @($violationAgents | Where-Object { $_.Severity -eq 'Critical' }).Count
     $highCount     = @($violationAgents | Where-Object { $_.Severity -eq 'High' }).Count

--- a/hitl-workflow-governance/scripts/private/Get-HWGValidationResults.ps1
+++ b/hitl-workflow-governance/scripts/private/Get-HWGValidationResults.ps1
@@ -102,16 +102,6 @@ $intToCheckpointType = @{
     100000004 = 'NotApplicable'
 }
 
-$intToActionCategory = @{
-    100000000 = 'Write'
-    100000001 = 'Financial'
-    100000002 = 'ExternalSharing'
-    100000003 = 'PiiProcessing'
-    100000004 = 'CustomerFacing'
-    100000005 = 'InternalReadOnly'
-    100000006 = 'Unknown'
-}
-
 $baseUrl = $DataverseUrl.TrimEnd('/')
 
 $headers = @{

--- a/message-center-monitor/lab/01_New-AppRegistration.ps1
+++ b/message-center-monitor/lab/01_New-AppRegistration.ps1
@@ -132,7 +132,6 @@ try {
     if ($existingApp) {
         $app = $existingApp | Select-Object -First 1
         Write-LabLog -Level Info -Message "App reg '$appName' already exists (objectId=$($app.Id), appId=$($app.AppId)). Reusing."
-        $appCreated = $false
     } else {
         Write-LabLog -Level Info -Message "Creating app reg '$appName'..."
         if ($PSCmdlet.ShouldProcess($appName, 'New-MgApplication')) {
@@ -151,7 +150,6 @@ try {
                 )
             }
             $app = New-MgApplication -BodyParameter $appBody -ErrorAction Stop
-            $appCreated = $true
         }
     }
 

--- a/message-center-monitor/lab/06_Invoke-LabSmokeTest.ps1
+++ b/message-center-monitor/lab/06_Invoke-LabSmokeTest.ps1
@@ -292,7 +292,6 @@ try {
 } catch { Add-Failure 'Step9' $_.Exception.Message }
 
 # ---------- Step 10: Manual cloud-flow gate ---------------------------------
-$manualOutcome = 'skipped'
 $manualBy      = $null
 if ($SkipManualGate) {
     Write-LabLog -Level Warn -Message "[Step 10/10] SKIPPED (-SkipManualGate). Production readiness REQUIRES this validation."
@@ -310,9 +309,9 @@ if ($SkipManualGate) {
     Write-Host ""
     $resp = Read-Host "Did the cloud flow pass all checks? (y/n/skip)"
     switch ($resp.ToLower()) {
-        'y' { $manualOutcome = 'pass'; $manualBy = $cfg.operator.runnerUpn; Write-LabLog -Level Info -Message "  Manual gate: PASS by $manualBy" }
-        'n' { $manualOutcome = 'fail'; $manualBy = $cfg.operator.runnerUpn; Add-Failure 'Step10' "Engineer reported cloud flow validation FAILED. Fix the flow per docs/flow-configuration.md before declaring lab dry-run complete." }
-        default { $manualOutcome = 'skipped'; Write-LabLog -Level Warn -Message "  Manual gate: SKIPPED" }
+        'y' { $manualBy = $cfg.operator.runnerUpn; Write-LabLog -Level Info -Message "  Manual gate: PASS by $manualBy" }
+        'n' { $manualBy = $cfg.operator.runnerUpn; Add-Failure 'Step10' "Engineer reported cloud flow validation FAILED. Fix the flow per docs/flow-configuration.md before declaring lab dry-run complete." }
+        default { Write-LabLog -Level Warn -Message "  Manual gate: SKIPPED" }
     }
 }
 

--- a/message-center-monitor/tests/TeamsWebhook.Tests.ps1
+++ b/message-center-monitor/tests/TeamsWebhook.Tests.ps1
@@ -259,7 +259,7 @@ Describe 'Send-McmTeamsWebhook - payload shape' {
             -CardTokens (New-StandardTokens) `
             -AdaptiveCardTemplatePath $script:cardPath | Out-Null
 
-        $body = $script:capturedCalls[0].Body | ConvertFrom-Json
+        $script:capturedCalls[0].Body | ConvertFrom-Json | Out-Null
         # The serialized body string must contain the substituted concrete
         # values, and must NOT contain any unsubstituted {tokenName}
         # placeholders from the template's standard token vocabulary.

--- a/scripts/Invoke-CopilotStudioBenchmark.ps1
+++ b/scripts/Invoke-CopilotStudioBenchmark.ps1
@@ -548,8 +548,6 @@ foreach ($r in $results) {
         'Skipped' { 'DarkGray' }
     }
 
-    $line = $headerFormat -f $r.CheckId, $r.CheckName, '', $r.ViolationCount, $r.Duration
-    $statusStart = $line.IndexOf('        ') + 6
     Write-Host ("  {0,-4} {1,-50} " -f $r.CheckId, $r.CheckName) -NoNewline
     Write-Host ("{0,-8} " -f $rowStatus) -ForegroundColor $statusColor -NoNewline
     Write-Host ("{0,-12} {1,-10}" -f $r.ViolationCount, $r.Duration) -ForegroundColor Gray

--- a/segregation-detector/scripts/Import-ConflictRules.ps1
+++ b/segregation-detector/scripts/Import-ConflictRules.ps1
@@ -345,7 +345,7 @@ function Import-Rule {
     $body = $Rule | ConvertTo-Json -Depth 5
 
     try {
-        $response = Invoke-WithRetry { Invoke-RestMethod -Uri $uri -Headers $headers -Method Post -Body $body }
+        Invoke-WithRetry { Invoke-RestMethod -Uri $uri -Headers $headers -Method Post -Body $body } | Out-Null
         return @{ Success = $true; Rule = $Rule.fsi_name }
     } catch {
         return @{ Success = $false; Rule = $Rule.fsi_name; Error = $_.Exception.Message }

--- a/session-security-configurator/scripts/Test-SessionCompliance.ps1
+++ b/session-security-configurator/scripts/Test-SessionCompliance.ps1
@@ -340,7 +340,7 @@ Write-Host ""
 
 # Connect to Microsoft Graph
 try {
-    $graphContext = Connect-GraphSession @authParams
+    Connect-GraphSession @authParams | Out-Null
 }
 catch {
     Write-Error "Failed to connect to Microsoft Graph: $($_.Exception.Message)"

--- a/unrestricted-agent-sharing-detector/scripts/governance/Test-AgentSharingCompliance.ps1
+++ b/unrestricted-agent-sharing-detector/scripts/governance/Test-AgentSharingCompliance.ps1
@@ -990,16 +990,7 @@ function Test-AgentSharingCompliance {
                 @{Label='Sharing'; Expression={$_.SharingScope}; Width=15},
                 @{
                     Label='Severity'
-                    Expression={
-                        $sev = $_.Severity
-                        $color = switch ($sev) {
-                            'Critical' { 'Red' }
-                            'High'     { 'DarkYellow' }
-                            'Medium'   { 'Yellow' }
-                            default    { 'White' }
-                        }
-                        $sev
-                    }
+                    Expression={$_.Severity}
                     Width=10
                 },
                 @{Label='Remediated'; Expression={if ($_.RemediatedAt) { 'Yes' } else { 'No' }}; Width=10}


### PR DESCRIPTION
## Summary
- Clears Wave 6 Phase 4d dead-store cleanup: PSUseDeclaredVarsMoreThanAssignments now reports 0 hits.
- Disposition: removed 25 truly orphaned assignments, removed 14 assignments while preserving side-effecting/validation calls with output discarded, and suppressed 11 PSSA false positives for Pester/child-scriptblock cross-scope reads.
- Preserved command side effects for token acquisition, REST/POST calls, CLI validation, Graph connection, JSON parse validation, and reachability checks.

## Validation
- Dead-store PSSA rule count: 0
- Full PSSA total: 165 (was 215)
- Parsed 35 changed PowerShell files successfully with System.Management.Automation.Language.Parser.ParseFile
- git diff --check