### PR TITLE
chore(agent-observability-foundation): track deferred Q2 monitoring-analytics items (#158)

### DIFF
--- a/agent-observability-foundation/templates/diagnostic-settings.json
+++ b/agent-observability-foundation/templates/diagnostic-settings.json
@@ -5,7 +5,7 @@
     "description": "ARM template for configuring Diagnostic Settings to export Application Insights logs to StorageV2 storage (hierarchical namespace disabled) for long-term SEC 17a-4 retention.",
     "version": "0.1.1",
     "lastUpdated": "2026-Q2",
-    "apiVersionNote": "Microsoft Learn diagnostic-settings ARM/Bicep samples currently use Microsoft.Insights/diagnosticSettings@2021-05-01-preview; retain this supported preview API until a stable replacement is published."
+    "apiVersionNote": "Microsoft Learn diagnostic-settings ARM/Bicep samples currently use Microsoft.Insights/diagnosticSettings@2021-05-01-preview; retain this supported preview API until a stable replacement is published. Tracked as deferred item D1 in #158."
   },
   "parameters": {
     "appInsightsName": {


### PR DESCRIPTION
## Summary

Cross-references deferred item D1 in the diagnostic-settings.json template metadata, linking to issue #158 which is the durable tracking record for all three deferred Q2 monitoring-analytics adoption items from umbrella #127.

### Deferred items tracked by #158

| ID | Item | Trigger for re-evaluation |
|----|------|--------------------------|
| D1 | \Microsoft.Insights/diagnosticSettings@2021-05-01-preview\ remains preview | GA API version published |
| D2 | Azure AI Foundry / Content Safety evaluation integration | Approved use case + data-handling review |
| D3 | PRs #98, #104 had no adoption callouts | Upstream #95 / #101 surfaces concrete pattern |

### What changed

- Updated \gent-observability-foundation/templates/diagnostic-settings.json\ \piVersionNote\ to reference #158 as the tracking issue for the preview API deferral (D1).

### Acceptance criteria (from #158)

- [x] Defer rationale for D1, D2, D3 recorded in durable issue (#158)
- [x] Each defer includes concrete trigger for re-evaluation
- [x] Future monitoring-analytics adoption work filed as scoped issues (not reopening #127)

Closes #158