### PR TITLE
fix: update retired framework paths in 9 solution READMEs

### DIFF
--- a/agent-365-lifecycle-governance/README.md
+++ b/agent-365-lifecycle-governance/README.md
@@ -208,13 +208,13 @@ FSI organizations should use the Agentic CoE for tenant-level visibility and gen
 
 ## Related Controls
 
-- [Control 2.3 — Change Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/2.3-change-management.md)
-- [Control 1.2 — Agent Registry](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/1.2-agent-registry.md)
-- [Control 1.11 — Conditional Access](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/1.11-conditional-access.md)
-- [Control 2.1 — Managed Environments](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/2.1-managed-environments.md)
-- [Control 2.8 — Access Control](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/2.8-access-control.md)
-- [Control 2.12 — Supervision](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/2.12-supervision.md)
-- [Control 3.1 — Audit Logging](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/3.1-audit-logging.md)
+- [Control 2.3 — Change Management and Release Planning](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.3-change-management-and-release-planning.md)
+- [Control 1.2 — Agent Registry and Integrated Apps Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.2-agent-registry-and-integrated-apps-management.md)
+- [Control 1.11 — Conditional Access and Phishing-Resistant MFA](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.11-conditional-access-and-phishing-resistant-mfa.md)
+- [Control 2.1 — Managed Environments](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.1-managed-environments.md)
+- [Control 2.8 — Access Control and Segregation of Duties](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.8-access-control-and-segregation-of-duties.md)
+- [Control 2.12 — Supervision and Oversight (FINRA Rule 3110)](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.12-supervision-and-oversight-finra-rule-3110.md)
+- [Control 3.1 — Agent Inventory and Metadata Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-3-reporting/3.1-agent-inventory-and-metadata-management.md)
 
 ## Version
 

--- a/agent-knowledge-source-scanner/README.md
+++ b/agent-knowledge-source-scanner/README.md
@@ -290,9 +290,9 @@ The CSV report includes these columns:
 
 | Control | Description | Relationship |
 |---------|-------------|--------------|
-| [4.3 - SharePoint Oversharing Prevention](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-4-sharepoint/4.3-sharepoint-oversharing-prevention-for-agents.md) | Prevent agents from accessing overshared content | Primary |
-| [1.4 - Data Boundary Enforcement](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.4-data-boundary-enforcement.md) | Enforce data boundaries for agent access | Related |
-| [1.5 - DLP Policy Application](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.5-dlp-policy-application.md) | Apply DLP policies to agent data access | Related |
+| [4.3 - Site and Document Retention Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-4-sharepoint/4.3-site-and-document-retention-management.md) | Prevent agents from accessing overshared content | Primary |
+| [1.4 - Advanced Connector Policies (ACP)](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.4-advanced-connector-policies-acp.md) | Enforce data boundaries for agent access | Related |
+| [1.5 - DLP and Sensitivity Labels](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.5-data-loss-prevention-dlp-and-sensitivity-labels.md) | Apply DLP policies to agent data access | Related |
 
 ## Regulatory Context
 

--- a/agent-registry-automation/README.md
+++ b/agent-registry-automation/README.md
@@ -207,9 +207,9 @@ Follow the step-by-step instructions in [Flow Configuration](docs/flow-configura
 | Control | Relationship |
 |---------|--------------|
 | [1.2 — Agent Registry and Integrated Apps Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.2-agent-registry-and-integrated-apps-management.md) | Primary — centralized agent inventory |
-| [1.7 — Comprehensive Audit Logging](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-monitoring.md) | Secondary — immutable compliance event log |
-| [2.1 — Managed Environments](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-governance/2.1-managed-environments-for-power-platform.md) | Secondary — environment governance |
-| [2.13 — Documentation and Record Keeping](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-governance/2.13-documentation-and-record-keeping.md) | Secondary — ownership and lifecycle records |
+| [1.7 — Comprehensive Audit Logging and Compliance](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md) | Secondary — immutable compliance event log |
+| [2.1 — Managed Environments](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.1-managed-environments.md) | Secondary — environment governance |
+| [2.13 — Documentation and Record Keeping](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.13-documentation-and-record-keeping.md) | Secondary — ownership and lifecycle records |
 
 ## Platform Update Notes
 

--- a/compliance-dashboard/README.md
+++ b/compliance-dashboard/README.md
@@ -335,7 +335,7 @@ This section documents limitations and design decisions for the v1.0.x release.
 |---------|--------------|
 | [3.1 - Agent Inventory](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-3-reporting/3.1-agent-inventory-and-metadata-management.md) | Agent count metrics |
 | [3.2 - Usage Analytics](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-3-reporting/3.2-usage-analytics-and-activity-monitoring.md) | Usage trend data |
-| [3.3 - Compliance Reporting](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-3-reporting/3.3-compliance-reporting-and-attestation.md) | Aggregated compliance reporting |
+| [3.3 - Compliance and Regulatory Reporting](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-3-reporting/3.3-compliance-and-regulatory-reporting.md) | Aggregated compliance reporting |
 | [3.4 - Incident Reporting](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-3-reporting/3.4-incident-reporting-and-root-cause-analysis.md) | Exception correlation |
 
 ## Rollback and Uninstall

--- a/conditional-access-automation/README.md
+++ b/conditional-access-automation/README.md
@@ -447,9 +447,9 @@ See [docs/troubleshooting.md](./docs/troubleshooting.md) for complete error reco
 
 This solution supports:
 
-- [Control 1.11: Conditional Access and MFA](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.11-conditional-access-and-mfa.md)
-- [Control 1.23: Step-Up Authentication](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.23-step-up-authentication-for-high-risk-operations.md)
-- [Control 1.18: Application-Level RBAC](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.18-application-level-rbac.md)
+- [Control 1.11: Conditional Access and Phishing-Resistant MFA](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.11-conditional-access-and-phishing-resistant-mfa.md)
+- [Control 1.23: Step-Up Authentication for Agent Operations](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.23-step-up-authentication-for-agent-operations.md)
+- [Control 1.18: Application-Level Authorization and RBAC](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.18-application-level-authorization-and-role-based-access-control-rbac.md)
 
 ## Playbook Reference
 

--- a/deny-event-correlation-report/README.md
+++ b/deny-event-correlation-report/README.md
@@ -158,7 +158,7 @@ This solution implements the [Deny Event Correlation Report](https://github.com/
 
 - [Control 1.5: DLP and Sensitivity Labels](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.5-data-loss-prevention-dlp-and-sensitivity-labels.md)
 - [Control 1.7: Comprehensive Audit Logging](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md)
-- [Control 1.8: Content Moderation](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.8-content-moderation-and-responsible-ai.md)
+- [Control 1.8: Runtime Protection and External Threat Detection](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.8-runtime-protection-and-external-threat-detection.md)
 - [Control 3.4: Incident Reporting](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-3-reporting/3.4-incident-reporting-and-root-cause-analysis.md)
 
 ## Support

--- a/model-risk-management-automation/README.md
+++ b/model-risk-management-automation/README.md
@@ -224,9 +224,9 @@ Review and complete all items in [DELIVERY-CHECKLIST.md](DELIVERY-CHECKLIST.md) 
 
 | Control | Relationship |
 |---------|--------------|
-| [2.6 — Model Risk Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management.md) | Primary — model inventory, risk scoring, validation workflow |
+| [2.6 — Model Risk Management (SR 26-2)](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md) | Primary — model inventory, risk scoring, validation workflow |
 | [2.5 — Testing, Validation, and Quality Assurance](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.5-testing-validation-and-quality-assurance.md) | Secondary — independent validation cycles |
-| [2.9 — Agent Performance Monitoring](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.9-agent-performance-monitoring.md) | Secondary — ongoing monitoring with threshold detection |
+| [2.9 — Agent Performance Monitoring and Optimization](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.9-agent-performance-monitoring-and-optimization.md) | Secondary — ongoing monitoring with threshold detection |
 | [2.11 — Bias Testing and Fairness Assessment](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.11-bias-testing-and-fairness-assessment.md) | Secondary — finding category includes Bias/Fairness |
 | [2.13 — Documentation and Record Keeping](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.13-documentation-and-record-keeping.md) | Secondary — Agent Cards and immutable compliance events |
 | [3.1 — Agent Inventory and Metadata Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-3-reporting/3.1-agent-inventory-and-metadata-management.md) | Secondary — fsi_modelinventory + fsi_mrmcomplianceevent provide MRM-scoped inventory and metadata |

--- a/scope-drift-monitor/README.md
+++ b/scope-drift-monitor/README.md
@@ -237,8 +237,8 @@ If Denied: Remediate Access → Close Violation
 
 | Control | Relationship |
 |---------|--------------|
-| [1.14 - Data Loss Prevention](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.14-data-loss-prevention.md) | Detective scope-drift monitoring complements preventive DLP policy enforcement |
-| [1.4 - Advanced Connector Policies](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.4-advanced-connector-policies-for-copilot-studio.md) | Provides monitoring evidence for connector classification (this solution does not block connectors) |
+| [1.14 - Data Minimization and Agent Scope Control](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.14-data-minimization-and-agent-scope-control.md) | Detective scope-drift monitoring complements preventive DLP policy enforcement |
+| [1.4 - Advanced Connector Policies (ACP)](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.4-advanced-connector-policies-acp.md) | Provides monitoring evidence for connector classification (this solution does not block connectors) |
 | [1.5 - DLP and Sensitivity Labels](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.5-data-loss-prevention-dlp-and-sensitivity-labels.md) | Provides monitoring evidence for sensitive-data access (row-level / column-level enforcement is not implemented) |
 
 ## Known Limitations

--- a/segregation-detector/README.md
+++ b/segregation-detector/README.md
@@ -293,7 +293,7 @@ For supervision queue assignments:
 
 | Control | Relationship |
 |---------|--------------|
-| [2.8 - Segregation of Duties](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.8-segregation-of-duties.md) | Primary — role conflict detection supporting Maker/Checker controls |
+| [2.8 - Access Control and Segregation of Duties](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.8-access-control-and-segregation-of-duties.md) | Primary — role conflict detection supporting Maker/Checker controls |
 | [2.1 - Managed Environments](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.1-managed-environments.md) | Environment role context |
 | [2.3 - Change Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.3-change-management-and-release-planning.md) | Pipeline integration |
 


### PR DESCRIPTION
## Summary

Fixes FSI-AgentGov framework finding U-051 (P2). Updates 22 broken framework control links across 9 solution READMEs to match the canonical paths at framework v1.6.2.

## Changes by Solution

| Solution | Fixes | Issue |
|----------|-------|-------|
| agent-365-lifecycle-governance | 7 links — added missing pillar subdirectory, expanded short filenames | Missing `pillar-X-*/` path segments |
| agent-registry-automation | 3 links — `pillar-2-governance` → `pillar-2-management`, fixed 1.7 filename | Wrong pillar name, wrong filename suffix |
| conditional-access-automation | 3 links — fixed 1.11, 1.23, 1.18 filenames | Outdated/shortened filenames |
| model-risk-management-automation | 2 links — fixed 2.6, 2.9 filenames | Missing filename suffixes |
| deny-event-correlation-report | 1 link — fixed 1.8 filename | Old filename |
| scope-drift-monitor | 2 links — fixed 1.14, 1.4 filenames | Wrong control names in filenames |
| agent-knowledge-source-scanner | 3 links — fixed 4.3, 1.4, 1.5 filenames | Old/incorrect filenames |
| compliance-dashboard | 1 link — fixed 3.3 filename | Old filename |
| segregation-detector | 1 link — fixed 2.8 filename | Shortened filename |

## Verification

- [x] All updated URLs resolve to existing framework pages
- [x] `python scripts/build-manifest.py --check` passes
- [x] No remaining `docs/controls/{number}` patterns (without pillar directory)

Closes #164