### PR TITLE
fix: replace 6 broken Microsoft Learn URLs across 5 solutions

### DIFF
--- a/agent-observability-foundation/docs/worm-configuration.md
+++ b/agent-observability-foundation/docs/worm-configuration.md
@@ -272,7 +272,7 @@ Locked WORM storage has cost implications:
 
 - [verify_worm.py](https://github.com/judeper/FSI-AgentGov-Solutions/blob/main/agent-observability-foundation/scripts/verify_worm.py) - Verification script (read-only)
 - [Azure Immutable Storage Overview](https://learn.microsoft.com/azure/storage/blobs/immutable-storage-overview)
-- [SEC 17a-4 Compliance Assessment](https://learn.microsoft.com/azure/compliance/offerings/offering-sec-17a-4)
+- [SEC 17a-4 Compliance Assessment](https://learn.microsoft.com/en-us/compliance/regulatory/offering-SEC-docs)
 - [Cohasset Compliance Assessment](https://servicetrust.microsoft.com)
 
 ---

--- a/agent-observability-foundation/power-bi/README.md
+++ b/agent-observability-foundation/power-bi/README.md
@@ -221,7 +221,7 @@ The Power BI solution connects to Application Insights telemetry via Azure Data 
 
 ### Microsoft Learn Resources
 - **[Power BI DirectQuery](https://learn.microsoft.com/power-bi/connect-data/desktop-directquery-about)** - DirectQuery concepts and limitations
-- **[Azure Data Explorer Connector](https://learn.microsoft.com/power-bi/connect-data/desktop-connect-azure-data-explorer)** - ADX connector documentation
+- **[Azure Data Explorer Connector](https://learn.microsoft.com/en-us/azure/data-explorer/power-bi-data-connector)** - ADX connector documentation
 - **[Log Analytics Workspace](https://learn.microsoft.com/azure/azure-monitor/logs/log-analytics-workspace-overview)** - Workspace concepts and query optimization
 
 ---

--- a/conditional-access-automation/docs/deployment-guide.md
+++ b/conditional-access-automation/docs/deployment-guide.md
@@ -250,7 +250,7 @@ Allow 24-48 hours for report-only data collection.
 > is part of the Microsoft Graph beta surface and is subject to change without
 > notice. Do not depend on its response shape in production runbooks; treat
 > it as an interactive validation aid only. Track changes in the
-> [Microsoft Graph beta changelog](https://learn.microsoft.com/graph/changelog).
+> [Microsoft Graph changelog](https://learn.microsoft.com/en-us/graph/whats-new-overview).
 
 ```powershell
 # Test Zone 3 user accessing Copilot Studio

--- a/deny-event-correlation-report/docs/prerequisites.md
+++ b/deny-event-correlation-report/docs/prerequisites.md
@@ -242,7 +242,7 @@ union isfuzzy=true
 
 ### Reference
 
-- [Azure Monitor deprecation announcement](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/api/deprecation)
+- [Azure Monitor API migration guide](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/api/migrate-batch-and-beta)
 - [Entra ID authentication for Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/api/access-api)
 
 ---

--- a/finra-supervision-workflow/docs/power-bi-setup.md
+++ b/finra-supervision-workflow/docs/power-bi-setup.md
@@ -303,5 +303,5 @@ For regulatory examinations, export compliance evidence:
 ## Related Resources
 
 - [Power BI Documentation](https://learn.microsoft.com/en-us/power-bi/)
-- [Dataverse Connector](https://learn.microsoft.com/en-us/power-bi/connect-data/service-connect-to-dataverse)
+- [Dataverse Connector](https://learn.microsoft.com/en-us/power-query/connectors/dataverse)
 - [Control 3.3: Compliance Reporting](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-3-reporting/3.3-compliance-and-regulatory-reporting.md)

--- a/hitl-workflow-governance/docs/prerequisites.md
+++ b/hitl-workflow-governance/docs/prerequisites.md
@@ -2,7 +2,7 @@
 
 Requirements for deploying the HITL Workflow Governance solution.
 
-> **Preview Notice:** The Human in the Loop connector actions — **Request for Information** (RFI) and **Run a Multistage Approval** — are currently in public preview. RFI entered public preview in July 2025. The connector reference labels both actions as "(preview)." Preview features may change before general availability. This solution provides governance tooling, but administrators should monitor the [Copilot Studio release notes](https://learn.microsoft.com/en-us/microsoft-copilot-studio/release-notes) and connector reference for changes that may affect behavior.
+> **Preview Notice:** The Human in the Loop connector actions — **Request for Information** (RFI) and **Run a Multistage Approval** — are currently in public preview. RFI entered public preview in July 2025. The connector reference labels both actions as "(preview)." Preview features may change before general availability. This solution provides governance tooling, but administrators should monitor the [Copilot Studio release notes](https://learn.microsoft.com/en-us/microsoft-copilot-studio/whats-new) and connector reference for changes that may affect behavior.
 
 ---
 

--- a/hitl-workflow-governance/docs/troubleshooting.md
+++ b/hitl-workflow-governance/docs/troubleshooting.md
@@ -116,7 +116,7 @@ Error: Access denied to table fsi_HitlCheckpointResult
 **Cause:** The **Request for Information** action entered public preview in July 2025. The `advancedapprovals` connector schema may change before general availability. Microsoft may update action parameter names, add new required fields, or modify the bot component representation.
 
 **Resolution:**
-1. Check the [Copilot Studio release notes](https://learn.microsoft.com/en-us/microsoft-copilot-studio/release-notes) for recent connector changes
+1. Check the [Copilot Studio release notes](https://learn.microsoft.com/en-us/microsoft-copilot-studio/whats-new) for recent connector changes
 2. Compare current `botcomponent` content against the expected patterns in `Test-HitlWorkflowCompliance.ps1`
 3. If the connector schema has changed:
    - Update the scan script's action detection patterns to match the new schema


### PR DESCRIPTION
## Summary

Initial onboarding review of all 36 solution scaffolds in FSI-AgentGov-Solutions. Validated documentation accuracy, metadata consistency, and cross-references.

### Changes

Fixed 6 broken Microsoft Learn URLs (HTTP 404) across 5 solutions:

| Solution | File | Issue |
|----------|------|-------|
| agent-observability-foundation | docs/worm-configuration.md | SEC 17a-4 page moved |
| agent-observability-foundation | power-bi/README.md | ADX connector page moved |
| conditional-access-automation | docs/deployment-guide.md | Graph changelog page moved |
| deny-event-correlation-report | docs/prerequisites.md | API deprecation page replaced with migration guide |
| finra-supervision-workflow | docs/power-bi-setup.md | Dataverse connector page moved |
| hitl-workflow-governance | docs/prerequisites.md, docs/troubleshooting.md | Copilot Studio release notes page moved |

### Validation performed (all passing)

- [x] **89 unique Microsoft Learn URLs validated** — 6 broken, all fixed
- [x] **Version consistency** — manifest.yaml matches CHANGELOG.md across all 36 solutions
- [x] **Structural completeness** — README.md, CHANGELOG.md, manifest.yaml present in all 36
- [x] **Required manifest fields** — name, version, status, domain, controls, description, zones
- [x] **FSI language rules** — no prohibited phrases (\\nsures compliance\\, \\guarantees\\, etc.) in non-CHANGELOG files
- [x] **Product naming** — no legacy \\Azure Active Directory\\ references; \\Azure AD\\ only in historical CHANGELOG entries
- [x] **Role naming** — \\Global Administrator\\/\\Compliance Administrator\\ references are in technical contexts (Entra role assignments, conflict detection rules with GUIDs) where official role names are correct
- [x] **Manifest build** — \\python scripts/build-manifest.py --check\\ passes

Resolves judeper/OceanSquad#36