### PR TITLE
fix(infra-sweep): correct stale anchor and version in CAA and UASD READMEs

### DIFF
--- a/conditional-access-automation/README.md
+++ b/conditional-access-automation/README.md
@@ -534,7 +534,7 @@ The `List_Validation_Records` operations in both flows use `$top: 1` to retrieve
 
 ## Version
 
-2.0.1 - 2026-Q2 Microsoft Learn refresh
+2.0.2 — May 2026
 
 See [CHANGELOG.md](./CHANGELOG.md) for version history.
 

--- a/unrestricted-agent-sharing-detector/README.md
+++ b/unrestricted-agent-sharing-detector/README.md
@@ -77,7 +77,7 @@ Power Automate flows and Canvas apps are built manually using the instructions i
 
 ### Native Agent Sharing Rules (GA May 2025)
 
-Microsoft introduced native admin controls in the Power Platform admin center to [block and limit sharing for Copilot Studio agents](https://learn.microsoft.com/en-us/power-platform/admin/managed-environment-sharing-limits#agent-sharing-rules-preview). These controls allow administrators to:
+Microsoft introduced native admin controls in the Power Platform admin center to [block and limit sharing for Copilot Studio agents](https://learn.microsoft.com/en-us/power-platform/admin/managed-environment-sharing-limits#agent-sharing-rules). These controls allow administrators to:
 
 - Allow or block makers from sharing agents with individuals as editors
 - Allow or block makers from sharing agents with viewers (individuals and security groups)


### PR DESCRIPTION
## Validation Sweep: Infrastructure & Cross-cutting (6 solutions)

Closes judeper/OceanSquad#62

### Scope

Full accuracy validation of 6 infrastructure & cross-cutting solutions:
- `conditional-access-automation`
- `cross-solution-integration`
- `cross-tenant-external-sharing-governance`
- `dr-testing-framework`
- `pipeline-governance-cleanup`
- `unrestricted-agent-sharing-detector`

### Changes

| Solution | File | Before | After | Why |
|----------|------|--------|-------|-----|
| unrestricted-agent-sharing-detector | README.md | `#agent-sharing-rules-preview` | `#agent-sharing-rules` | Feature graduated from preview to GA; Microsoft removed the `-preview` suffix from the heading anchor |
| conditional-access-automation | README.md | Version footer said `2.0.1` | `2.0.2` | Mismatched the CHANGELOG (v2.0.2 released 2026-05-23) and the header metadata |

### Validation Results (all pass)

| Check | Result | Details |
|-------|--------|---------|
| Microsoft Learn URLs | **21/21 resolve** | All return 200 OK (2 had locale redirects, resolved correctly) |
| PowerShell cmdlets | **Current** | `Backup-PowerAppEnvironment`, `Get-PowerAppTenantIsolationPolicy`, `Copy-PowerAppEnvironment` confirmed in current module docs |
| Graph API endpoints | **Current** | `/v1.0/policies/crossTenantAccessPolicy`, `/beta/identity/conditionalAccess/evaluate` (still beta-only), permissions all valid |
| Cross-solution references | **Valid** | ACV, SSC, AAM, CMM, FUS, CAA, ELM, CD references all point to real solutions |
| DR procedures | **Accurate** | Correctly describes Power Platform backup as Microsoft-managed, PPAC-initiated restore, 28-day retention for production |
| Prerequisites | **Current** | Entra ID P1/P2, Power Platform Premium, managed identity guidance all current |
| Python packages | **Current** | msal>=1.24.0, requests>=2.31.0, azure-identity>=1.15.0 floors are all reasonable |
| FSI language rules | **No violations** | Zero hits for prohibited phrases across all 6 solutions |
| Legacy branding | **Clean** | No Azure AD/AAD references (only historical CHANGELOG entry) |

### Items NOT requiring changes

- **No `Last Verified` field** exists in manifests or READMEs; solutions use version dates instead
- **Graph `/beta/` CA evaluate endpoint** is still beta-only per Microsoft docs — correct as-is
- **manifest.yaml** files not edited (review-tier, per charter)