### PR TITLE
fix: validation sweep — lifecycle & registry (6 solutions)

### DIFF
--- a/agent-365-lifecycle-governance/DELIVERY-CHECKLIST.md
+++ b/agent-365-lifecycle-governance/DELIVERY-CHECKLIST.md
@@ -1,6 +1,6 @@
 # Agent 365 Lifecycle Governance — Delivery Checklist
 
-**Version:** v1.1.4
+**Version:** v1.1.5
 **Solution:** Agent 365 Lifecycle Governance
 
 Pre-deployment validation and post-deployment verification tasks. Complete each phase in order.
@@ -149,5 +149,5 @@ Do NOT include these repository management files:
 
 ---
 
-**Package Version:** v1.1.4
+**Package Version:** v1.1.5
 **Solution:** Agent 365 Lifecycle Governance

--- a/agent-365-lifecycle-governance/scripts/requirements.txt
+++ b/agent-365-lifecycle-governance/scripts/requirements.txt
@@ -1,3 +1,3 @@
-msal>=1.20.0
-requests>=2.28.0
-azure-identity>=1.16.0
+msal>=1.30.0
+requests>=2.32.0
+azure-identity>=1.18.0

--- a/agent-registry-automation/docs/prerequisites.md
+++ b/agent-registry-automation/docs/prerequisites.md
@@ -25,7 +25,7 @@ Install or update the supporting admin tooling on workstations used for validati
 ```powershell
 Install-Module -Name Microsoft.PowerApps.Administration.PowerShell -RequiredVersion 2.0.217 -Scope CurrentUser
 Install-Module -Name Microsoft.PowerApps.PowerShell -RequiredVersion 1.0.45 -AllowClobber -Scope CurrentUser
-Install-Module -Name Microsoft.Graph -RequiredVersion 2.36.1 -Scope CurrentUser
+Install-Module -Name Microsoft.Graph -RequiredVersion 2.37.0 -Scope CurrentUser
 Install-Module -Name Az.Accounts -RequiredVersion 5.3.4 -Scope CurrentUser
 pac --version
 ```

--- a/scope-drift-monitor/CHANGELOG.md
+++ b/scope-drift-monitor/CHANGELOG.md
@@ -46,7 +46,7 @@ All notable changes to the Scope Drift Monitor.
 
 ---
 
-## [1.1.1] - 2026-07-15
+## [1.1.1] - 2026-03-15
 
 ### Removed
 

--- a/scope-drift-monitor/README.md
+++ b/scope-drift-monitor/README.md
@@ -259,7 +259,7 @@ Microsoft is introducing [sensitivity label visibility in Copilot Studio](https:
 | 1.2.2 | May 2026 | PS 5.1 compatibility fix for `Get-Date -AsUTC`; non-ASCII em-dashes replaced |
 | 1.2.1 | May 2026 | Microsoft Learn 2026-Q2 refresh: Copilot audit schema parsing, managed identity-first scripts, and updated Purview/Graph guidance |
 | 1.1.2 | April 2026 | Fixed Write-Output pipeline contamination, prohibited language, PnP 3.x compatibility |
-| 1.1.1 | July 2026 | Removed exported Dataverse solution package per content policy |
+| 1.1.1 | March 2026 | Removed exported Dataverse solution package per content policy |
 | 1.1.0 | February 2026 | Production release with flows, scripts, and full documentation |
 | 1.0.0 | February 2026 | Initial schema and concept |
 

--- a/scope-drift-monitor/docs/baseline-configuration.md
+++ b/scope-drift-monitor/docs/baseline-configuration.md
@@ -311,4 +311,4 @@ Update-DataverseRecord -EntityName "fsi_agentscope" -RecordId $scopeId -Data @{
 
 ---
 
-*Scope Drift Monitor v1.2.1*
+*Scope Drift Monitor v1.2.2*

--- a/scope-drift-monitor/docs/dataverse-schema.md
+++ b/scope-drift-monitor/docs/dataverse-schema.md
@@ -324,4 +324,4 @@ Retention period should align with your organization's audit requirements (e.g.,
 
 ---
 
-*Scope Drift Monitor v1.2.1*
+*Scope Drift Monitor v1.2.2*

--- a/scope-drift-monitor/docs/flow-configuration.md
+++ b/scope-drift-monitor/docs/flow-configuration.md
@@ -233,4 +233,4 @@ For common issues and resolutions, see [Troubleshooting Guide](troubleshooting.m
 
 ---
 
-*Scope Drift Monitor v1.2.1*
+*Scope Drift Monitor v1.2.2*

--- a/scope-drift-monitor/docs/prerequisites.md
+++ b/scope-drift-monitor/docs/prerequisites.md
@@ -93,4 +93,4 @@ Use managed identity for Azure-hosted production automation:
 
 ---
 
-*Scope Drift Monitor v1.2.1*
+*Scope Drift Monitor v1.2.2*

--- a/scope-drift-monitor/docs/troubleshooting.md
+++ b/scope-drift-monitor/docs/troubleshooting.md
@@ -368,4 +368,4 @@ For issues not covered here:
 
 ---
 
-*Scope Drift Monitor v1.2.1*
+*Scope Drift Monitor v1.2.2*


### PR DESCRIPTION
## Validation Sweep — Lifecycle & Registry (6 solutions)

Addresses [OceanSquad Issue #59](https://github.com/judeper/OceanSquad/issues/59).

### Scope
Full accuracy validation of 6 lifecycle & registry solutions:
- `agent-365-lifecycle-governance`
- `agent-registry-automation`
- `agent-intake`
- `agent-knowledge-source-scanner`
- `environment-lifecycle-management`
- `scope-drift-monitor`

### What was validated
| Check | Result |
|-------|--------|
| Microsoft Learn URLs (49 unique) | ✅ All resolve (200) |
| FSI language rules (prohibited phrases) | ✅ Clean (no violations in non-CHANGELOG files) |
| Microsoft Entra ID product naming | ✅ Clean (legacy refs only in CHANGELOG historical entries) |
| PowerShell modules current | ✅ Az.Accounts 5.3.4, PnP.PowerShell 2.5.0+, Microsoft.Graph.* |
| Graph API permissions | ✅ `AgentInstance.ReadWrite.All` current |
| Cross-solution references | ✅ 4 cross-refs validated |
| Dataverse column naming | ✅ Compliant |
| Python package versions | ⚠️ Fixed (see below) |
| Version footers consistent | ⚠️ Fixed (see below) |

### Fixes applied

**scope-drift-monitor:**
- 5 doc footers bumped from v1.2.1 → v1.2.2 (prerequisites, dataverse-schema, flow-configuration, troubleshooting, baseline-configuration)
- v1.1.1 date corrected from `July 2026` → `March 2026` (was chronologically impossible — sat between Feb and Apr entries)

**agent-365-lifecycle-governance:**
- DELIVERY-CHECKLIST.md version bumped from v1.1.4 → v1.1.5 (2 locations)
- Python requirements.txt: `requests >=2.28.0` → `>=2.32.0` (CVE-2024-35195), `msal >=1.20.0` → `>=1.30.0`, `azure-identity >=1.16.0` → `>=1.18.0`

**agent-registry-automation:**
- Microsoft.Graph recommended version updated from 2.36.1 → 2.37.0 in prerequisites

### No issues found in
- `agent-intake` — docs already current at v1.0.0-preview
- `agent-knowledge-source-scanner` — docs already current at v1.1.2
- `environment-lifecycle-management` — docs already current at v1.2.2

### Items for human review
- scope-drift-monitor CHANGELOG v1.1.1 date: I corrected `2026-07-15` to `2026-03-15` based on chronological ordering. Please verify this is the correct date.
