### PR TITLE
docs(agent-365-lifecycle-governance): lab-readiness validation and corrections

### DIFF
--- a/agent-365-lifecycle-governance/CHANGELOG.md
+++ b/agent-365-lifecycle-governance/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the Agent 365 Lifecycle Governance solution.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Doc drift**: `docs/flow-configuration.md` Managed Solution Wrapper component table said "All 14 variables" while `scripts/create_alg_environment_variables.py` deploys 16 and the Environment Variables Reference table lists 16. Corrected to 16. (lab-validation)
+- **API accuracy**: `docs/troubleshooting.md` and `DELIVERY-CHECKLIST.md` Phase 3 described access-review creation as requiring `principalScopes`/`resourceScopes`, contradicting Flow 2, which uses the `accessReviewQueryScope` (`scope.query` = `/servicePrincipals/{id}`, `queryType` = `MicrosoftGraph`). Per Microsoft Graph, `principalScopes`/`resourceScopes` apply only to the `principalResourceMembershipsScope` shape, which this solution does not use. Aligned both files to the scope shape Flow 2 actually sends. (lab-validation)
+
 ## [1.1.5] - 2026-05-23
 
 ### Fixed

--- a/agent-365-lifecycle-governance/DELIVERY-CHECKLIST.md
+++ b/agent-365-lifecycle-governance/DELIVERY-CHECKLIST.md
@@ -54,7 +54,7 @@ Pre-deployment validation and post-deployment verification tasks. Complete each 
 
 - [ ] Validate Agent 365 `agentInstances` owner PATCH body schema (`ownerIds` collection) — confirm owner is actually set after the PATCH by calling GET
 - [ ] Validate supported OData filter syntax for ownerless agent instances — document whether server-side filter works or client-side filtering is required
-- [ ] Validate access review creation with `principalScopes` + `resourceScopes` returns 201 for agent service principals
+- [ ] Validate access review creation with the Flow 2 `accessReviewQueryScope` (`scope.query` = `/servicePrincipals/{id}`, `scope.queryType` = `MicrosoftGraph`) returns 201 for agent service principals
 - [ ] Validate PPAC Bots API (`api-version=2022-03-01-preview`) returns `lastModifiedTime` and `publishedOn` for Copilot Studio agents
 - [ ] Validate Entra Lifecycle Workflow activation uses sponsor-user subjects, not agent service principals
 - [ ] Document confirmed working API patterns in this section

--- a/agent-365-lifecycle-governance/LAB-VALIDATION.md
+++ b/agent-365-lifecycle-governance/LAB-VALIDATION.md
@@ -1,0 +1,94 @@
+# Lab Validation Report — Agent 365 Lifecycle Governance
+
+**Solution version:** v1.1.5 · **Validation date:** 2026-06-04 · **Validation type:** Static (no live tenant)
+
+## Purpose and controls
+
+Automated lifecycle governance for AI agents using Microsoft Agent 365, Microsoft Entra
+Agent ID, and Microsoft Entra ID Governance: sponsor/owner assignment, zone-based access
+reviews, inactivity detection, approval-gated deactivation, and deletion holds.
+
+Primary control 2.3 (Change Management); secondary 1.2, 1.11, 2.1, 2.8, 2.12, 3.1.
+
+## What was checked
+
+- Parse/compile validity of all scripts (Python + PowerShell).
+- Correctness of every external API endpoint, version, permission/scope against
+  authoritative Microsoft Learn documentation.
+- Dataverse column logical-name correctness (verified against
+  `scripts/create_alg_dataverse_schema.py`, the source of truth).
+- Option-set integer values referenced in flow docs, Power BI DAX, and canvas guide vs the
+  schema script.
+- Schema doc currency (`--output-docs` regenerate + diff → no drift).
+- Environment-variable count and key shape (script vs docs vs sample template).
+- FSI regulatory language rules and version-footer consistency.
+
+## Authoritative sources cited
+
+- Get agentInstance (beta): https://learn.microsoft.com/graph/api/agentinstance-get?view=graph-rest-beta
+- List agentInstances (beta): https://learn.microsoft.com/graph/api/agentregistry-list-agentinstances?view=graph-rest-beta
+- Update agentInstance (beta): https://learn.microsoft.com/graph/api/agentinstance-update?view=graph-rest-beta
+- agentInstance resource type (`ownerIds` String collection; May 2026 convergence notice):
+  https://learn.microsoft.com/graph/api/resources/agentinstance?view=graph-rest-beta
+- Agent Registry convergence with Microsoft Agent 365:
+  https://learn.microsoft.com/entra/agent-id/agent-registry-convergence
+- Agent 365 agent permissions / blueprint registration:
+  https://learn.microsoft.com/microsoft-agent-365/developer/registration#agent-permissions
+- `AgentInstance.*` are beta permissions (Dec 2025 note):
+  https://learn.microsoft.com/microsoft-agent-365/developer/custom-client-app-registration#4-configure-api-permissions
+- Microsoft Graph permissions reference (`AgentInstance.Read.All` / `AgentInstance.ReadWrite.All`):
+  https://learn.microsoft.com/graph/permissions-reference#all-permissions
+- accessReviewScheduleDefinition resource (`scope`, `reviewers`, `settings`):
+  https://learn.microsoft.com/graph/api/resources/accessreviewscheduledefinition?view=graph-rest-1.0
+- Configure access review scope (accessReviewQueryScope vs principalResourceMembershipsScope/`principalScopes`/`resourceScopes`):
+  https://learn.microsoft.com/graph/accessreviews-scope-concept
+
+## Verification outcomes (already correct)
+
+- **Agent Registry endpoint** `GET/PATCH /beta/agentRegistry/agentInstances` is the current
+  documented surface; `ownerIds` is the correct updatable owner property (the prior
+  `sponsor@odata.bind` pattern is stale, as the docs already note). Scripts filter ownerless
+  instances client-side on `ownerIds` — appropriate given undocumented server-side filter support.
+- **Permissions** `AgentInstance.Read.All` (read/list) and `AgentInstance.ReadWrite.All`
+  (create/update/delete) match Microsoft Learn exactly. Beta-permission caveat is documented.
+- **Convergence caveat** (Agent Registry APIs replaced by Agent 365-powered APIs starting
+  May 2026) matches the live Microsoft Learn notice; feature-flag gating is sound.
+- **Dataverse**: schema doc regenerated with no diff; all column references use correct
+  logical names (`fsi_iscurrent`, `fsi_approvalstatus`, `fsi_deletionholduntil`, etc.);
+  option-set integers consistent across flow docs, DAX, and canvas guide.
+- **Auth**: managed-identity-first; Az.Accounts 5.x SecureString token handling correct.
+- **Language rules**: no prohibited phrases; regulatory claims appropriately hedged.
+- **Versions**: all footers consistent at v1.1.5.
+
+## Gaps found and fixes applied
+
+| # | File | Issue | Fix |
+|---|------|-------|-----|
+| 1 | `docs/flow-configuration.md` | Managed-solution component table said "All 14 variables"; script deploys 16 and the reference table lists 16. | Corrected to 16. |
+| 2 | `docs/troubleshooting.md` | Access-review 400 row claimed `principalScopes`/`resourceScopes` are "required", contradicting Flow 2 (which uses `accessReviewQueryScope`). Per Microsoft Graph those properties belong only to `principalResourceMembershipsScope`. | Rewrote to reference the `scope.query`/`queryType` shape Flow 2 sends. |
+| 3 | `DELIVERY-CHECKLIST.md` (Phase 3) | Same `principalScopes`/`resourceScopes` inconsistency in the API-validation task. | Aligned to the `accessReviewQueryScope` shape. |
+
+No script logic changes were required — Python and PowerShell parse cleanly and the API
+calls match current documentation.
+
+## Runtime-only caveats (cannot be validated statically)
+
+- Agent Registry beta APIs may change before GA / May 2026 convergence; validate
+  `agentInstances` list/PATCH and `ownerIds` behavior in a non-production tenant (Phase 3).
+- Server-side OData `$filter` support for `ownerIds` is unconfirmed; client-side filtering
+  is the documented fallback.
+- PPAC Bots API (`api-version=2022-03-01-preview`) is an internal BAP endpoint not covered by
+  Microsoft Learn; `flow-configuration.md` and `troubleshooting.md` show slightly different
+  paths (the latter includes `/scopes/admin/`). Confirm the working path and that
+  `lastModifiedTime`/`publishedOn` are returned (Phase 3) — left as-is pending tenant validation.
+- `AuditLog.Read.All` may be restricted in some FSI tenants; Flow 3 degrades to PPAC data.
+- Dataverse alternate-key activation latency and LTR/no-delete role configuration are
+  tenant-side operational steps.
+
+## Lab-readiness assessment
+
+**Ready for lab deployment**, gated by the existing `IsAgent365LifecycleEnabled` feature flag
+and the Phase 3 non-production API validation already mandated in `DELIVERY-CHECKLIST.md`.
+Static validation found no blocking defects; the three doc-drift corrections remove
+contradictions that would have misled an operator building Flow 2 or sizing environment
+variables. No version bump applied (doc-only corrections; avoids manifest/catalog churn).

--- a/agent-365-lifecycle-governance/docs/flow-configuration.md
+++ b/agent-365-lifecycle-governance/docs/flow-configuration.md
@@ -1193,7 +1193,7 @@ All components should be developed inside a Dataverse solution container for man
 | Security Roles | ALG Administrator, ALG Reviewer, ALG Read Only |
 | Cloud Flows | Flow 1–6 (all six lifecycle flows) |
 | Connection References | Dataverse, HTTP with Microsoft Entra ID, Microsoft Teams, Approvals, Power Platform for Admins V2 |
-| Environment Variables | All 14 variables listed above |
+| Environment Variables | All 16 variables listed above |
 
 ---
 

--- a/agent-365-lifecycle-governance/docs/troubleshooting.md
+++ b/agent-365-lifecycle-governance/docs/troubleshooting.md
@@ -9,7 +9,7 @@ Common issues and resolutions for the Agent 365 Lifecycle Governance solution.
 | Issue | Cause | Resolution |
 |-------|-------|------------|
 | Owner PATCH returns 200 but owner not set | Wrong body format — used UPN string or stale `sponsor@odata.bind` | Use `ownerIds` with sponsor user Object IDs for `agentInstance` PATCH |
-| Access review creation returns 400 | Missing `principalScopes` or `resourceScopes` | Both scopes are required — verify payload matches Flow 2 specification |
+| Access review creation returns 400 | Malformed `scope` on the access review definition | Flow 2 uses an `accessReviewQueryScope` — supply `scope` with `query` (e.g. `/servicePrincipals/{id}`) and `queryType` (`MicrosoftGraph`), plus a `reviewers` collection. The `principalScopes`/`resourceScopes` properties apply only to the `principalResourceMembershipsScope` shape and are not used by Flow 2. Verify the payload matches the Flow 2 specification. |
 | Flow terminates immediately without processing | Feature flag `IsAgent365LifecycleEnabled` is `"false"` | Set to `"true"` after confirming Agent 365 licensing and validating beta Graph API behavior |
 | Sign-in log query returns 403 | `AuditLog.Read.All` permission not granted or tenant restriction | Grant permission or accept fallback to PPAC-only activity data |
 | Agent not added to security group | Group ID environment variable empty or incorrect | Verify `FSIAllAgentIdentitiesGroupId` and `FSIZone3AgentsGroupId` values |


### PR DESCRIPTION
## Summary
Static lab-readiness validation of **agent-365-lifecycle-governance** (v1.1.5) against authoritative Microsoft Learn sources. No live tenant; validation = parse/compile + authoritative-source verification + doc completeness.

## Verified correct (no change needed)
- Agent Registry beta endpoint `/beta/agentRegistry/agentInstances` (GET/PATCH) and `ownerIds` property — confirmed against the agentInstance resource docs.
- Permissions `AgentInstance.Read.All` / `AgentInstance.ReadWrite.All` match the Graph permissions reference; beta-permission + May 2026 convergence caveats accurate.
- Dataverse schema doc regenerated (`--output-docs`) with **no diff**; all column logical names and option-set integers consistent across flow docs, DAX, and canvas guide.
- PowerShell (Az.Accounts 5.x SecureString handling) and Python scripts parse/compile clean; managed-identity-first auth intact.
- FSI language rules pass; version footers consistent at v1.1.5.

## Fixes
1. `flow-configuration.md` — managed-solution component table said "14 variables"; script deploys **16** (table already lists 16). Corrected.
2. `troubleshooting.md` + `DELIVERY-CHECKLIST.md` — access-review docs cited `principalScopes`/`resourceScopes` as required, contradicting Flow 2 which uses `accessReviewQueryScope` (`scope.query`). Per Microsoft Graph those props belong only to `principalResourceMembershipsScope`. Aligned to the shape Flow 2 sends.
3. Added `LAB-VALIDATION.md` evidence report (sources, outcomes, caveats).

## Runtime-only caveats
- Agent Registry beta APIs may change pre-GA / May 2026 convergence — Phase 3 non-prod validation already mandated.
- Server-side `ownerIds` `` support unconfirmed (client-side fallback documented).
- PPAC Bots API (`2022-03-01-preview`) is internal/undocumented; `flow-configuration.md` and `troubleshooting.md` show slightly different paths — left as-is pending tenant validation, flagged in report.

## Notes
- Sources cited: ~10 Microsoft Learn URLs (see LAB-VALIDATION.md).
- No version bump (doc-only; avoids manifest.yaml / catalog churn).
- `manifest.yaml` untouched.