### PR TITLE
fix(agent-communication-restriction-detector): lab-readiness validation and corrections

### DIFF
--- a/agent-communication-restriction-detector/CHANGELOG.md
+++ b/agent-communication-restriction-detector/CHANGELOG.md
@@ -4,9 +4,16 @@ All notable changes to the Agent Communication Restriction Detector are document
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Get-CrossTenantAccessCorrelation.ps1` read `isServiceProvider` off the wrong Graph object.** The script accessed `$partner.B2BCollaborationInbound.IsServiceProvider` and `$partner.B2BDirectConnectInbound.IsServiceProvider`, but per the Microsoft Graph [`crossTenantAccessPolicyConfigurationPartner`](https://learn.microsoft.com/graph/api/resources/crosstenantaccesspolicyconfigurationpartner) resource, `isServiceProvider` is a property of the partner object itself — `b2bCollaborationInbound`/`b2bDirectConnectInbound` are `crossTenantAccessPolicyB2BSetting` objects that expose `usersAndGroups`/`applications`, not `isServiceProvider`. The previous expressions always evaluated to `$null`. Now reads `IsServiceProvider` from the partner and records inbound B2B collaboration / direct-connect configuration as presence checks.
+
 ### Changed
 
+- **`Test-ChildAgentPayloadSize.ps1` advisory threshold made configurable and reference corrected.** The script claimed a "documented 1 MB Copilot Studio limit" and cited `microsoft-copilot-studio/advanced-flow-input-output`, which no longer documents a child-agent input/output byte limit (the page now redirects to general agent-flow guidance). Current published [Copilot Studio limits](https://learn.microsoft.com/microsoft-copilot-studio/requirements-quotas#copilot-studio-web-app-limits) document a 5 MB connector payload limit (450 KB GCC) and a 28 KB Omnichannel channel-data limit, but no explicit child-agent payload byte limit. Reframed the 1 MB value as a configurable advisory heuristic via a new `-PayloadLimitKB` parameter (default 1024), widened threshold validation ranges accordingly, updated finding text and the `PlatformReference` URL, and corrected the README feature description.
+- **`docs/prerequisites.md` corrected MSAL.PS / Az.Accounts roles.** MSAL.PS was mislabeled as "Evidence export authentication"; `Export-CommViolationEvidence.ps1` migrated to Az.Accounts in v1.2.1. MSAL.PS is now documented as a runbook-only certificate-auth dependency (and flagged as archived), and the Az.Accounts minimum was raised to 2.17+ to match the Export script's `#Requires`.
 - `Get-CrossTenantAccessCorrelation.ps1` and `Test-ChildAgentPayloadSize.ps1` now honor `-WhatIf` by returning before Graph or Dataverse scan work when `ShouldProcess` declines the operation.
+- Documented the previously undocumented `-IncludeCompliant` parameter in `Get-CrossTenantAccessCorrelation.ps1` comment-based help.
 
 ## [1.2.1] - 2026-05-23
 

--- a/agent-communication-restriction-detector/LAB-VALIDATION.md
+++ b/agent-communication-restriction-detector/LAB-VALIDATION.md
@@ -1,0 +1,112 @@
+# Lab Validation Report — Agent Communication Restriction Detector (ACRD)
+
+> **Validation type:** Static (no live tenant). Parse-validity + authoritative-source
+> verification + documentation completeness.
+> **Date:** 2026-06-04
+> **Solution version:** v1.2.1
+> **Primary control:** 2.17 — Multi-Agent Orchestration Limits
+> **Supporting controls:** 1.8 (Runtime Protection), 2.1 (Managed Environments), 3.8 (Copilot Hub)
+
+## Purpose
+
+ACRD detects unauthorized agent-to-agent communication patterns, zone boundary
+violations, cross-environment and cross-tenant communication, and maker/checker
+violations in Copilot Studio multi-agent orchestration. It supports compliance with
+FINRA Rule 3110, SOX 404, and GLBA 501(b) by producing auditable evidence of
+agent communication topology and policy alignment.
+
+## What was checked
+
+| Area | Method | Result |
+|------|--------|--------|
+| Python compile | `python -m py_compile` on all 5 `scripts/*.py` | Pass |
+| PowerShell parse | `Parser::ParseFile` on all 14 `.ps1`/`.psm1` | Pass (0 errors) |
+| Dataverse column names | Cross-checked every OData `$select`/`$filter` against `create_dataverse_schema.py` | Logical names correct (e.g. `fsi_violationtype`, `fsi_validationtime`, `fsi_environmentsscanned`) |
+| Option-set value drift | Compared `flow-configuration.md` and scripts against schema option sets | Correct — uses `100000000+` integers; no `0/1/2` drift |
+| Entity set names | Verified `fsi_commscanrun` (singular, explicit) vs auto-plural sets | Consistent with schema `EntitySetName` |
+| Schema docs sync | Compared `docs/dataverse-schema.md` against schema script | In sync |
+| Language rules | Grep for prohibited phrases in `*.md`/scripts (excl. CHANGELOG history) | No violations |
+| External API/feature claims | Verified against Microsoft Learn (see Sources) | 2 issues found and fixed |
+
+## Authoritative sources cited
+
+1. Get-MgPolicyCrossTenantAccessPolicyPartner (module Microsoft.Graph.Identity.SignIns) —
+   https://learn.microsoft.com/powershell/module/microsoft.graph.identity.signins/get-mgpolicycrosstenantaccesspolicypartner
+2. crossTenantAccessPolicyConfigurationPartner resource (property shapes; `isServiceProvider`,
+   `b2bCollaborationInbound`, `b2bDirectConnectInbound`, `inboundTrust`) —
+   https://learn.microsoft.com/graph/api/resources/crosstenantaccesspolicyconfigurationpartner
+3. crossTenantAccessPolicyB2BSetting (confirms B2B settings expose `usersAndGroups`/`applications`,
+   not `isServiceProvider`) —
+   https://learn.microsoft.com/graph/api/resources/crosstenantaccesspolicyb2bsetting
+4. Copilot Studio quotas and limits (connector payload 5 MB / 450 KB GCC; Omnichannel 28 KB;
+   Skills 100/agent) —
+   https://learn.microsoft.com/microsoft-copilot-studio/requirements-quotas#copilot-studio-web-app-limits
+5. Add a child agent (child agents have their own orchestration/tool limits) —
+   https://learn.microsoft.com/microsoft-copilot-studio/add-agent-child-agent
+6. Copilot component (botcomponent) table reference (Dataverse) —
+   https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/botcomponent
+
+## Gaps found and fixes applied
+
+### Scripts
+
+1. **Cross-tenant correlation read `isServiceProvider` off the wrong object (correctness bug).**
+   `Get-CrossTenantAccessCorrelation.ps1` read
+   `$partner.B2BCollaborationInbound.IsServiceProvider` /
+   `$partner.B2BDirectConnectInbound.IsServiceProvider`. Per source (2)/(3),
+   `isServiceProvider` is a property of the partner object; the B2B inbound members are
+   `crossTenantAccessPolicyB2BSetting` objects without that property, so both expressions
+   always evaluated to `$null`. **Fix:** read `IsServiceProvider` from the partner and
+   record B2B collaboration / direct-connect inbound as presence checks; added a citation
+   comment. Also documented the previously-undocumented `-IncludeCompliant` parameter.
+
+2. **`Test-ChildAgentPayloadSize.ps1` cited a non-existent "documented 1 MB limit" and a dead URL.**
+   The script asserted a "documented 1 MB Copilot Studio limit" for child-agent input/output and
+   cited `microsoft-copilot-studio/advanced-flow-input-output`, which now redirects to generic
+   agent-flow guidance with no byte limit. Per source (4), current published limits are a 5 MB
+   connector payload (450 KB GCC) and a 28 KB Omnichannel channel-data limit — there is **no
+   published child-agent input/output byte limit**. **Fix:** reframed the 1 MB value as a
+   configurable advisory heuristic via a new `-PayloadLimitKB` parameter (default 1024), widened
+   threshold validation ranges, updated finding text + `PlatformReference` URL, and corrected the
+   README feature description. Behavior is unchanged at defaults.
+
+### Documentation
+
+3. **`docs/prerequisites.md` mislabeled MSAL.PS.** It listed MSAL.PS as "Evidence export
+   authentication", but `Export-CommViolationEvidence.ps1` migrated to Az.Accounts in v1.2.1
+   (CHANGELOG M-5). MSAL.PS is now used only by the Azure Automation runbook for certificate
+   auth. **Fix:** corrected the purpose, flagged MSAL.PS as archived/runbook-only, and raised the
+   Az.Accounts minimum to 2.17+ to match `Export-CommViolationEvidence.ps1` `#Requires`.
+
+### Verified correct (no change needed)
+
+- Dataverse OData queries use correct logical column names and entity set names.
+- Power Automate option-set mappings use integer values `100000001`/`100000002` (Approved/Denied).
+- Bot/skill discovery queries `bots` and `botcomponents` with `componenttype eq 2 or 10` and extracts
+  `connectedAgentSchemaName` — consistent with the Dataverse botcomponent table (source 6).
+- Cross-tenant token-audience fix (C-1), `Get-Date -AsUTC` removal (C-2), and
+  `Connect-EnvironmentDataverse` call-operator fix (C-3) from v1.2.1 remain correct.
+- Sovereign-cloud Dataverse URL `ValidatePattern` regexes accept commercial + US Gov + Germany clouds.
+
+## Runtime-only caveats (cannot be verified without a live tenant)
+
+- **Payload-size estimation is heuristic.** `Test-ChildAgentPayloadSize.ps1` estimates payload size
+  from botcomponent YAML byte counts; it does not measure actual runtime request/response sizes.
+  Treat findings as advisory. Microsoft does not publish a child-agent byte limit, so the default
+  threshold is a conservative organizational heuristic — tune `-PayloadLimitKB` to policy.
+- **MSAL.PS is archived.** The runbook still depends on MSAL.PS for certificate auth. It functions
+  today but receives no security updates; a future migration to `Get-AzAccessToken` (cert) or a
+  managed identity is recommended. Left as-is to avoid an out-of-scope rewrite of the runbook auth.
+- **`Get-CrossTenantAccessCorrelation.ps1` correlation** depends on tenant GUIDs being extractable
+  from `fsi_calledenvironmentid`; per `.ralph-config.json`, explicit tenant-ID comparison is a
+  URL/GUID heuristic and not yet a first-class tenant match. Behavior unchanged by this validation.
+- Graph cmdlet return-object property names (PascalCased SDK projections) were validated against the
+  Graph REST resource definitions; the live PowerShell SDK object graph was not exercised.
+
+## Final lab-readiness assessment
+
+**Lab-ready (static validation passed).** All scripts parse and compile; documentation is internally
+consistent and matches the Dataverse schema; option-set and column references are correct; no
+prohibited compliance language. Two authoritative-source defects (a Graph property-access bug and an
+outdated/unverifiable platform-limit claim) were corrected. Remaining items are runtime-only caveats
+that require a live tenant to exercise and are documented above. No `manifest.yaml` change was needed.

--- a/agent-communication-restriction-detector/README.md
+++ b/agent-communication-restriction-detector/README.md
@@ -59,7 +59,7 @@ Each governance zone defines which agent-to-agent communication patterns are per
 | **Evidence Export** | SHA-256 integrity-hashed JSON evidence for regulatory examinations |
 | **Approved Route Import** | CSV-based governance import for approved communication routes |
 | **Cross-Tenant Entra Correlation** | Correlates cross-tenant violations with Entra cross-tenant access policies and B2B direct connect settings |
-| **Child-Agent Payload Size Checks** | Validates child-agent input/output declarations against the documented 1 MB Copilot Studio limit |
+| **Child-Agent Payload Size Checks** | Estimates child-agent input/output declarations against a configurable advisory payload-size threshold (default 1 MB; current Copilot Studio docs publish a 5 MB connector payload limit, 450 KB for GCC) |
 
 ## Solution Components
 

--- a/agent-communication-restriction-detector/docs/prerequisites.md
+++ b/agent-communication-restriction-detector/docs/prerequisites.md
@@ -8,8 +8,8 @@ Requirements for deploying the Agent Communication Restriction Detector (ACRD) s
 |-------------|---------|---------|
 | Windows PowerShell | 5.1 | Required for Microsoft.PowerApps.Administration.PowerShell environment enumeration |
 | Microsoft.PowerApps.Administration.PowerShell | 2.0.180+ | Power Platform environment enumeration |
-| Az.Accounts | 2.0+ | Dataverse token acquisition (interactive mode) |
-| MSAL.PS | 4.37+ | Evidence export authentication (`Install-Module MSAL.PS`) |
+| Az.Accounts | 2.17+ | Dataverse token acquisition (interactive and service-principal) for evidence export and helper scripts |
+| MSAL.PS | 4.37+ | Certificate-based Dataverse token acquisition in the Azure Automation runbook only (`Install-Module MSAL.PS`). MSAL.PS is archived by its maintainer and receives no security updates; treat as a runbook-only legacy dependency. |
 
 ## Python Requirements
 

--- a/agent-communication-restriction-detector/scripts/Get-CrossTenantAccessCorrelation.ps1
+++ b/agent-communication-restriction-detector/scripts/Get-CrossTenantAccessCorrelation.ps1
@@ -26,6 +26,11 @@
 .PARAMETER OutputFormat
     Output format: Table (default), Json, or Object.
 
+.PARAMETER IncludeCompliant
+    Include correlation results that align with the cross-tenant access policy
+    (PolicyAction = AllowedByPartnerPolicy) in the output. By default only
+    policy-blocked violations are returned.
+
 .PARAMETER WhatIf
     Preview mode — shows correlation results without persisting to Dataverse.
 
@@ -88,10 +93,19 @@ function Get-CrossTenantAccessCorrelation {
         $allowedTenantIds = @{}
         foreach ($partner in $partners) {
             $tenantId = $partner.TenantId
+            # isServiceProvider is a property of the partner configuration object
+            # itself, NOT of the b2bCollaborationInbound / b2bDirectConnectInbound
+            # settings. Those are crossTenantAccessPolicyB2BSetting objects that expose
+            # usersAndGroups / applications, with no isServiceProvider member — so the
+            # previous $partner.B2BCollaborationInbound.IsServiceProvider always read
+            # $null. Capture inbound B2B configuration as a presence check and read
+            # isServiceProvider from the partner object.
+            # Ref: https://learn.microsoft.com/graph/api/resources/crosstenantaccesspolicyconfigurationpartner
             $allowedTenantIds[$tenantId] = @{
-                TenantId            = $tenantId
-                B2BCollaborationInbound  = $partner.B2BCollaborationInbound.IsServiceProvider
-                B2BDirectConnectInbound  = $partner.B2BDirectConnectInbound.IsServiceProvider
+                TenantId                 = $tenantId
+                IsServiceProvider        = $partner.IsServiceProvider
+                B2BCollaborationInbound  = $null -ne $partner.B2BCollaborationInbound
+                B2BDirectConnectInbound  = $null -ne $partner.B2BDirectConnectInbound
                 InboundTrustCompliant    = $null -ne $partner.InboundTrust
                 AutomaticUserConsent     = $partner.AutomaticUserConsentSettings.InboundAllowed
             }

--- a/agent-communication-restriction-detector/scripts/Test-ChildAgentPayloadSize.ps1
+++ b/agent-communication-restriction-detector/scripts/Test-ChildAgentPayloadSize.ps1
@@ -1,12 +1,20 @@
 ﻿<#
 .SYNOPSIS
-    Validates child-agent input/output payload sizes against the documented
-    Copilot Studio 1 MB limit.
+    Estimates child-agent input/output payload sizes against a configurable
+    advisory payload-size threshold.
 
 .DESCRIPTION
-    Scans Copilot Studio agent skill registrations and flow response configurations
-    to detect child-agent payloads that approach or exceed the documented 1 MB
-    (1,048,576 bytes) limit for child-agent input and output.
+    Scans Copilot Studio agent skill registrations and connected-agent topic
+    configurations to estimate child-agent payloads that approach or exceed a
+    configurable advisory threshold (default 1 MB / 1,048,576 bytes).
+
+    Important: Microsoft does not currently publish an explicit byte limit for
+    child-agent (connected-agent) input/output. The published Copilot Studio
+    limits document a 5 MB connector payload limit (450 KB for GCC) and a 28 KB
+    Omnichannel channel-data limit. The 1 MB default used here is a conservative
+    advisory heuristic, not a hard platform limit; tune it with -PayloadLimitKB
+    to match your organization's policy.
+    Reference: https://learn.microsoft.com/microsoft-copilot-studio/requirements-quotas#copilot-studio-web-app-limits
 
     Detection methods:
     1. Queries agent topic YAML for InvokeConnectedAgentTaskAction nodes and
@@ -14,15 +22,17 @@
     2. Checks flow response receive configurations for payload size thresholds
     3. Emits warning events when estimated payloads exceed configurable thresholds
 
-    Threshold levels:
-    - Warning:  >= 768 KB (75% of limit)
-    - Critical: >= 960 KB (93.75% of limit)
-    - Blocked:  >= 1,048,576 bytes (1 MB — documented platform limit)
-
-    Reference: https://learn.microsoft.com/microsoft-copilot-studio/advanced-flow-input-output
+    Threshold levels (relative to -PayloadLimitKB, default 1024 KB):
+    - Warning:  >= WarningThresholdKB  (default 768 KB)
+    - Critical: >= CriticalThresholdKB (default 960 KB)
+    - Blocked:  >= PayloadLimitKB      (default 1024 KB advisory threshold)
 
 .PARAMETER DataverseUrl
     Dataverse environment URL.
+
+.PARAMETER PayloadLimitKB
+    Advisory payload-size threshold in KB that marks a finding as Critical
+    (default: 1024). Not a documented platform limit — see DESCRIPTION.
 
 .PARAMETER WarningThresholdKB
     Payload size in KB to trigger warning (default: 768).
@@ -66,10 +76,13 @@ function Test-ChildAgentPayloadSize {
         )]
         [string]$DataverseUrl,
 
-        [ValidateRange(1, 1024)]
+        [ValidateRange(1, 5120)]
+        [int]$PayloadLimitKB = 1024,
+
+        [ValidateRange(1, 5120)]
         [int]$WarningThresholdKB = 768,
 
-        [ValidateRange(1, 1024)]
+        [ValidateRange(1, 5120)]
         [int]$CriticalThresholdKB = 960,
 
         [ValidateSet('Table', 'Json', 'Object')]
@@ -84,7 +97,7 @@ function Test-ChildAgentPayloadSize {
 
     begin {
         $ErrorActionPreference = 'Stop'
-        $LIMIT_BYTES = 1048576  # 1 MB documented limit
+        $LIMIT_BYTES = $PayloadLimitKB * 1024  # advisory threshold (not a documented platform limit)
         $WARNING_BYTES = $WarningThresholdKB * 1024
         $CRITICAL_BYTES = $CriticalThresholdKB * 1024
 
@@ -94,7 +107,7 @@ function Test-ChildAgentPayloadSize {
             . (Join-Path $privatePath 'Connect-EnvironmentDataverse.ps1')
         }
 
-        Write-Verbose "Payload size thresholds: Warning=$($WarningThresholdKB)KB, Critical=$($CriticalThresholdKB)KB, Limit=1024KB"
+        Write-Verbose "Payload size thresholds: Warning=$($WarningThresholdKB)KB, Critical=$($CriticalThresholdKB)KB, Advisory limit=$($PayloadLimitKB)KB"
     }
 
     process {
@@ -208,14 +221,14 @@ function Test-ChildAgentPayloadSize {
                         EstimatedInputKB   = [Math]::Round($inputSize / 1024, 1)
                         EstimatedOutputKB  = [Math]::Round($outputSize / 1024, 1)
                         EstimatedTotalKB   = [Math]::Round($estimatedPayloadBytes / 1024, 1)
-                        LimitKB            = 1024
+                        LimitKB            = $PayloadLimitKB
                         Severity           = $severity
                         Recommendation     = switch ($severity) {
-                            'Critical' { 'Payload exceeds 1 MB limit — reduce input/output variable count or use pagination' }
-                            'High'     { 'Payload approaching 1 MB limit — review for optimization opportunities' }
-                            'Warning'  { 'Payload at 75%+ of 1 MB limit — monitor growth' }
+                            'Critical' { 'Payload exceeds advisory limit — reduce input/output variable count or use pagination' }
+                            'High'     { 'Payload approaching advisory limit — review for optimization opportunities' }
+                            'Warning'  { 'Payload at 75%+ of advisory limit — monitor growth' }
                         }
-                        PlatformReference  = 'https://learn.microsoft.com/microsoft-copilot-studio/advanced-flow-input-output'
+                        PlatformReference  = 'https://learn.microsoft.com/microsoft-copilot-studio/requirements-quotas#copilot-studio-web-app-limits'
                     })
                 }
             }


### PR DESCRIPTION
## Summary
Static lab-readiness validation of **agent-communication-restriction-detector** (v1.2.1, control 2.17). No live tenant — parse/compile validity + authoritative Microsoft-source verification + doc completeness. See `LAB-VALIDATION.md` for the full evidence report.

## What & why
- **Get-CrossTenantAccessCorrelation.ps1 — Graph property-access bug (correctness).** Read `isServiceProvider` off `b2bCollaborationInbound`/`b2bDirectConnectInbound`, but those are `crossTenantAccessPolicyB2BSetting` objects without that property; `isServiceProvider` is partner-level, so the expressions always returned `null`. Now reads it from the partner and records B2B inbound config as presence checks. Documented `-IncludeCompliant`.
- **Test-ChildAgentPayloadSize.ps1 — outdated/unverifiable limit claim.** The "documented 1 MB Copilot Studio limit" and the `advanced-flow-input-output` URL are no longer valid; current docs publish a **5 MB connector payload** limit (450 KB GCC) and **no** child-agent byte limit. Reframed 1 MB as a configurable advisory threshold (new `-PayloadLimitKB`), widened validation ranges, fixed the reference URL and README description. Defaults unchanged.
- **docs/prerequisites.md — stale dependency.** MSAL.PS was labeled "evidence export auth"; the Export script moved to Az.Accounts in v1.2.1. Corrected to runbook-only cert auth (archived), raised Az.Accounts min to 2.17+.
- Added `LAB-VALIDATION.md`.

## Verified correct (no change)
Dataverse logical column names, entity-set names, option-set integer values (`100000001`/`100000002`), schema-doc sync, bot/botcomponent discovery queries, language rules.

## Authoritative sources
Graph `crossTenantAccessPolicyConfigurationPartner` + `crossTenantAccessPolicyB2BSetting` resources; `Get-MgPolicyCrossTenantAccessPolicyPartner`; Copilot Studio requirements-quotas (web-app limits); Add-a-child-agent; Dataverse botcomponent table. Full URLs in `LAB-VALIDATION.md`.

## Caveats (runtime-only)
Payload-size estimation is heuristic (not runtime-measured); MSAL.PS runbook dependency is archived; cross-tenant correlation relies on a GUID heuristic. No `manifest.yaml` change.

## Verification
`python -m py_compile` (5 files) pass · PowerShell `ParseFile` (14 files) 0 errors · language scan clean.