### PR TITLE
fix(agent-knowledge-source-scanner): lab-readiness validation and corrections

### DIFF
--- a/agent-knowledge-source-scanner/CHANGELOG.md
+++ b/agent-knowledge-source-scanner/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to agent-knowledge-source-scanner will be documented in this
 ### Fixed
 
 - **Wave 6 P4b:** Empty catch blocks now log via `Write-Verbose` instead of silently swallowing errors. Output is unchanged unless caller passes `-Verbose`.
+- **Least-privilege Graph permissions corrected.** The Graph v1.0 scanner (`Invoke-GraphPermissionScan.ps1`) documentation listed `Group.Read.All` as required, but the [list-permissions endpoint](https://learn.microsoft.com/graph/api/driveitem-list-permissions?view=graph-rest-1.0#permissions) requires only `Files.Read.All` (application) / `Files.Read` (delegated), with `Sites.Read.All` as a higher-privileged alternative. Group-based grants are returned inline in the `grantedToV2`/`grantedToIdentitiesV2` facets, so no group-membership call (and no `Group.Read.All`) is made. Corrected README "Microsoft Graph Permissions" table and the script `.NOTES`. (lab-readiness validation)
+- **`Get-AzAccessToken` example updated for Az.Accounts 5.x.** `.Token` is now a `SecureString` by default, so the previous `(Get-AzAccessToken -ResourceUrl ...).Token` example no longer binds to the `[string]$AccessToken` parameter. Examples now use `-ResourceTypeName MSGraph -AsSecureString` and convert to plain text. (lab-readiness validation)
+
+### Added
+
+- **`LAB-VALIDATION.md`** — static (no-tenant) lab-readiness validation report: authoritative Microsoft source verification of Graph endpoints/permissions/batching, PnP.PowerShell 3.x authentication, gaps found and fixed, and runtime-only caveats. (lab-readiness validation)
 ## [1.1.2] - 2026-05-23
 
 ### Fixed

--- a/agent-knowledge-source-scanner/LAB-VALIDATION.md
+++ b/agent-knowledge-source-scanner/LAB-VALIDATION.md
@@ -1,0 +1,108 @@
+# Lab Validation — Agent Knowledge Source Scanner
+
+> **Validation type:** Static (no live tenant). Parse-validity + authoritative Microsoft source verification + documentation completeness.
+> **Date:** 2026-06-04
+> **Solution version at validation:** v1.1.2 (+ `[Unreleased]` doc/permission corrections)
+
+## Purpose and controls
+
+Item-level permission scanning for SharePoint libraries that back Copilot Studio agent
+knowledge sources. Surfaces files/folders shared more broadly than an agent's intended
+audience (Anyone links, external/guest grants, org-wide links, sensitivity-label
+mismatches) and produces a risk-scored CSV.
+
+| Control | Pillar | Relationship |
+|---------|--------|--------------|
+| 4.3 | SharePoint | Primary — oversharing prevention for agent knowledge sources |
+| 1.4 | Security | Related — data boundary enforcement |
+| 1.5 | Security | Related — DLP and sensitivity labels |
+
+Regulatory context: GLBA 501(b) safeguards, FINRA Rule 4511 record-keeping, SEC 17a-3/4
+retention of access-review evidence.
+
+## What was checked
+
+- **Parse validity** of both PowerShell scripts (`Parser::ParseFile`, zero errors).
+- **Language rules** — grep for the prohibited absolute-compliance phrasing across
+  Markdown (excluding CHANGELOG history): zero hits.
+- **Authoritative verification** of every Microsoft Graph API, permission, batching, and
+  PnP.PowerShell authentication claim in the scripts and docs.
+- **Dataverse column naming** — N/A. This solution has no Dataverse integration; output is
+  CSV-only (confirmed in `.ralph-config.json`). No option sets or logical names to verify.
+- **No Power Platform runtime artifacts** — confirmed; solution ships scripts + docs +
+  one JSON config template only.
+
+## Authoritative sources cited
+
+| Claim (in code/docs) | Verified against | Result |
+|----------------------|------------------|--------|
+| `GET /drives/{driveId}/items/{itemId}/permissions` is **v1.0** and returns `permission` resources | [List permissions on a driveItem](https://learn.microsoft.com/graph/api/driveitem-list-permissions?view=graph-rest-1.0) | ✅ Confirmed |
+| Least-privileged permission for that endpoint | [List permissions — Permissions](https://learn.microsoft.com/graph/api/driveitem-list-permissions?view=graph-rest-1.0#permissions) | ✅ App: `Files.Read.All`; Delegated: `Files.Read`; higher: `Sites.Read.All`. **`Group.Read.All` not listed** |
+| `grantedToIdentitiesV2` resolves specific-people (link `scope: users`) grants | [permission resource type](https://learn.microsoft.com/graph/api/resources/permission?view=graph-rest-1.0) | ✅ Confirmed (Collection of `sharePointIdentitySet`, for link-type permissions) |
+| `link.scope` values handled (`anonymous`, `organization`, `users`) | [sharingLink resource type](https://learn.microsoft.com/graph/api/resources/sharinglink?view=graph-rest-1.0) | ✅ Confirmed; `existingAccess` also valid (falls to script's `default`/`OtherLink` branch) |
+| JSON batching hard cap of **20** requests; throttled sub-requests return `429` | [Combine multiple HTTP requests using JSON batching](https://learn.microsoft.com/graph/json-batching) | ✅ Confirmed ("limited to 20 individual requests") |
+| `Connect-PnPOnline -ManagedIdentity` with `-UserAssignedManagedIdentityClientId` / `ObjectId` / `AzureResourceId` | [Connect-PnPOnline](https://pnp.github.io/powershell/cmdlets/Connect-PnPOnline.html) | ✅ Confirmed — exact parameter sets used by the script |
+| PnP.PowerShell 3.x requires PowerShell **7.4+** and **.NET 8**; `Get-PnPAzureADGroupMember` → `Get-PnPEntraIDGroupMember` | PnP.PowerShell 3.0 release notes / [cmdlet docs](https://pnp.github.io/powershell/cmdlets/) | ✅ Confirmed |
+| Multi-tenant PnP app retired Sept 2024; interactive auth needs tenant-specific app via `Register-PnPEntraIDAppForInteractiveLogin` | PnP.PowerShell docs / 3.x migration guidance | ✅ Confirmed (consistent with vendor guidance) |
+| `Get-AzAccessToken` returns `.Token` as `SecureString` (Az.Accounts 5.x default) | [Get-AzAccessToken](https://learn.microsoft.com/powershell/module/az.accounts/get-azaccesstoken) | ✅ Confirmed; `-AsSecureString` / `-ResourceTypeName MSGraph` are current |
+
+## Gaps found and fixes applied
+
+### 1. Over-claimed Graph permission (`Group.Read.All`) — security/least-privilege
+- **Gap:** README "Microsoft Graph Permissions" table and `Invoke-GraphPermissionScan.ps1`
+  `.NOTES` listed `Group.Read.All` as required for the Graph scanner. The
+  list-permissions endpoint requires only `Files.Read.All` (app) / `Files.Read`
+  (delegated); `Sites.Read.All` is a higher-privileged alternative. The Graph scanner
+  never calls a group-membership endpoint — it reads group display names inline from the
+  `grantedToV2` / `grantedToIdentitiesV2` facets of each permission. For a governance
+  solution that itself enforces least privilege, documenting an unneeded directory-wide
+  read scope was a contradiction.
+- **Fix:** Rewrote the README permissions table to mirror the authoritative least-privileged
+  set, added the source link, and explicitly stated `Group.Read.All` is not required (group
+  names returned inline). Updated the script `.NOTES` to match. The PnP scanner's
+  `Group.Read.All` / `GroupMember.Read.All` requirement in `docs/prerequisites.md` is
+  **correct and unchanged** — that scanner does resolve group membership via
+  `Get-PnPEntraIDGroupMember`.
+
+### 2. `Get-AzAccessToken` example broken on current Az.Accounts — doc accuracy
+- **Gap:** Examples used `(Get-AzAccessToken -ResourceUrl "https://graph.microsoft.com").Token`
+  and fed the result to the `[string]$AccessToken` parameter. On Az.Accounts 5.x, `.Token`
+  is a `SecureString` by default, so this binds the type name (not the token) and auth fails.
+- **Fix:** Updated both examples (README and script `.EXAMPLE`) to
+  `(Get-AzAccessToken -ResourceTypeName MSGraph -AsSecureString).Token` and convert to plain
+  text via `[System.Net.NetworkCredential]` before passing to `-AccessToken`.
+
+### Items reviewed and intentionally left unchanged
+- **Risk scoring, batch ID↔index contract, claims-encoding comments** — already corrected in
+  prior council reviews (CHANGELOG 1.1.0–1.1.2); verified still accurate.
+- **PnP scanner auth, managed-identity-first ordering, certificate paths** — match current
+  `Connect-PnPOnline` parameter sets; no change needed.
+- **`manifest.yaml`** — not modified (no metadata drift; controls/version accurate).
+
+## Runtime-only caveats (cannot be verified without a live tenant)
+
+1. **`link.scope` population for specific-people links.** The Graph `sharingLink` example for
+   specific-people links does not always include `scope: "users"`. If a tenant returns such a
+   permission without `scope`, the scanner classifies it as `OtherLink` (via the `default`
+   switch branch) rather than `SpecificPeopleLink`; `grantedToIdentitiesV2` is still present in
+   the response but is only parsed under the `users` branch. Behavior is non-fatal but should be
+   confirmed against real tenant data; consider parsing `grantedToIdentitiesV2` regardless of
+   `scope` in a future revision.
+2. **Sensitivity-label field shape.** `_SensitivityLabel` may store GUIDs rather than display
+   names in some tenants; the config tier map must then use GUIDs. Documented in README/
+   troubleshooting; unverifiable statically.
+3. **Throttling/Retry-After timing.** The batch retry path honors per-sub-response `Retry-After`
+   and falls back to exponential backoff; the actual throttling thresholds are service-imposed
+   and only observable under load.
+4. **Managed identity SharePoint access (`Sites.Selected`) grants** and transitive group
+   expansion depend on tenant configuration and cannot be exercised here.
+
+## Lab-readiness assessment
+
+**Lab-ready (static validation passed).** Both scripts parse cleanly, all external API /
+permission / authentication assertions are confirmed against authoritative Microsoft and
+PnP.PowerShell sources, documentation is complete (prerequisites, step-by-step, expected
+outputs, troubleshooting), and the solution honors the no-runtime-artifact and language-rule
+conventions. Two documentation/permission gaps were corrected (least-privilege Graph scope and
+the Az.Accounts `SecureString` token example). Remaining caveats are inherently runtime-only and
+require a live tenant to exercise; they are documented above and do not block lab validation.

--- a/agent-knowledge-source-scanner/README.md
+++ b/agent-knowledge-source-scanner/README.md
@@ -195,13 +195,15 @@ Install-Module -Name PnP.PowerShell -MinimumVersion 2.5.0 -Force -Scope CurrentU
 
 ## Microsoft Graph Permissions
 
-When using the Graph v1.0 scanner (`Invoke-GraphPermissionScan.ps1`), the following Microsoft Graph application or delegated permissions are required:
+The Graph v1.0 scanner (`Invoke-GraphPermissionScan.ps1`) reads the [list permissions on a driveItem](https://learn.microsoft.com/graph/api/driveitem-list-permissions?view=graph-rest-1.0) endpoint. Choose the least-privileged permission that satisfies your flow:
 
 | Permission | Type | Purpose |
 |-----------|------|---------|
-| `Sites.Read.All` | Application or Delegated | Read SharePoint site and drive metadata |
-| `Files.Read.All` | Application or Delegated | Read file content and item permissions |
-| `Group.Read.All` | Application or Delegated | Resolve Entra ID group membership for permission grants |
+| `Files.Read.All` | Application (least privileged) | Read driveItem sharing permissions (`/drives/{driveId}/items/{itemId}/permissions`) |
+| `Files.Read` | Delegated (least privileged) | Read driveItem sharing permissions for the signed-in user |
+| `Sites.Read.All` | Application or Delegated (higher privileged) | Alternative when the app already holds site-level read; not required if `Files.Read[.All]` is granted |
+
+Permission set per the authoritative [list permissions](https://learn.microsoft.com/graph/api/driveitem-list-permissions?view=graph-rest-1.0#permissions) reference. `Group.Read.All` is **not** required for this scanner: group-based grants are returned inline in the `grantedToV2` / `grantedToIdentitiesV2` facets of each permission, so the script displays group display names without making a separate group-membership call.
 
 For delegated flows, the signed-in user must also have access to the target SharePoint site. For application-only flows, admin consent is required.
 
@@ -215,8 +217,10 @@ The `Invoke-GraphPermissionScan.ps1` script provides an alternative scan path us
 - Handles `Retry-After` headers on 429/503 responses; falls back to exponential backoff when the header is absent
 
 ```powershell
-# Get an access token (requires Sites.Read.All, Files.Read.All, Group.Read.All)
-$token = (Get-AzAccessToken -ResourceUrl "https://graph.microsoft.com").Token
+# Get an access token (least privileged: Files.Read.All for app-only, Files.Read for delegated)
+# Az.Accounts 5.x returns .Token as a SecureString by default; convert to plain text for the -AccessToken string parameter.
+$secureToken = (Get-AzAccessToken -ResourceTypeName MSGraph -AsSecureString).Token
+$token = [System.Net.NetworkCredential]::new('', $secureToken).Password
 
 # Scan permissions for specific drive items
 .\scripts\Invoke-GraphPermissionScan.ps1 `

--- a/agent-knowledge-source-scanner/scripts/Invoke-GraphPermissionScan.ps1
+++ b/agent-knowledge-source-scanner/scripts/Invoke-GraphPermissionScan.ps1
@@ -40,7 +40,9 @@
     Maximum retry attempts for throttled requests. Defaults to 5.
 
 .EXAMPLE
-    $token = (Get-AzAccessToken -ResourceUrl "https://graph.microsoft.com").Token
+    # Az.Accounts 5.x returns .Token as a SecureString; convert to plain text for -AccessToken.
+    $secureToken = (Get-AzAccessToken -ResourceTypeName MSGraph -AsSecureString).Token
+    $token = [System.Net.NetworkCredential]::new('', $secureToken).Password
     .\Invoke-GraphPermissionScan.ps1 -DriveId "b!abc123" -ItemIds @("01ABC","02DEF") -AccessToken $token
 
 .NOTES
@@ -49,10 +51,15 @@
     Framework:  FSI Agent Governance
     Controls:   4.3, 1.4, 1.5
 
-    Required Microsoft Graph permissions (application or delegated):
-    - Sites.Read.All  — Read site and drive metadata
-    - Files.Read.All  — Read file content and permissions
-    - Group.Read.All  — Resolve group-based permission grants
+    Required Microsoft Graph permissions (application or delegated) for the
+    list-permissions endpoint (https://learn.microsoft.com/graph/api/driveitem-list-permissions):
+    - Files.Read.All  — Read driveItem sharing permissions (application, least privileged)
+    - Files.Read      — Read driveItem sharing permissions (delegated, least privileged)
+    - Sites.Read.All  — Higher-privileged alternative; not required if Files.Read[.All] is granted
+
+    Group.Read.All is NOT required: group-based grants are returned inline in the
+    grantedToV2 / grantedToIdentitiesV2 facets, so no separate group-membership
+    call is made.
 
     For delegated flows, the signed-in user must also have access to the
     target SharePoint site.


### PR DESCRIPTION
## Summary

Static (no live tenant) lab-readiness validation of **agent-knowledge-source-scanner** (controls 4.3, 1.4, 1.5). Verified every Microsoft Graph and PnP.PowerShell claim against authoritative Microsoft sources, fixed two documentation/permission gaps, and added an evidence report (LAB-VALIDATION.md).

## What changed and why

- **Least-privilege Graph permission corrected.** The Graph v1.0 scanner docs/.NOTES listed Group.Read.All as required. The [list-permissions endpoint](https://learn.microsoft.com/graph/api/driveitem-list-permissions?view=graph-rest-1.0#permissions) requires only `Files.Read.All` (application) / `Files.Read` (delegated), with `Sites.Read.All` as a higher-privileged alternative. Group grants are returned **inline** in the `grantedToV2`/`grantedToIdentitiesV2` facets, so no group-membership call (and no `Group.Read.All`) is made. The PnP scanner's `Group.Read.All`/`GroupMember.Read.All` requirement is correct and left unchanged.
- **`Get-AzAccessToken` example fixed for Az.Accounts 5.x**, which returns `.Token` as a `SecureString` by default — the old plaintext `.Token` example no longer binds to the `[string] -AccessToken` parameter. Examples now use `-ResourceTypeName MSGraph -AsSecureString` and convert to plain text.
- **Added `LAB-VALIDATION.md`** with source citations, gaps/fixes, and runtime-only caveats.

## Authoritative sources

- List permissions on a driveItem (v1.0) + required permissions
- permission / sharingLink resource types (`grantedToIdentitiesV2`, `link.scope` values)
- Microsoft Graph JSON batching (20-request cap)
- `Connect-PnPOnline` (managed-identity parameter sets); PnP.PowerShell 3.x (PowerShell 7.4 / .NET 8, `Get-PnPEntraIDGroupMember`)
- `Get-AzAccessToken` (SecureString default)

## Caveats (runtime-only, documented in LAB-VALIDATION.md)

`link.scope` population for specific-people links, sensitivity-label field shape (GUID vs name), throttling timing, and managed-identity/`Sites.Selected` grants require a live tenant to exercise.

## Verification

- Both `.ps1` parse cleanly (`Parser::ParseFile`, zero errors)
- No prohibited compliance-language hits in Markdown (excl. CHANGELOG)
- Config template JSON valid
- `manifest.yaml` **not** modified

No Dataverse integration (CSV-only), so no column-naming/option-set validation applies.