### PR TITLE
docs(audit-compliance-manager): lab-readiness validation and corrections

### DIFF
--- a/audit-compliance-manager/CHANGELOG.md
+++ b/audit-compliance-manager/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Operator ergonomics (Wave 6 P4a):** State-changing scripts now support `-WhatIf` and `-Confirm` switches via `SupportsShouldProcess`. Existing callers see no behavior change unless they explicitly pass `-WhatIf`.
+- **Lab-readiness validation pass:** Aligned `ExchangeOnlineManagement` minimum-version references to the enforced `#Requires` gate (`3.0.0`/`3.0+`). NOTES prose, the install-hint error message in `private/Connect-AuditServices.ps1`, `SOLUTION-DOCUMENTATION.md`, and `docs/flow-setup.md` previously said `3.7.0`, contradicting every `#Requires` statement (`3.0.0`) and the README runtime table (`3.0+`).
+- **Audit-access modernization note:** Added a README "Platform Update Notes" subsection documenting that `Search-UnifiedAuditLog` remains the supported cmdlet (the retiring `Search-MailboxAuditLog` / `New-MailboxAuditLogSearch` cmdlets are not used here) and that the Microsoft Graph `auditLogQuery` API (`AuditLogsQuery.Read.All`) is the recommended modern programmatic path to evaluate for a future release. Authoritative Microsoft Learn sources cited. See `LAB-VALIDATION.md`.
 
 ### Fixed
 

--- a/audit-compliance-manager/LAB-VALIDATION.md
+++ b/audit-compliance-manager/LAB-VALIDATION.md
@@ -1,0 +1,124 @@
+# Lab Validation Report — Audit Compliance Manager (ACM)
+
+> **Solution:** audit-compliance-manager · **Version:** v1.0.5 (Unreleased changes pending)
+> **Primary control:** 1.7 (Audit logging) · **Tier:** 2
+> **Validation type:** Static (no live tenant) — parse-validity, authoritative-source verification, documentation completeness
+> **Date:** 2026-06-04
+
+## Purpose and scope
+
+ACM is a unified audit-compliance solution merging the Audit Configuration
+Validator (ACV) and Audit Logging Compliance Automation (ALCA). It validates
+tenant- and environment-level audit configuration, detects compliance gaps,
+remediates non-compliant Power Platform environments by enabling Dataverse
+auditing, and exports SHA-256-hashed evidence. It supports compliance with
+FINRA Rule 4511, SEC Rule 17a-3/17a-4, GLBA 501(b), and SOX Section 404
+record-keeping requirements (no single control satisfies a regulation in
+isolation).
+
+This pass brought the solution to a lab-ready steady state through static
+validation against authoritative Microsoft sources. The solution had already
+passed several prior council reviews (see CHANGELOG v1.0.1–v1.0.5), so it
+entered this pass in strong shape; findings were limited to documentation drift
+and a forward-looking platform note.
+
+## What was checked
+
+| Area | Method | Result |
+|------|--------|--------|
+| PowerShell parse validity (changed `.ps1`) | `Parser::ParseFile` (0 errors) | Pass |
+| Python compile validity (`.py`) | `python -m py_compile` | Pass |
+| Language rules (no absolute compliance-guarantee phrasing) | grep across solution (excl. CHANGELOG history) | Pass — 0 hits |
+| Dataverse column naming (logical names, no inter-word underscores) | grep `fsi_*_*` + schema cross-check | Pass — all hits are option-set / connection-reference / alternate-key names or intentional "invalid" test fixtures |
+| Option-set values documented as `100000000+` (not `0/1/2`) | inspect `private/Get-ValidationResults.ps1`, `Write-ValidationResult.ps1` | Pass |
+| Audit cmdlet currency (`Search-UnifiedAuditLog`, `Get-AdminAuditLogConfig`) | Microsoft Learn | Pass — current |
+| Managed-identity-first auth + token audiences | inspect `AuditComplianceHelpers.psm1` | Pass |
+| Module version consistency (`ExchangeOnlineManagement`) | grep across solution | **Fixed** — drift `3.7.0` vs `3.0.0` |
+| Graph Audit Query API permission name | Microsoft Learn | **Corrected during drafting** — `AuditLogsQuery.Read.All` |
+
+## Authoritative sources cited (exact URLs)
+
+- Turn auditing on or off (`Get-AdminAuditLogConfig | FL UnifiedAuditLogIngestionEnabled`, `Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled $true`, Audit Logs role requirement, on-by-default) — https://learn.microsoft.com/purview/audit-log-enable-disable
+- `Search-UnifiedAuditLog` reference (current cmdlet; replacement for retiring mailbox audit cmdlets) — https://learn.microsoft.com/powershell/module/exchangepowershell/search-unifiedauditlog
+- Microsoft Graph `auditLogQuery` resource + `List auditLogQueries` (permission `AuditLogsQuery.Read.All` and workload-scoped variants; `GET /security/auditLog/queries`) — https://learn.microsoft.com/graph/api/resources/security-auditlogquery
+- Azure Automation managed identity token endpoint (`IDENTITY_ENDPOINT` / `X-IDENTITY-HEADER`, `api-version=2019-08-01`) — https://learn.microsoft.com/azure/automation/enable-managed-identity-for-automation
+- Microsoft Graph `users: sendMail` (requires `Mail.Send`) — https://learn.microsoft.com/graph/api/user-sendmail
+
+All cited Learn URLs were confirmed to return HTTP 200 during this pass.
+
+## Authoritative findings (verification detail)
+
+1. **`Search-UnifiedAuditLog` is current, not deprecated.** The "this cmdlet will
+   be deprecated" note in the Exchange audit docs refers to the mailbox-specific
+   cmdlets (`Search-MailboxAuditLog`, `New-MailboxAuditLogSearch`), which point
+   operators *to* `Search-UnifiedAuditLog`. ACM uses only
+   `Search-UnifiedAuditLog`, so it is unaffected. Mailbox-specific cmdlets are
+   retiring at the end of 2025.
+2. **`Get-AdminAuditLogConfig` remains the documented enablement check.** Microsoft
+   Learn still shows `Get-AdminAuditLogConfig | Format-List UnifiedAuditLogIngestionEnabled`
+   (Exchange Online PowerShell) as the verification method, and
+   `Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled $true` to enable —
+   matching the scripts. The script comment that the Security & Compliance
+   PowerShell variant returns `False` for this property is a correct, important
+   caveat.
+3. **Graph Audit Query API permission corrected.** The modern Graph audit path
+   uses `AuditLogsQuery.Read.All` (plus workload variants like
+   `AuditLogsQuery-Entra.Read.All`) — **not** `AuditLog.Read.All` (a distinct
+   directory-audit permission). The initial README draft was corrected before
+   commit.
+4. **Managed-identity auth verified.** `Get-ManagedIdentityToken` uses the Azure
+   Automation IMDS endpoint with `api-version=2019-08-01`; the Dataverse token
+   audience is the environment org URL and the Graph token audience is
+   `https://graph.microsoft.com` for `sendMail` — correct audiences per service.
+
+## Gaps found and fixes applied
+
+### Fixed in this pass
+
+- **`ExchangeOnlineManagement` version drift (documentation/consistency).** Every
+  `#Requires` gate enforces `3.0.0` and the README runtime table says `3.0+`, but
+  NOTES prose, the install-hint error message in
+  `private/Connect-AuditServices.ps1`, `SOLUTION-DOCUMENTATION.md` (2 places), and
+  `docs/flow-setup.md` (3 places) said `3.7.0`. A lab operator following the error
+  message would install a stricter minimum than the code enforces. Aligned all
+  prose down to `3.0.0`/`3.0+` to match the authoritative `#Requires` gate. No
+  cmdlet/parameter used by ACM requires 3.7.0.
+- **Audit-access modernization note added.** New README "Platform Update Notes"
+  subsection records the `Search-UnifiedAuditLog` vs Graph `auditLogQuery`
+  distinction, the retiring mailbox cmdlets (not used here), and the recommended
+  future migration path — with authoritative citations.
+
+### Not changed (verified correct as-is)
+
+- Audit cmdlets and parameters, mailbox-audit inverted-logic handling
+  (`AuditDisabled`), canary-event dual-validation, Purview retention via
+  `Get-UnifiedAuditLogRetentionPolicy` / `New-UnifiedAuditLogRetentionPolicy`,
+  managed-identity-first auth, option-set values, Dataverse logical names, and
+  the documented certificate/MSAL.PS fallbacks (already flagged as
+  dev-only/legacy with a pinned `4.37.0` and deprecation note).
+- `manifest.yaml` was **not** modified.
+
+## Runtime-only caveats (cannot be statically verified)
+
+- Live behavior of `Search-UnifiedAuditLog` canary retrieval depends on
+  tenant-specific audit ingestion lag (script allows a configurable grace period
+  up to 24h).
+- Actual unified audit log **retention** is license-bounded (Audit Standard
+  180 days for records on/after 2023-10-17; Audit Premium/E5 1 year default; 10
+  years with the add-on). The solution flags shortfalls but cannot extend
+  retention beyond licensing — documented accurately in README.
+- Managed-identity role assignments (Power Platform Admin, Exchange Online Admin,
+  `Mail.Send`, Dataverse application user) must exist in the target tenant;
+  presence cannot be confirmed without a live environment.
+- Dataverse table creation, alternate-key upsert behavior, and Power Automate
+  approval flows require a live environment to exercise end-to-end.
+
+## Lab-readiness assessment
+
+**Lab-ready.** All changed scripts parse cleanly, all Python compiles, there are
+zero regulatory-language violations, Dataverse naming and option-set values are
+correct, and the audit APIs/cmdlets/permissions in scripts and docs are verified
+against current authoritative Microsoft sources. The only corrections needed were
+documentation-level (module-version drift) plus an additive forward-looking
+platform note. Remaining unknowns are inherent runtime/tenant dependencies that
+require a live environment and are documented above.

--- a/audit-compliance-manager/README.md
+++ b/audit-compliance-manager/README.md
@@ -309,6 +309,30 @@ Microsoft has expanded the [Power Platform REST API](https://learn.microsoft.com
 
 > **Note:** DSR compliance automation is not yet included in ACM scripts. Organizations should track DSR capabilities through their privacy operations program and evaluate integration in a future release.
 
+### Audit log access: Exchange Online cmdlet vs Microsoft Graph Audit Query API
+
+This solution reads the unified audit log through Exchange Online PowerShell
+([`Search-UnifiedAuditLog`](https://learn.microsoft.com/powershell/module/exchangepowershell/search-unifiedauditlog))
+and checks enablement with
+[`Get-AdminAuditLogConfig`](https://learn.microsoft.com/purview/audit-log-enable-disable).
+Two related platform changes are worth tracking:
+
+- **Mailbox-specific audit cmdlets are retiring.** Microsoft has announced the
+  retirement of `Search-MailboxAuditLog` and `New-MailboxAuditLogSearch`. This
+  solution does **not** use those cmdlets — `Search-UnifiedAuditLog` is the
+  supported replacement and remains current. See the
+  [Search-UnifiedAuditLog reference](https://learn.microsoft.com/powershell/module/exchangepowershell/search-unifiedauditlog).
+- **The Microsoft Graph Audit Query API is the modern programmatic path.** The
+  [`auditLogQuery` API](https://learn.microsoft.com/graph/api/resources/security-auditlogquery)
+  (under `/security/auditLog/queries`) is generally available and offers
+  asynchronous search and granular `AuditLogsQuery.Read.All` permissions (plus
+  workload-scoped variants such as `AuditLogsQuery-Entra.Read.All`). ACM still
+  uses the cmdlet for tenant validation because it is simpler to run from Azure
+  Automation runbooks and aligns with the canary-event verification pattern.
+  Migrating the audit-search steps to the Graph Audit Query API is recommended
+  to evaluate for a future minor release; it is not required for current
+  lab-readiness because the cmdlet path remains supported.
+
 ## Components
 
 ### Scripts

--- a/audit-compliance-manager/SOLUTION-DOCUMENTATION.md
+++ b/audit-compliance-manager/SOLUTION-DOCUMENTATION.md
@@ -482,7 +482,7 @@ python create_audit_compliance_schema.py \
 | Module | Version | Purpose |
 |--------|---------|---------|
 | `Microsoft.PowerApps.Administration.PowerShell` | 2.0+ | Power Platform environment management |
-| `ExchangeOnlineManagement` | 3.7.0+ | Exchange Online MI auth, audit log search |
+| `ExchangeOnlineManagement` | 3.0+ | Exchange Online MI auth, audit log search |
 | `AuditComplianceHelpers` | 1.0.0 | ALCA shared helper module (custom) |
 
 #### Configuration Steps
@@ -550,7 +550,7 @@ For each Power Platform environment with Dataverse:
 1. Navigate to **Azure Automation Account** → **Modules** → **Browse gallery**
 2. Search and import:
    - `Microsoft.PowerApps.Administration.PowerShell` (version 2.0+)
-   - `ExchangeOnlineManagement` (version 3.7.0+)
+   - `ExchangeOnlineManagement` (version 3.0+)
 3. Wait for import completion (Status: Available)
 
 **Step 4: Upload Custom Helper Module**

--- a/audit-compliance-manager/docs/flow-setup.md
+++ b/audit-compliance-manager/docs/flow-setup.md
@@ -26,7 +26,7 @@ Before creating the flows, ensure you have:
 - [ ] **Azure subscription** with Automation Account containing:
   - Start-TenantValidationRunbook.ps1 (imported as PowerShell 7.2 runbook)
   - Start-EnvironmentValidationRunbook.ps1 (imported as PowerShell 7.2 runbook)
-  - Required PowerShell modules installed (MSAL.PS 4.37.0, ExchangeOnlineManagement 3.7.0+, Microsoft.PowerApps.Administration.PowerShell 2.0.180+)
+  - Required PowerShell modules installed (MSAL.PS 4.37.0, ExchangeOnlineManagement 3.0+, Microsoft.PowerApps.Administration.PowerShell 2.0.180+)
   - Certificate uploaded for service principal authentication
 - [ ] **Power Automate Premium license** (required for Azure Automation connector)
 - [ ] **Microsoft Teams** with Workflows app installed and channel created for alerts
@@ -83,7 +83,7 @@ Navigate to **Automation Account** > **Modules** > **Browse gallery** and import
 | Module | Version | Purpose |
 |--------|---------|---------|
 | MSAL.PS | 4.37.0 | Dataverse Web API token acquisition |
-| ExchangeOnlineManagement | 3.7.0 | Tenant-level audit configuration checks |
+| ExchangeOnlineManagement | 3.0+ | Tenant-level audit configuration checks |
 | Microsoft.PowerApps.Administration.PowerShell | 2.0.180+ | Environment discovery and validation |
 
 **Important:** Wait for each module to finish importing before starting the next one (status = "Available").
@@ -564,7 +564,7 @@ This table defines the alert behavior based on validation status:
 1. Navigate to **Automation Account** > **Modules**
 2. Check module versions match requirements:
    - MSAL.PS: 4.37.0
-   - ExchangeOnlineManagement: 3.7.0
+   - ExchangeOnlineManagement: 3.0+
    - Microsoft.PowerApps.Administration.PowerShell: 2.0.0
 3. Update modules if needed (may require reimporting)
 

--- a/audit-compliance-manager/scripts/Invoke-TenantAuditValidation.ps1
+++ b/audit-compliance-manager/scripts/Invoke-TenantAuditValidation.ps1
@@ -100,7 +100,7 @@
 .NOTES
     Version: 1.0.4
     Requires:
-    - ExchangeOnlineManagement module v3.7.0 or later
+    - ExchangeOnlineManagement module v3.0.0 or later
     - PowerShell 7.0 or later
     - Exchange Online Admin or Entra Global Admin role
     - Purview Compliance Admin role (for Purview retention validation)

--- a/audit-compliance-manager/scripts/Test-MailboxAudit.ps1
+++ b/audit-compliance-manager/scripts/Test-MailboxAudit.ps1
@@ -57,7 +57,7 @@
 .NOTES
     Version: 1.0.2
     Requires:
-    - ExchangeOnlineManagement module v3.7.0 or later
+    - ExchangeOnlineManagement module v3.0.0 or later
     - Exchange Online Administrator or Global Administrator role
     - For service principal: Application with Exchange.ManageAsApp permission
 

--- a/audit-compliance-manager/scripts/Test-PurviewRetention.ps1
+++ b/audit-compliance-manager/scripts/Test-PurviewRetention.ps1
@@ -73,7 +73,7 @@
 .NOTES
     Version: 1.0.4
     Requires:
-    - ExchangeOnlineManagement module v3.7.0 or later
+    - ExchangeOnlineManagement module v3.0.0 or later
     - Security & Compliance PowerShell connection for retention policies
     - Purview Compliance Admin or Entra Global Admin role
     - For service principal: Application with Compliance.ManageAsApp permission

--- a/audit-compliance-manager/scripts/Test-UnifiedAuditLog.ps1
+++ b/audit-compliance-manager/scripts/Test-UnifiedAuditLog.ps1
@@ -80,7 +80,7 @@
 .NOTES
     Version: 1.0.4
     Requires:
-    - ExchangeOnlineManagement module v3.7.0 or later
+    - ExchangeOnlineManagement module v3.0.0 or later
     - Exchange Online Admin or Entra Global Admin role
     - For service principal: Application with Exchange.ManageAsApp permission
 

--- a/audit-compliance-manager/scripts/private/Connect-AuditServices.ps1
+++ b/audit-compliance-manager/scripts/private/Connect-AuditServices.ps1
@@ -53,7 +53,7 @@
 
 .NOTES
     Version: 1.0.4
-    Requires ExchangeOnlineManagement module v3.7.0 or later.
+    Requires ExchangeOnlineManagement module v3.0.0 or later.
 
     IMPORTANT: Get-AdminAuditLogConfig must be called via Exchange Online PowerShell,
     NOT Security & Compliance PowerShell. The UnifiedAuditLogIngestionEnabled property
@@ -161,7 +161,7 @@ function Connect-AuditServices {
         }
     }
     catch [System.Management.Automation.CommandNotFoundException] {
-        throw "ExchangeOnlineManagement module not found. Install with: Install-Module ExchangeOnlineManagement -MinimumVersion 3.7.0"
+        throw "ExchangeOnlineManagement module not found. Install with: Install-Module ExchangeOnlineManagement -MinimumVersion 3.0.0"
     }
     catch {
         throw "Failed to connect to audit services: $($_.Exception.Message)"


### PR DESCRIPTION
## Summary

Static **lab-readiness validation** pass for `audit-compliance-manager` (v1.0.5, control 1.7). No live tenant — validation was parse-validity + authoritative Microsoft-source verification + documentation completeness. The solution was already mature from prior council reviews, so findings were documentation-level plus one additive platform note.

## What & why

- **ExchangeOnlineManagement version drift fixed.** Every `#Requires` gate enforces `3.0.0` and the README runtime table says `3.0+`, but NOTES prose, the install-hint error message in `private/Connect-AuditServices.ps1`, `SOLUTION-DOCUMENTATION.md`, and `docs/flow-setup.md` said `3.7.0`. A lab operator following the error message would install a stricter minimum than the code enforces. Aligned all prose down to `3.0.0`/`3.0+` (the authoritative `#Requires` gate). No cmdlet/parameter used by ACM requires 3.7.0.
- **Audit-access modernization note added** to README "Platform Update Notes": `Search-UnifiedAuditLog` remains the supported cmdlet (the retiring `Search-MailboxAuditLog` / `New-MailboxAuditLogSearch` cmdlets are **not** used here); the Microsoft Graph `auditLogQuery` API (`AuditLogsQuery.Read.All`) is the recommended modern programmatic path to evaluate for a future release.
- **`LAB-VALIDATION.md`** evidence report added at the solution root.

## Authoritative sources (all confirmed HTTP 200)

- https://learn.microsoft.com/purview/audit-log-enable-disable
- https://learn.microsoft.com/powershell/module/exchangepowershell/search-unifiedauditlog
- https://learn.microsoft.com/graph/api/resources/security-auditlogquery
- https://learn.microsoft.com/azure/automation/enable-managed-identity-for-automation
- https://learn.microsoft.com/graph/api/user-sendmail

## Owl-mode note

Initial README draft cited the wrong Graph permission (`AuditLog.Read.All`); verified against Microsoft Learn and corrected to `AuditLogsQuery.Read.All` before commit.

## Verification

- Changed `.ps1` parse clean (`Parser::ParseFile`, 0 errors).
- Zero regulatory-language violations (grep, excl. CHANGELOG history).
- Dataverse logical names and option-set values (`100000000+`) correct; managed-identity-first auth and token audiences correct.
- `manifest.yaml` **untouched**.

## Caveats (runtime-only, require a live tenant)

Audit ingestion lag, license-bounded retention, managed-identity role assignments, Dataverse table/upsert behavior, and Power Automate approval flows can only be exercised end-to-end in a live environment. Documented in `LAB-VALIDATION.md`.