### PR TITLE
fix(agent-registry-automation): lab-readiness validation and corrections

### DIFF
--- a/agent-registry-automation/.ralph-config.json
+++ b/agent-registry-automation/.ralph-config.json
@@ -3,6 +3,7 @@
     "There are significant schema-script mismatches in this solution. The create_dataverse_schema.py is the source of truth. Scripts and flow docs reference different column names (e.g., fsi_botframeworkendpoint vs fsi_agentendpointurl, fsi_requeststatus vs fsi_approvalstatus). Full alignment is needed.",
     "Environment variable and connection reference names in create_*_environment_variables.py and create_*_connection_references.py do not match what README/flow-configuration.md reference. Validate actual deployed names against script output.",
     "Microsoft Entra Agent ID for Copilot Studio is preview. Verify current Graph beta endpoints and permission names against Microsoft Learn before enabling Flow 3.",
-    "HTTP with Microsoft Entra ID (preauthorized) is the current connector name — avoid legacy connector naming."
+    "HTTP with Microsoft Entra ID (preauthorized) is the current connector name — avoid legacy connector naming.",
+    "Discovery (v2.1.1 lab-validation): there is NO Power Platform 'Bots API'. Agent discovery enumerates environments via the BAP admin API (https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments?api-version=2020-10-01, audience https://service.powerapps.com/) and reads each environment's Dataverse `bot` table (entity set `bots`, PK `botid`, name `name`). The `bot` table has no botFrameworkEndpoint column; fsi_agentendpointurl is left blank at discovery. Prior `/appmanagement/.../bots?api-version=2022-03-01-preview` route was unverified/incorrect (AppManagement namespace is for Microsoft app packages)."
   ]
 }

--- a/agent-registry-automation/CHANGELOG.md
+++ b/agent-registry-automation/CHANGELOG.md
@@ -6,7 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [2.1.1] - 2026-05-23
+## [Unreleased]
+
+### Fixed
+
+- **Major (discovery API correction):** Replaced the unverified Power Platform "Bots API" discovery surface with authoritative Microsoft APIs. Environment enumeration now uses the documented BAP admin API (`https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments?api-version=2020-10-01`, audience `https://service.powerapps.com/`), and agent enumeration reads each environment's Dataverse `bot` table (entity set `bots`, PK `botid`, name `name`). The prior `https://api.powerplatform.com/appmanagement/environments/{id}/bots?api-version=2022-03-01-preview` route is undocumented and conflicts with the AppManagement namespace (which is scoped to Microsoft-provided application packages, per the Power Platform REST API reference). Affects `scripts/Deploy-AgentRegistry-Baseline.ps1` and `docs/flow-configuration.md` (Flow 1). The `2.0.0` change that swapped `/powervirtualagents/.../bots` for `/appmanagement/.../bots` was itself unverified.
+- **Major:** Removed the `properties.botFrameworkEndpoint` → `fsi_agentendpointurl` mapping. The Dataverse `bot` table has no Bot Framework endpoint column ([bot table reference](https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/bot)); `fsi_agentendpointurl` is left blank during discovery.
+- **Major (auth audiences):** Baseline script now requests a BAP token (audience `https://service.powerapps.com/`) for environment enumeration and a per-environment Dataverse token (audience = each environment's `instanceUrl` from `properties.linkedEnvironmentMetadata`) for `bot`-table reads, instead of a single `https://api.powerplatform.com` token.
+- **Major:** Corrected prerequisite permissions — removed the non-existent `Bot.Read.All` / `Environment.Read.All` Power Platform API application permissions. Environment enumeration is authorized by the Power Platform Admin role; agent discovery requires a Dataverse security role with `bot`-table read in each scanned environment. `docs/prerequisites.md`, `docs/troubleshooting.md`.
+- **Minor:** Updated network endpoint list (`api.bap.microsoft.com` replaces `api.powerplatform.com`), connection-reference descriptions, README architecture diagram, Known Limitations, and Platform Update Notes to match the corrected discovery mechanism.
+- **Minor:** Reworded the README Agent Store future-enhancement bullet ("add an `fsi_agentsource` choice column" instead of "extending" a non-existent choice set).
+
+### Notes
+
+- Verified against Microsoft Learn (June 2026): Power Platform REST API reference, BAP "List environments", Dataverse `bot` table reference, and Power Platform programmability authentication. See `LAB-VALIDATION.md` for the full evidence report and runtime-only caveats.
+- Version header and manifest bump deferred to maintainer: these corrections warrant a minor version bump (suggest `2.2.0`) plus the standard 4-file catalog sync and `manifest.yaml` update, which were intentionally left untouched in this validation pass.
+
+---
 
 ### Fixed
 

--- a/agent-registry-automation/CHANGELOG.md
+++ b/agent-registry-automation/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [2.1.1] - 2026-05-23
+
 ### Fixed
 
 - **Major**: Replaced `contoso.crm.dynamics.com` with `example.crm.dynamics.com` (RFC 2606) in `fsi_ARA_DataverseEnvironmentUrl` description. `scripts/create_environment_variables.py:108`. (council review M2)

--- a/agent-registry-automation/DELIVERY-CHECKLIST.md
+++ b/agent-registry-automation/DELIVERY-CHECKLIST.md
@@ -30,7 +30,7 @@
 ## Phase 2: Environment Preparation
 
 - [ ] Verify target environment is Managed Environment
-- [ ] Register Microsoft Entra ID application for Bots API and Graph API access
+- [ ] Register Microsoft Entra ID application for BAP environment enumeration, Dataverse, and Graph API access
 - [ ] Grant required API permissions and admin consent (see `docs/prerequisites.md`)
 - [ ] Configure managed identity, workload identity federation, or certificate authentication; use client secrets only for legacy development fallback
 - [ ] Verify Dataverse capacity is sufficient for agent inventory and compliance events
@@ -76,7 +76,7 @@
 - [ ] Run `scripts/create_connection_references.py` to deploy connection references
 - [ ] Bind each connection reference to an active connection:
   - `fsi_cr_dataverse_agentregistry` — Dataverse
-  - `fsi_cr_http_agentregistry` — HTTP with Microsoft Entra ID (Bots API + Graph API)
+  - `fsi_cr_http_agentregistry` — HTTP with Microsoft Entra ID (BAP environment enumeration + Graph API)
   - `fsi_cr_teams_agentregistry` — Microsoft Teams
   - `fsi_cr_office365_agentregistry` — Office 365
 
@@ -88,7 +88,7 @@ Follow the step-by-step instructions in `docs/flow-configuration.md` for each fl
 
 - [ ] **Flow 1: Discover-UnregisteredAgents-Daily**
   - Build trigger (Recurrence — daily)
-  - Build environment enumeration (HTTP with Microsoft Entra ID → Bots API)
+  - Build environment enumeration (HTTP with Microsoft Entra ID → BAP admin API) and per-environment Dataverse `bot` table reads
   - Build Dataverse upsert logic (alternate key)
   - Build Zone 3 auto-quarantine branch
   - Build compliance event logging
@@ -123,7 +123,7 @@ Follow the step-by-step instructions in `docs/flow-configuration.md` for each fl
 - [ ] Run `scripts/Deploy-AgentRegistry-Baseline.ps1` to seed the agent inventory
 - [ ] Review baseline export output for accuracy
 - [ ] Verify agent records appear in Dataverse with correct zone classifications
-- [ ] Confirm agent count matches expected number from Bots API
+- [ ] Confirm agent count matches the expected number of rows in each environment's Dataverse `bot` table
 
 ---
 
@@ -154,9 +154,15 @@ Follow the step-by-step instructions in `docs/flow-configuration.md` for each fl
 
 ## Pre-Handoff Notes
 
-### BotFrameworkEndpoint Field Name
+### Agent Endpoint URL Field
 
-The `properties.botFrameworkEndpoint` field path in the Bots API response has been documented based on API specification review. **Confirm the exact field path** against a live API response in the customer's environment before enabling Flow 1 in production. The flow includes error handling for missing or renamed fields.
+The Dataverse `bot` table has no Bot Framework endpoint column, so
+`fsi_agentendpointurl` is left blank during discovery. If your governance
+process requires an endpoint URL, populate it later from the agent's channel
+configuration. The flow includes error handling for missing or renamed fields
+on the `bot` table (for example, owner-expand columns that vary by Dataverse
+version) — confirm the exact column availability against a live environment
+before enabling Flow 1 in production.
 
 ### Office 365 Users Connector (DLP Consideration)
 

--- a/agent-registry-automation/LAB-VALIDATION.md
+++ b/agent-registry-automation/LAB-VALIDATION.md
@@ -1,0 +1,127 @@
+# Lab Validation Report — Agent Registry Automation
+
+> Static validation performed without a live tenant. Scope: parse-validity,
+> authoritative-source verification of every documented API/permission/endpoint,
+> and documentation completeness. Validated June 2026 against Microsoft Learn.
+
+## Solution purpose and controls
+
+Automated discovery, registration, approval, and lifecycle governance of AI
+agents across Power Platform. Version 2.1.1. Primary controls: **1.2** (Agent
+Registry and Integrated Apps Management), **1.7** (Comprehensive Audit Logging),
+**2.1** (Managed Environments), **2.13** (Documentation and Record Keeping).
+Supports compliance with FINRA Rule 4511, SEC Rule 17a-3/4, OCC Bulletin
+2011-12, Fed SR 11-7, and GLBA 501(b). No single control satisfies a regulation
+in isolation.
+
+## What was checked
+
+- PowerShell parse-validity (`Parser::ParseFile`) on both `.ps1` scripts — 0 errors.
+- Python `py_compile` on all five `.py` scripts — pass.
+- Every Dataverse column / entity-set reference in scripts and docs against the
+  canonical schema in `scripts/create_dataverse_schema.py` and the generated
+  `docs/dataverse-schema.md` (logical names, option-set values 100000000+).
+- Every documented API endpoint, API version, auth audience, and permission name
+  against authoritative Microsoft sources.
+- Managed-identity-first auth patterns and correct token audiences per service.
+- FSI regulatory language rules across edited Markdown.
+
+## Authoritative sources cited
+
+| Topic | Source URL |
+|-------|-----------|
+| Power Platform REST API reference (namespaces; AppManagement = Microsoft-provided application packages) | https://learn.microsoft.com/rest/api/power-platform/ |
+| BAP "List environments" (admin) — `api.bap.microsoft.com/.../scopes/admin/environments?api-version=2020-10-01` | https://learn.microsoft.com/rest/api/power-platform/ |
+| Power Platform programmability authentication — scopes `https://api.powerplatform.com/.default` and `https://service.powerapps.com//.default` | https://learn.microsoft.com/power-platform/admin/programmability-authentication |
+| Dataverse `bot` (Copilot) table — EntitySetName `bots`, PK `botid`, PrimaryName `name`, no `botFrameworkEndpoint` column | https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/bot |
+| Copilot Studio Agent Inventory (`bot`/`botcomponent` Dataverse tables) | https://learn.microsoft.com/microsoft-copilot-studio/guidance/kit-agent-inventory-data-source |
+| `ILinkedEnvironmentMetadata.instanceUrl` (environment Dataverse org URL) | https://learn.microsoft.com/javascript/api/@microsoft/powerapps/ilinkedenvironmentmetadata |
+| Cross-environment Dataverse connector usage | https://learn.microsoft.com/power-automate/dataverse/connect-other-environments |
+
+## Gaps found and fixes applied
+
+### 1. Fabricated "Bots API" discovery surface (High) — fixed
+
+The discovery design used `https://api.powerplatform.com/appmanagement/environments/{id}/bots?api-version=2022-03-01-preview`.
+The Power Platform REST API reference scopes the **AppManagement** namespace to
+"managing installation for Microsoft-provided application packages in Dataverse"
+— it has no `/bots` route. The authoritative agent inventory is the Dataverse
+`bot` table. The CHANGELOG shows this path was previously guessed twice
+(`/powervirtualagents/.../bots` → `/appmanagement/.../bots`) and never verified.
+
+**Fix:** `Deploy-AgentRegistry-Baseline.ps1` and `docs/flow-configuration.md`
+(Flow 1) now:
+- Enumerate environments via the BAP admin API (`scopes/admin/environments?api-version=2020-10-01`).
+- Read agents from each environment's Dataverse `bot` table (`GET {instanceUrl}/api/data/v9.2/bots`),
+  mapping `botid` → `fsi_agentid` and `name` → `fsi_agentname`.
+
+### 2. Non-existent `botFrameworkEndpoint` column (High) — fixed
+
+`properties.botFrameworkEndpoint` was mapped to `fsi_agentendpointurl`. The `bot`
+table has no such column. **Fix:** mapping removed; `fsi_agentendpointurl` is left
+blank during discovery, with a note to populate from channel config if required.
+
+### 3. Wrong/missing token audiences (Medium) — fixed
+
+The script acquired a single `https://api.powerplatform.com` token for both
+environment listing and bot reads. **Fix:** BAP enumeration uses audience
+`https://service.powerapps.com/`; per-environment `bot`-table reads use a token
+whose audience is that environment's `instanceUrl`. Tokens are cached per
+instance URL. Acquisition remains managed-identity-first via
+`Get-AzAccessToken -ResourceUrl`.
+
+### 4. Fabricated permission names (Medium) — fixed
+
+`docs/prerequisites.md` / `docs/troubleshooting.md` listed `Bot.Read.All` and
+`Environment.Read.All` as Power Platform API application permissions. These are
+not documented. **Fix:** environment enumeration is authorized by the **Power
+Platform Admin** role; agent discovery requires a Dataverse security role with
+read on the `bot` table in each scanned environment. Microsoft Graph permissions
+(`User.Read.All`, `Directory.Read.All`, `AuditLog.Read.All`) for Flow 4 are
+retained and verified as Graph application permissions requiring admin consent.
+
+### 5. Documentation coherence (Minor) — fixed
+
+Network endpoint list (`api.bap.microsoft.com` replaces `api.powerplatform.com`),
+connection-reference descriptions, README architecture diagram, Known
+Limitations, Platform Update Notes, and the `fsi_agentsource` future-enhancement
+wording were aligned to the corrected mechanism. The HTTP-with-Entra-ID
+connector note now flags that one connection authenticates against one resource
+URI, so separate connections are needed for the BAP (`service.powerapps.com`) and
+Graph (`graph.microsoft.com`) audiences.
+
+## Items verified as already correct
+
+- All Dataverse logical column names and entity-set names match the schema script.
+- Option-set values use 100000000+ (not 0/1/2) consistently in scripts and docs.
+- `Test-AgentRegistryCompliance.ps1` uses correct entity sets, logical names,
+  managed-identity auth, and correct per-service token audiences (Dataverse vs
+  Graph). No changes required.
+- Python deployment scripts are Dataverse-only, managed-identity-first, with the
+  legacy client-secret path properly marked as a dev-only fallback.
+- Flow 3 (Entra Agent ID) is feature-flagged off and already carries appropriate
+  preview caveats — left unchanged.
+
+## Runtime-only caveats (cannot be confirmed without a live tenant)
+
+- The owner-expand path on the `bot` table (`owninguser.domainname` /
+  `internalemailaddress`) and the `statecode` semantics should be confirmed
+  against the live table; column availability can vary by Dataverse version.
+- The exact JSON path `properties.linkedEnvironmentMetadata.instanceUrl` in the
+  BAP admin environments response should be confirmed against a live response;
+  the field is documented on `ILinkedEnvironmentMetadata` but the admin REST
+  payload shape is version-dependent.
+- Cross-environment `bot`-table reads require the runtime identity to hold a
+  read-capable Dataverse role in every scanned environment — verify per tenant.
+- Microsoft Entra Agent ID (Flow 3) remains preview; endpoints and permission
+  names must be confirmed in-tenant before enabling.
+
+## Lab-readiness assessment
+
+**Ready for lab deployment with documented runtime verification.** The discovery
+pipeline now targets only authoritative, documented Microsoft APIs, with correct
+token audiences and accurate prerequisites. Scripts parse cleanly and Python
+compiles. The remaining unknowns are runtime-only (exact response field paths,
+per-environment role assignments) and are explicitly flagged above for
+confirmation during the first lab run. A maintainer version bump (suggested
+`2.2.0`) plus the standard catalog/manifest sync is recommended as a follow-up.

--- a/agent-registry-automation/README.md
+++ b/agent-registry-automation/README.md
@@ -23,7 +23,7 @@ Many organizations deploy AI agents across multiple Power Platform environments 
 
 | Feature | Description |
 |---------|-------------|
-| **Daily Discovery** | Scans all Power Platform environments via Bots API for unregistered agents |
+| **Daily Discovery** | Scans all Power Platform environments and reads each environment's Dataverse `bot` table for unregistered agents |
 | **Auto-Quarantine** | Zone 3 agents without committee approval are automatically quarantined |
 | **Registration Workflow** | Teams-based approval with configurable SLA tracking and escalation |
 | **Agent ID Sync** | Syncs registered agents to Microsoft Entra Agent ID when the preview API is enabled (feature-flagged) |
@@ -51,9 +51,9 @@ Many organizations deploy AI agents across multiple Power Platform environments 
          │                 │
          ▼                 ▼
 ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐
-│  Bots API        │  │  Microsoft       │  │  Entra Agent ID  │
-│  (2022-03-01-    │  │  Graph API       │  │  (feature-       │
-│   preview)       │  │                  │  │   flagged)       │
+│  BAP admin API + │  │  Microsoft       │  │  Entra Agent ID  │
+│  Dataverse `bot` │  │  Graph API       │  │  (feature-       │
+│  table per env   │  │                  │  │   flagged)       │
 └──────────────────┘  └──────────────────┘  └──────────────────┘
          │                 │
          ▼                 ▼
@@ -107,14 +107,14 @@ Many organizations deploy AI agents across multiple Power Platform environments 
 
 | Role | Required For |
 |------|--------------|
-| **Power Platform Admin** | Environment enumeration and Bots API access |
+| **Power Platform Admin** | Environment enumeration (BAP admin API) and `bot`-table read access |
 | **System Administrator** | Dataverse table creation and solution import |
 | **Entra Global Admin** or **Application Administrator** | Service principal registration and API permission grants |
 
 ### Environment
 
 - Target environment must be a **Managed Environment** (required for Dataverse Long-Term Retention)
-- Service principal must have Bots API and Graph API permissions (see [Prerequisites](docs/prerequisites.md))
+- Identity must have Power Platform Admin (for BAP environment enumeration), Dataverse `bot`-table read in each scanned environment, and Microsoft Graph permissions (see [Prerequisites](docs/prerequisites.md))
 
 ## Solution Components
 
@@ -189,7 +189,7 @@ Follow the step-by-step instructions in [Flow Configuration](docs/flow-configura
 ## Key Configuration Notes
 
 - **Microsoft Entra Agent ID (Flow 3):** Disabled by default via the `fsi_ARA_IsEntraRegistrySyncEnabled` environment variable. Enable only after confirming the current Microsoft Graph beta endpoint, Agent ID permissions, and Microsoft Agent 365 or Microsoft 365 E7 licensing in your tenant.
-- **BotFrameworkEndpoint field name:** The `properties.botFrameworkEndpoint` field from the Bots API response needs live API confirmation. Verify the exact field path in your environment before enabling Flow 1.
+- **Agent endpoint URL:** The Dataverse `bot` table does not expose a Bot Framework endpoint column, so `fsi_agentendpointurl` is not populated during discovery. Populate it from channel configuration post-discovery if your governance process requires it.
 - **Office 365 connector for SLA:** The SLA calculation in Flow 2 uses the Office 365 Users connector to determine the approver's time zone for business-day calculations. If DLP policies block this connector, configure a fallback time zone in the `fsi_ARA_DefaultTimeZone` environment variable.
 - **7-year retention (LTR):** The `fsi_agentcomplianceevent` table is designed for Dataverse Long-Term Retention. Enable LTR policies after deployment to support SEC 17a-3/4 retention requirements.
 
@@ -220,28 +220,28 @@ Microsoft has introduced the [Microsoft 365 Copilot Agent Store](https://learn.m
 | Path | Source | Governance Implication |
 |------|--------|----------------------|
 | **Prebuilt** | Microsoft-provided agents | Require admin-level deployment approval; should be inventoried alongside custom agents |
-| **Copilot Studio** | Organization-built agents via Copilot Studio | Already covered by this solution's Bots API discovery |
-| **External Platforms** | Third-party agents via Teams Bot or custom integrations | May not be discoverable via the Bots API; require alternative inventory mechanisms |
+| **Copilot Studio** | Organization-built agents via Copilot Studio | Already covered by this solution's Dataverse `bot`-table discovery |
+| **External Platforms** | Third-party agents via Teams Bot or custom integrations | May not appear in the Dataverse `bot` table; require alternative inventory mechanisms |
 
-**Impact on this solution:** The current discovery mechanism uses the Power Platform Bots API (`2022-03-01-preview`) to scan for agents within Power Platform environments. This does not cover:
+**Impact on this solution:** The current discovery mechanism enumerates environments via the BAP admin API and reads each environment's Dataverse `bot` table to find agents. This does not cover:
 
-- **Prebuilt agents** deployed from the Agent Store, which may not appear in the Bots API response
+- **Prebuilt agents** deployed from the Agent Store, which may not appear as rows in the Dataverse `bot` table
 - **External platform agents** registered through Teams Bot manifests or custom engine agents
 - **Agent Store admin controls** for blocking or allowing agent deployment at the tenant level
 
 Future enhancements should consider:
 
 - Adding Graph API queries for the [Microsoft 365 Agents admin guide](https://learn.microsoft.com/en-us/microsoft-365/copilot/agent-essentials/m365-agents-admin-guide) endpoints to discover Agent Store deployments
-- Extending the `fsi_agentsource` choice set to include Agent Store (Prebuilt) and External Platform categories
+- Adding an `fsi_agentsource` choice column to distinguish Copilot Studio, Agent Store (Prebuilt), and External Platform categories
 - Monitoring the Agent Store admin center for new agent deployments as a supplementary discovery channel
 
 > **Note:** Agent Store discovery integration is not yet implemented. Organizations should manually inventory prebuilt and external agents until automated discovery support is added.
 
 ## Known Limitations
 
-- **Bots API preview:** The Power Platform Bots API (`2022-03-01-preview`) may change at GA. Monitor Microsoft documentation for breaking changes to the endpoint schema.
+- **Environment enumeration (BAP admin API):** Discovery lists environments via the Business Application Platform admin API (`api-version=2020-10-01`). Monitor the [Power Platform REST API documentation](https://learn.microsoft.com/rest/api/power-platform/) for version changes.
 - **Microsoft Entra Agent ID:** Flow 3 (Entra Sync) requires Microsoft Agent 365 or Microsoft 365 E7 licensing and is feature-flagged off by default. Confirm the current preview endpoint and permission names before enabling.
-- **BotFrameworkEndpoint field:** The exact field path (`properties.botFrameworkEndpoint`) in the Bots API response needs live API confirmation. The flow includes error handling for missing fields.
+- **Agent discovery (Dataverse `bot` table):** Discovery reads each environment's `bot` table, which requires `bot`-table read access in every scanned environment. The owner-expand path (`owninguser.domainname`) and `statecode` semantics should be confirmed against the live table in your tenant. The `bot` table has no Bot Framework endpoint column.
 - **Sandbox environments:** By default, sandbox environments are excluded from discovery scans. Set `fsi_ARA_IncludeSandboxEnvironments` to `true` to include them.
 
 ## Version History

--- a/agent-registry-automation/docs/flow-configuration.md
+++ b/agent-registry-automation/docs/flow-configuration.md
@@ -17,10 +17,10 @@ The Agent Registry Automation uses 4 Power Automate flows to manage the agent li
 
 ```
 ┌─────────────────────────────┐
-│  Flow 1: Daily Discovery    │──── Bots API ────┐
-│  (Recurrence — daily)       │                   │
-└──────────────┬──────────────┘                   │
-               │ Upsert                           │
+│  Flow 1: Daily Discovery    │── BAP env list + ──┐
+│  (Recurrence — daily)       │   Dataverse `bot`  │
+└──────────────┬──────────────┘   table per env    │
+               │ Upsert                            │
                ▼                                  ▼
 ┌─────────────────────────────┐      ┌────────────────────┐
 │  fsi_agentinventory         │      │  Power Platform    │
@@ -52,7 +52,7 @@ Configure these connection references before building the flows.
 | Connection Reference | Connector | Purpose |
 |---------------------|-----------|---------|
 | `fsi_cr_dataverse_agentregistry` | Dataverse | Read/write agent inventory and compliance events |
-| `fsi_cr_http_agentregistry` | HTTP with Microsoft Entra ID | Bots API, Graph API, and Microsoft Entra Agent ID calls |
+| `fsi_cr_http_agentregistry` | HTTP with Microsoft Entra ID | BAP environment enumeration (Flow 1), Graph API (Flow 4), and Microsoft Entra Agent ID calls (Flow 3) |
 | `fsi_cr_teams_agentregistry` | Microsoft Teams | Post adaptive cards and notifications |
 | `fsi_cr_office365_agentregistry` | Office 365 | Business day calculation for SLA deadlines |
 
@@ -62,8 +62,8 @@ Configure these connection references before building the flows.
 2. Select **Connection References**
 3. For each reference, click **Edit** and select or create an active connection
 4. For `fsi_cr_http_agentregistry`:
-   - **Base Resource URL:** `https://api.powerplatform.com`
-   - **Microsoft Entra ID Resource URI:** `https://api.powerplatform.com`
+   - **Base Resource URL / Microsoft Entra ID Resource URI:** `https://service.powerapps.com/` for the BAP environment-enumeration call in Flow 1.
+   - **Graph calls (Flow 4) and Agent ID calls (Flow 3)** use a different audience (`https://graph.microsoft.com`). A single HTTP with Microsoft Entra ID connection authenticates against one resource URI, so create a **separate** HTTP with Microsoft Entra ID connection per audience (one for `https://service.powerapps.com/`, one for `https://graph.microsoft.com`).
 
 ---
 
@@ -96,7 +96,9 @@ Configure these values before enabling the flows.
 
 ### Purpose
 
-Scans all Power Platform environments daily using the Bots API to discover AI agents. Creates or updates agent inventory records using an alternate-key upsert. Agents discovered in Zone 3 environments without prior registration are automatically quarantined.
+Scans all Power Platform environments daily, discovering AI agents by querying each environment's Dataverse `bot` table. Creates or updates agent inventory records using an alternate-key upsert. Agents discovered in Zone 3 environments without prior registration are automatically quarantined.
+
+> **Discovery mechanism:** Copilot Studio agents are stored as rows in the Dataverse [`bot` table](https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/bot) (entity set `bots`). Environment enumeration uses the [Business Application Platform (BAP) admin API](https://learn.microsoft.com/rest/api/power-platform/). There is no Power Platform "Bots API" route for agent enumeration.
 
 ### Trigger
 
@@ -130,48 +132,49 @@ Add these **Initialize variable** actions:
 
 #### Step 3: Get Environment List
 
-Add **HTTP with Microsoft Entra ID** action:
+Add **HTTP with Microsoft Entra ID** action (using the connection scoped to the `https://service.powerapps.com/` resource):
 
 - **Method:** GET
-- **URI:** `https://api.powerplatform.com/appmanagement/environments?api-version=2022-03-01-preview&$filter=properties/environmentSku ne 'Developer'`
-- **Authentication:** Use `fsi_cr_http_agentregistry` connection reference
+- **URI:** `https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments?api-version=2020-10-01`
+- **Authentication:** Use `fsi_cr_http_agentregistry` connection reference (resource URI `https://service.powerapps.com/`)
 - **Headers:**
   - `Content-Type`: `application/json`
 
-> **Note:** This filters out Developer-type environments. To include sandbox environments, remove the `$filter` parameter or set the `fsi_ARA_IncludeSandboxEnvironments` environment variable.
+> **Note:** This is the documented BAP admin route for tenant-wide environment enumeration. To exclude Developer/sandbox environments, filter the parsed results in Step 5 on `properties.environmentSku` (for example, skip `Developer`), or set the `fsi_ARA_IncludeSandboxEnvironments` environment variable per your governance policy.
 
 #### Step 4: Parse Environment Response
 
 Add **Parse JSON** action:
 
 - **Content:** Body from Step 3
-- **Schema:** Use the schema from a sample Bots API environments response. Key fields: `value[].id`, `value[].name`, `value[].properties.displayName`, `value[].properties.environmentSku`
+- **Schema:** Use the schema from a sample BAP environments response. Key fields: `value[].name` (environment GUID), `value[].properties.displayName`, `value[].properties.environmentSku`, and `value[].properties.linkedEnvironmentMetadata.instanceUrl` (the environment's Dataverse organization URL used for bot discovery).
 
 #### Step 5: Loop Through Environments
 
 Add **Apply to each** action on the `value` array from Step 4.
 
-> **⚠ Concurrency:** Set concurrency control to **1** (sequential). The Bots API may rate-limit parallel requests.
+> **⚠ Concurrency:** Set concurrency control to **1** (sequential) to avoid Dataverse throttling across environments.
 
 Inside the loop:
 
-##### Step 5a: Get Bots for Environment
+##### Step 5a: Get Agents for Environment
 
-Add **HTTP with Microsoft Entra ID** action:
+Add **Dataverse — List rows** action, targeting **this environment's** Dataverse (use the Dataverse connector's **Environment** parameter set to `@{items('Apply_to_each')?['name']}`, or the environment's `instanceUrl` from Step 4). See [Connect to other environments using the Microsoft Dataverse connector](https://learn.microsoft.com/power-automate/dataverse/connect-other-environments).
 
-- **Method:** GET
-- **URI:** `https://api.powerplatform.com/appmanagement/environments/@{items('Apply_to_each')?['name']}/bots?api-version=2022-03-01-preview`
-- **Configure Run After:** Set to run on **success** and **failure** (some environments may not have Bots API access)
+- **Table name:** `bots` (the Dataverse `bot` table that stores Copilot Studio agents)
+- **Select columns:** `botid,name,statecode,_ownerid_value`
+- **Expand Query:** `owninguser($select=domainname,internalemailaddress)`
+- **Configure Run After:** Set to run on **success** and **failure** (the identity may lack `bot` read access in some environments)
+
+> **Note:** The Dataverse `bot` table has no `botFrameworkEndpoint` column. The `fsi_agentendpointurl` field is left blank during discovery; populate it later from channel configuration if your governance process requires it.
 
 ##### Step 5b: Check for Successful Response
 
-Add **Condition** — check if `outputs('Get_Bots')?['statusCode']` equals `200`.
+Add **Condition** — check that the List rows action in Step 5a succeeded (run-after status `Succeeded`).
 
-##### Step 5c: Parse Bots Response (Yes Branch)
+##### Step 5c: Loop Through Agents (Yes Branch)
 
-Add **Parse JSON** on the body from Step 5a. Key fields: `value[].name`, `value[].properties.displayName`, `value[].properties.botFrameworkEndpoint`
-
-> **Note:** The exact field path for `botFrameworkEndpoint` needs live API confirmation. The flow includes error handling if this field is missing.
+The List rows `value` array returns one row per agent. Key fields: `value[].botid` (durable GUID), `value[].name` (display name), and the expanded `value[].owninguser.domainname` (owner UPN).
 
 ##### Step 5d: Loop Through Bots
 
@@ -201,35 +204,33 @@ if(
 
 Use the `fsi_agentid` + `fsi_environmentid` business key to avoid duplicates while preserving approval workflow state on rediscovery.
 
-1. Add **Dataverse — List rows** on Agent Inventories (`fsi_agentinventories`):
-   - **Filter rows:** `fsi_agentid eq '@{items('Apply_to_each_Bot')?['name']}' and fsi_environmentid eq '@{items('Apply_to_each')?['name']}'`
+1. Add **Dataverse — List rows** on Agent Inventories (`fsi_agentinventories`) in the **registry** environment:
+   - **Filter rows:** `fsi_agentid eq '@{items('Apply_to_each_Bot')?['botid']}' and fsi_environmentid eq '@{items('Apply_to_each')?['name']}'`
    - **Top count:** 1
 2. Add a **Condition** on whether the list returned a row.
 
 **Existing row branch:** update only discovery-tracking columns:
 
-- `fsi_name`: `@{items('Apply_to_each_Bot')?['properties']?['displayName']}`
-- `fsi_agentname`: `@{items('Apply_to_each_Bot')?['properties']?['displayName']}`
+- `fsi_name`: `@{items('Apply_to_each_Bot')?['name']}`
+- `fsi_agentname`: `@{items('Apply_to_each_Bot')?['name']}`
 - `fsi_environmentname`: `@{items('Apply_to_each')?['properties']?['displayName']}`
-- `fsi_agentendpointurl`: `@{items('Apply_to_each_Bot')?['properties']?['botFrameworkEndpoint']}`
 - `fsi_lastscannedat`: `@{utcNow()}`
-- `fsi_rawjson`: body from Step 5a for this agent
+- `fsi_rawjson`: the agent row from Step 5a
 
 **Missing row branch:** add a new Agent Inventory row with all `ApplicationRequired` columns:
 
-- `fsi_name`: `@{items('Apply_to_each_Bot')?['properties']?['displayName']}`
-- `fsi_agentid`: `@{items('Apply_to_each_Bot')?['name']}`
-- `fsi_agentname`: `@{items('Apply_to_each_Bot')?['properties']?['displayName']}`
+- `fsi_name`: `@{items('Apply_to_each_Bot')?['name']}`
+- `fsi_agentid`: `@{items('Apply_to_each_Bot')?['botid']}`
+- `fsi_agentname`: `@{items('Apply_to_each_Bot')?['name']}`
 - `fsi_environmentid`: `@{items('Apply_to_each')?['name']}`
 - `fsi_environmentname`: `@{items('Apply_to_each')?['properties']?['displayName']}`
-- `fsi_agentendpointurl`: `@{items('Apply_to_each_Bot')?['properties']?['botFrameworkEndpoint']}`
 - `fsi_registrationstatus`: `100000000` (Unregistered)
-- `fsi_publishedstatus`: `100000001` (Draft) unless the API returns a mapped published status
+- `fsi_publishedstatus`: `100000001` (Draft) — the `bot` table does not expose a Copilot Studio published-lifecycle value; the registration flow governs published state from here
 - `fsi_zone`: Zone value from Step 5d-i
-- `fsi_ownerupn`: owner UPN from the API, or `unknown@unassigned.local` when unavailable
+- `fsi_ownerupn`: `@{items('Apply_to_each_Bot')?['owninguser']?['domainname']}`, or `unknown@unassigned.local` when unavailable
 - `fsi_isorphaned`: `true` when owner UPN is unavailable; otherwise `false`
 - `fsi_lastscannedat`: `@{utcNow()}`
-- `fsi_rawjson`: body from Step 5a for this agent
+- `fsi_rawjson`: the agent row from Step 5a
 
 > **Important:** The alternate key `fsi_AgentEnvUniqueKey` (logical: `fsi_agentenvuniquekey`) must be in **Active** status before using alternate-key upsert patterns. Dataverse Web API upsert can create rows when the key is absent, so create payloads must include every required non-key column.
 
@@ -251,10 +252,10 @@ Add **Condition** — if zone equals `100000003` AND `fsi_registrationstatus` eq
 ##### Step 5d-vi: Log Compliance Event
 
 Add **Dataverse — Add a new row** to `fsi_agentcomplianceevents`:
-- `fsi_name`: `Agent Discovered — @{items('Apply_to_each_Bot')?['properties']?['displayName']}`
+- `fsi_name`: `Agent Discovered — @{items('Apply_to_each_Bot')?['name']}`
 - `fsi_eventtype`: `100000000` (Discovered) — or `100000004` (Quarantined) if quarantined
 - `fsi_actorupn`: `system@example.com`
-- `fsi_agentid`: `@{items('Apply_to_each_Bot')?['name']}`
+- `fsi_agentid`: `@{items('Apply_to_each_Bot')?['botid']}`
 - `fsi_environmentid`: `@{items('Apply_to_each')?['name']}`
 - `fsi_zone`: Zone value from Step 5d-i
 - `fsi_details`: `{"correlationId":"@{variables('varDiscoveryCorrelationId')}","quarantined":@{variables('varQuarantined')}}`
@@ -578,8 +579,9 @@ Add a **Scope** around Steps 3–5 with **Configure Run After** on failure:
 
 ## Known Limitations
 
-- **Bots API preview:** The `2022-03-01-preview` API version may change at GA. Monitor the [Power Platform API documentation](https://learn.microsoft.com/en-us/rest/api/power-platform/) for updates.
-- **BotFrameworkEndpoint field:** The exact field path in the Bots API response needs live API confirmation. The flow includes null-check error handling for this field.
+- **Environment enumeration (BAP admin API):** Flow 1 lists environments via `https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments?api-version=2020-10-01`. Monitor the [Power Platform REST API documentation](https://learn.microsoft.com/rest/api/power-platform/) for version changes.
+- **Agent discovery (Dataverse `bot` table):** Flow 1 enumerates agents from each environment's [`bot` table](https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/bot) (entity set `bots`). The runtime identity needs `bot`-table read access in each scanned environment. The owner-expand path (`owninguser.domainname`) and `statecode` semantics should be confirmed against the live table in your tenant.
+- **Agent endpoint URL:** The `bot` table does not expose a Bot Framework endpoint column, so `fsi_agentendpointurl` is not populated during discovery.
 - **Office 365 Users connector:** Used for time zone lookup in SLA calculations. If blocked by DLP policies, configure `fsi_ARA_DefaultTimeZone` as a fallback.
 - **Microsoft Entra Agent ID API:** Flow 3 is disabled by default. The API endpoint and required permissions are subject to change.
 - **Graph signInActivity:** Requires Microsoft Entra ID P1/P2 license for the `signInActivity` property in the Graph API response. Without this license, the inactive-owner detection in Flow 4 is limited to account-enabled checks only.

--- a/agent-registry-automation/docs/prerequisites.md
+++ b/agent-registry-automation/docs/prerequisites.md
@@ -32,7 +32,7 @@ pac --version
 
 Install or update the Power Platform CLI using the current Microsoft Learn installation path for your workstation, then verify with `pac --version`.
 
-Use `Get-AdminPowerApp`, `Get-AdminFlow`, and `pac copilot list --environment <environmentId-or-url>` as supplementary validation checks. The primary automated discovery path remains the Power Platform API because tenant-wide Copilot Studio agent inventory requires API-based environment enumeration.
+Use `Get-AdminPowerApp`, `Get-AdminFlow`, and `pac copilot list --environment <environmentId-or-url>` as supplementary validation checks. The primary automated discovery path enumerates environments via the BAP admin API and then reads each environment's Dataverse `bot` table, because tenant-wide Copilot Studio agent inventory requires per-environment Dataverse access.
 
 ---
 
@@ -42,15 +42,16 @@ Use `Get-AdminPowerApp`, `Get-AdminFlow`, and `pac copilot list --environment <e
 
 | Role | Required For |
 |------|--------------|
-| **Power Platform Admin** | Environment enumeration and Bots API access |
-| **Entra Global Admin** or **Application Administrator** | Service principal registration and API permission grants |
+| **Power Platform Admin** | Environment enumeration via the BAP admin API |
+| **Entra Global Admin** or **Application Administrator** | Service principal registration and Graph API permission grants |
 
 ### Power Platform Roles
 
 | Role | Required For |
 |------|--------------|
-| **System Administrator** | Dataverse table creation and schema deployment |
+| **System Administrator** | Dataverse table creation and schema deployment in the registry environment |
 | **Environment Maker** | Power Automate flow creation |
+| **Dataverse `bot`-table read** | A security role with read access to the `bot` table in **each** environment to be scanned (agent discovery). The Power Platform Admin role provides this in environments where the identity is an administrator; otherwise assign an application user with a read role per environment. |
 
 ---
 
@@ -62,13 +63,13 @@ Register a Microsoft Entra ID application with the following permissions:
 
 | Permission | Type | API | Purpose |
 |------------|------|-----|---------|
-| `Environment.Read.All` | Application | Power Platform API | Enumerate environments for discovery |
-| `Bot.Read.All` | Application | Power Platform API | Read bot registrations via Bots API |
+| Power Platform Admin role | Directory role | BAP admin API | Enumerate environments via `scopes/admin/environments`. Environment enumeration is authorized by the Power Platform Admin role, not a Graph application permission. |
+| `bot`-table read (Dataverse) | Dataverse security role | Dataverse Web API | Read agent rows from each environment's `bot` table for discovery. |
 | `User.Read.All` | Application | Microsoft Graph | Check owner account status for orphan detection |
 | `Directory.Read.All` | Application | Microsoft Graph | Read user department and manager information |
 | `AuditLog.Read.All` | Application | Microsoft Graph | Read sign-in activity for inactivity detection |
 
-> **Note:** All permissions require **admin consent** from an Entra Global Admin.
+> **Note:** The Microsoft Graph application permissions require **admin consent** from an Entra Global Admin. Environment enumeration and `bot`-table access are governed by Power Platform/Dataverse role assignments rather than Graph consent.
 
 ### Microsoft Entra Agent ID API (Optional — Flow 3)
 
@@ -175,10 +176,10 @@ The following connectors are used by the solution's Power Automate flows. Verify
 
 | Endpoint | Protocol | Purpose |
 |----------|----------|---------|
-| `api.powerplatform.com` | HTTPS (443) | Bots API and environment enumeration |
+| `api.bap.microsoft.com` | HTTPS (443) | Business Application Platform admin API — environment enumeration |
 | `graph.microsoft.com` | HTTPS (443) | User status checks and Microsoft Entra Agent ID |
 | `login.microsoftonline.com` | HTTPS (443) | OAuth 2.0 authentication |
-| `*.crm.dynamics.com` | HTTPS (443) | Dataverse API operations |
+| `*.crm.dynamics.com` | HTTPS (443) | Dataverse API operations — registry tables and per-environment `bot` table |
 
 > **Note:** For GCC, GCC High, and DoD environments, substitute the appropriate sovereign cloud endpoints.
 

--- a/agent-registry-automation/docs/troubleshooting.md
+++ b/agent-registry-automation/docs/troubleshooting.md
@@ -6,49 +6,48 @@ Common issues and resolutions for the Agent Registry Automation solution.
 
 ## Discovery Issues (Flow 1)
 
-### Bots API Returns 401 Unauthorized
+### Environment enumeration returns 401 Unauthorized
 
-**Symptoms:** Flow 1 fails when calling the Bots API with a 401 error.
+**Symptoms:** Flow 1 fails when calling the BAP admin environments API with a 401 error.
 
 **Possible causes:**
 
 | Cause | Resolution |
 |-------|------------|
-| Token expired | Re-authorize the `fsi_cr_http_agentregistry` connection reference |
-| Missing API permissions | Grant `Environment.Read.All` and `Bot.Read.All` on Power Platform API |
-| Admin consent not granted | Navigate to Entra ID > App registrations > API permissions > Grant admin consent |
-| Wrong resource URI | Verify connection reference uses `https://api.powerplatform.com` as the resource URI |
+| Token expired | Re-authorize the `fsi_cr_http_agentregistry` connection reference used for the BAP call |
+| Wrong resource URI | Verify the connection's resource URI is `https://service.powerapps.com/` (the BAP admin audience), not the Graph or Dataverse audience |
+| Insufficient role | The identity must hold the **Power Platform Admin** role to use `scopes/admin/environments` |
 
 **Verify connection reference:**
 
 1. Navigate to **Power Apps** > **Solutions** > **Agent Registry Automation**
 2. Select **Connection References** > `fsi_cr_http_agentregistry`
-3. Verify **Base Resource URL** is `https://api.powerplatform.com`
+3. Verify the **Resource URI** for the BAP enumeration connection is `https://service.powerapps.com/`
 4. Click **Edit** and re-select or re-create the connection
 
-### Bots API Returns 403 Forbidden
+### `bot`-table query returns 401/403 Forbidden
 
-**Symptoms:** Flow 1 receives a 403 error for specific environments.
-
-**Possible causes:**
-
-| Cause | Resolution |
-|-------|------------|
-| Insufficient role | The service principal or user must have Power Platform Admin |
-| Environment-level restriction | Some environments may restrict API access — verify environment security settings |
-| Sovereign cloud mismatch | GCC/GCC High environments use different API endpoints |
-
-### Bots API Returns 404 Not Found
-
-**Symptoms:** Flow 1 receives a 404 for the Bots API endpoint.
+**Symptoms:** Flow 1 receives a 401/403 error when listing rows from the `bot` table in specific environments.
 
 **Possible causes:**
 
 | Cause | Resolution |
 |-------|------------|
-| API version change | The `2022-03-01-preview` API version may have been deprecated — check Power Platform API documentation |
-| Environment does not support Bots API | Not all environment types expose the Bots API — the flow should skip these gracefully |
-| Incorrect environment ID format | Verify the environment ID from the environment list matches the expected format |
+| No Dataverse access | The identity needs a Dataverse security role with **read** on the `bot` table in that environment. Add an application user or assign a read role per environment. |
+| Environment-level restriction | Some environments restrict cross-environment connections — verify tenant isolation / DLP settings |
+| Sovereign cloud mismatch | GCC/GCC High environments use different endpoints |
+
+### `bot`-table query returns 404 Not Found
+
+**Symptoms:** Flow 1 receives a 404 when querying an environment's Dataverse `bot` table.
+
+**Possible causes:**
+
+| Cause | Resolution |
+|-------|------------|
+| Environment has no Dataverse | Environments without a linked Dataverse instance have no `instanceUrl`; the flow should skip these gracefully |
+| Wrong instance URL | Verify `properties.linkedEnvironmentMetadata.instanceUrl` from the environment list is used as the Dataverse base URL |
+| Table not present | Confirm the environment provisions Copilot Studio (the `bot` table exists where Copilot Studio is enabled) |
 
 ### No Agents Discovered
 
@@ -60,8 +59,8 @@ Common issues and resolutions for the Agent Registry Automation solution.
 |-------|------------|
 | No agents deployed | Expected behavior if no AI agents exist in scanned environments |
 | Sandbox environments excluded | Set `fsi_ARA_IncludeSandboxEnvironments` to `true` if needed |
-| Developer environments filtered | Developer SKU environments are excluded by default — this is intentional |
-| Parse JSON schema mismatch | Verify the Parse JSON schema matches the actual Bots API response structure |
+| Developer environments filtered | Developer SKU environments are excluded by your filter — this is intentional |
+| `bot`-table read access missing | Confirm the identity can read the `bot` table in each environment |
 
 ---
 
@@ -153,7 +152,7 @@ This connector is **required** for the solution to function. Work with your DLP 
 1. Classify `HTTP with Microsoft Entra ID` in the **Business** connector group
 2. If organization-wide reclassification is not possible, create an environment-specific DLP policy that allows this connector in the governance environment
 
-> **Note:** The HTTP with Microsoft Entra ID connector is used for Bots API (Flow 1), Microsoft Entra Agent ID (Flow 3), and Graph API (Flow 4) calls. Without it, these flows cannot operate.
+> **Note:** The HTTP with Microsoft Entra ID connector is used for BAP environment enumeration (Flow 1), Microsoft Entra Agent ID (Flow 3), and Graph API (Flow 4) calls. Without it, these flows cannot operate. Per-environment agent discovery (Flow 1) uses the Dataverse connector against each environment's `bot` table.
 
 ---
 
@@ -185,14 +184,14 @@ This connector is **required** for the solution to function. Work with your DLP 
 
 ## Rate Limiting (429 Errors)
 
-### Bots API Rate Limiting
+### Discovery Rate Limiting
 
 **Symptoms:** Flow 1 receives 429 (Too Many Requests) responses during environment scanning.
 
 **Resolution:**
 
 1. The flow should be configured with concurrency set to **1** (sequential) for the environment loop
-2. If 429 errors persist, add a **Delay** action (e.g., 2 seconds) between Bots API calls
+2. If 429 errors persist, add a **Delay** action (e.g., 2 seconds) between per-environment `bot`-table queries
 3. For large tenants with 50+ environments, consider splitting the scan across multiple flow runs
 
 ### Graph API Rate Limiting

--- a/agent-registry-automation/scripts/Deploy-AgentRegistry-Baseline.ps1
+++ b/agent-registry-automation/scripts/Deploy-AgentRegistry-Baseline.ps1
@@ -6,20 +6,33 @@
     Exports baseline agent inventory from Power Platform to Dataverse.
 
 .DESCRIPTION
-    Scans all Power Platform environments using the Bots API
-    (2022-03-01-preview) and creates initial agent inventory records
-    in the fsi_agentinventory Dataverse table. Uses Managed Identity
+    Enumerates Power Platform environments via the Business Application
+    Platform (BAP) admin API, then discovers Copilot Studio agents by
+    querying each environment's Dataverse `bot` table (entity set `bots`).
+    Creates initial agent inventory records in the registry's
+    fsi_agentinventory Dataverse table. Uses Managed Identity
     authentication exclusively — no client secrets.
+
+    Authoritative sources for the discovery surface:
+    - Environment enumeration (BAP admin API):
+      https://learn.microsoft.com/rest/api/power-platform/ (List environments)
+      GET https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments?api-version=2020-10-01
+    - Copilot Studio agents are stored in the Dataverse `bot` table:
+      https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/bot
+      EntitySetName `bots`, PrimaryIdAttribute `botid`, PrimaryNameAttribute `name`.
 
     This script is typically run once during initial deployment to
     establish the baseline agent inventory. Subsequent updates are
     handled by the Discover-UnregisteredAgents-Daily flow.
 
 .PARAMETER DataverseUrl
-    Target Dataverse environment URL (e.g., https://example.crm.dynamics.com).
+    Target *registry* Dataverse environment URL where the fsi_* tables live
+    (e.g., https://example.crm.dynamics.com). Each scanned environment's own
+    Dataverse URL is resolved from the BAP environment metadata.
 
-.PARAMETER PowerPlatformApiUrl
-    Power Platform API base URL. Defaults to https://api.powerplatform.com.
+.PARAMETER BapApiUrl
+    Business Application Platform admin API base URL. Defaults to
+    https://api.bap.microsoft.com.
 
 .PARAMETER ExportPath
     Optional path to export baseline inventory as JSON file.
@@ -47,7 +60,11 @@
     Requires:
     - Azure Automation with System-Assigned Managed Identity
     - Managed Identity assigned Power Platform Administrator role
-    - Managed Identity assigned System Administrator in target Dataverse env
+      (for BAP admin environment enumeration)
+    - Managed Identity granted a Dataverse security role with read access to
+      the `bot` table in EACH environment to be scanned
+    - Managed Identity assigned System Administrator in the *registry*
+      Dataverse environment (to write fsi_* records)
     - Az.Accounts PowerShell module
 #>
 
@@ -58,7 +75,7 @@ param(
     [string]$DataverseUrl,
 
     [Parameter()]
-    [string]$PowerPlatformApiUrl = "https://api.powerplatform.com",
+    [string]$BapApiUrl = "https://api.bap.microsoft.com",
 
     [Parameter()]
     [string]$ExportPath,
@@ -233,7 +250,15 @@ function Get-PagedApiValues {
 function Get-PowerPlatformEnvironments {
     <#
     .SYNOPSIS
-        Lists all Power Platform environments via the Admin API.
+        Lists all Power Platform environments via the BAP admin API.
+
+    .DESCRIPTION
+        Uses the documented Business Application Platform admin route:
+        GET https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments?api-version=2020-10-01
+        Each returned environment exposes the Dataverse organization URL at
+        properties.linkedEnvironmentMetadata.instanceUrl, which is used to
+        query that environment's `bot` table for agent discovery.
+        Ref: https://learn.microsoft.com/rest/api/power-platform/ (List environments)
     #>
     param(
         [Parameter(Mandatory)]
@@ -243,8 +268,8 @@ function Get-PowerPlatformEnvironments {
         [string]$Token
     )
 
-    $uri = "$($ApiBaseUrl.TrimEnd('/'))/appmanagement/environments?api-version=2022-03-01-preview"
-    Write-AuditLog "Querying Power Platform environments..."
+    $uri = "$($ApiBaseUrl.TrimEnd('/'))/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments?api-version=2020-10-01"
+    Write-AuditLog "Querying Power Platform environments (BAP admin API)..."
 
     $environments = Get-PagedApiValues -Uri $uri -Token $Token
 
@@ -255,20 +280,36 @@ function Get-PowerPlatformEnvironments {
 function Get-EnvironmentBots {
     <#
     .SYNOPSIS
-        Lists all bots in a specific Power Platform environment.
+        Lists Copilot Studio agents in an environment via its Dataverse `bot` table.
+
+    .DESCRIPTION
+        Copilot Studio agents are stored as rows in the Dataverse `bot` table
+        (entity set `bots`, PrimaryIdAttribute `botid`, PrimaryNameAttribute
+        `name`). There is no Power Platform "Bots API" route for enumeration;
+        the authoritative inventory source is the per-environment Dataverse
+        Web API.
+        Ref: https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/bot
+
+        $InstanceUrl is the environment's Dataverse organization URL, taken
+        from the BAP environment metadata. A separate Dataverse token (audience
+        = $InstanceUrl) is required because each environment is a distinct
+        Dataverse resource.
+
+        NOTE (runtime-verify): the owner expand path `owninguser` and the
+        statecode→published mapping should be confirmed against the live
+        `bot` table in your tenant; column availability can vary by version.
     #>
     param(
         [Parameter(Mandatory)]
-        [string]$ApiBaseUrl,
-
-        [Parameter(Mandatory)]
-        [string]$EnvironmentId,
+        [string]$InstanceUrl,
 
         [Parameter(Mandatory)]
         [string]$Token
     )
 
-    $uri = "$($ApiBaseUrl.TrimEnd('/'))/appmanagement/environments/$EnvironmentId/bots?api-version=2022-03-01-preview"
+    $select = "botid,name,schemaname,statecode,_ownerid_value"
+    $expand = "owninguser(`$select=domainname,internalemailaddress)"
+    $uri = "$($InstanceUrl.TrimEnd('/'))/api/data/v9.2/bots?`$select=$select&`$expand=$expand"
 
     try {
         return @(Get-PagedApiValues -Uri $uri -Token $Token)
@@ -279,9 +320,10 @@ function Get-EnvironmentBots {
             $statusCode = [int]$_.Exception.Response.StatusCode
         }
 
-        # 403/404 typically means no PVA access in this environment — skip gracefully
-        if ($statusCode -in @(403, 404)) {
-            Write-AuditLog "No bot access in environment $EnvironmentId (HTTP $statusCode) — skipping" -Level WARN
+        # 401/403/404 typically means the identity has no Dataverse access in
+        # this environment, or the org is not provisioned — skip gracefully.
+        if ($statusCode -in @(401, 403, 404)) {
+            Write-AuditLog "No bot-table access at $InstanceUrl (HTTP $statusCode) — skipping" -Level WARN
             return @()
         }
         throw
@@ -416,14 +458,16 @@ catch {
     exit 1
 }
 
-# Step 2: Acquire tokens for Power Platform API and Dataverse
+# Step 2: Acquire tokens for the BAP admin API and the registry Dataverse env
 Write-AuditLog "Acquiring access tokens..."
 try {
-    $ppToken = Get-ManagedIdentityToken -ResourceUrl "https://api.powerplatform.com"
-    Write-AuditLog "  Power Platform API: authenticated"
+    # BAP admin API audience is the Power Apps service resource.
+    # Ref: https://learn.microsoft.com/power-platform/admin/programmability-authentication
+    $bapToken = Get-ManagedIdentityToken -ResourceUrl "https://service.powerapps.com/"
+    Write-AuditLog "  BAP admin API:      authenticated"
 
     $dvToken = Get-ManagedIdentityToken -ResourceUrl $DataverseUrl
-    Write-AuditLog "  Dataverse:          authenticated"
+    Write-AuditLog "  Registry Dataverse: authenticated"
 }
 catch {
     Write-AuditLog "Token acquisition failed: $($_.Exception.Message)" -Level ERROR
@@ -431,8 +475,8 @@ catch {
     exit 1
 }
 
-# Step 3: List all Power Platform environments
-$environments = Get-PowerPlatformEnvironments -ApiBaseUrl $PowerPlatformApiUrl -Token $ppToken
+# Step 3: List all Power Platform environments (BAP admin API)
+$environments = Get-PowerPlatformEnvironments -ApiBaseUrl $BapApiUrl -Token $bapToken
 
 if ($environments.Count -eq 0) {
     Write-AuditLog "No environments found. Verify Managed Identity has Power Platform Administrator role." -Level WARN
@@ -449,33 +493,50 @@ $counters = @{
     Errors              = 0
 }
 
+# Per-environment Dataverse tokens are cached by instance URL because each
+# environment is a distinct Dataverse resource (audience = its org URL).
+$envTokenCache = @{}
+
 $zoneValue = $script:ZoneOptionSet[$Zone]
 $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 
 foreach ($env in $environments) {
-    $envId = $env.name  # GUID — $env.id is the ARM resource path
+    $envId = $env.name  # environment GUID
     $envName = $env.properties.displayName
+    # Dataverse organization URL for this environment (BAP metadata).
+    $instanceUrl = $env.properties.linkedEnvironmentMetadata.instanceUrl
     $counters.EnvironmentsScanned++
 
     Write-AuditLog "Scanning environment: $envName ($envId)"
 
+    if ([string]::IsNullOrWhiteSpace($instanceUrl)) {
+        Write-AuditLog "  No Dataverse instance linked to $envName — skipping" -Level WARN
+        continue
+    }
+
     try {
-        $bots = Get-EnvironmentBots -ApiBaseUrl $PowerPlatformApiUrl -EnvironmentId $envId -Token $ppToken
+        # Acquire (or reuse) a Dataverse token scoped to this environment.
+        if (-not $envTokenCache.ContainsKey($instanceUrl)) {
+            $envTokenCache[$instanceUrl] = Get-ManagedIdentityToken -ResourceUrl $instanceUrl
+        }
+        $envDvToken = $envTokenCache[$instanceUrl]
+
+        $bots = Get-EnvironmentBots -InstanceUrl $instanceUrl -Token $envDvToken
 
         if ($bots.Count -eq 0) {
-            Write-AuditLog "  No bots found in $envName"
+            Write-AuditLog "  No agents found in $envName"
             continue
         }
 
-        Write-AuditLog "  Found $($bots.Count) bot(s) in $envName"
+        Write-AuditLog "  Found $($bots.Count) agent(s) in $envName"
 
         foreach ($bot in $bots) {
             $counters.TotalAgents++
-            # Power Platform Bots API returns the GUID in `name`; `id` is the
-            # ARM resource path. Use `name` as the durable bot identifier so
-            # the alternate key (fsi_agentid + fsi_environmentid) stays stable.
-            $botId = $bot.name
-            $botName = $bot.properties.displayName
+            # Dataverse `bot` table: botid is the durable GUID identifier and
+            # name is the display name. Use botid for fsi_agentid so the
+            # alternate key (fsi_agentid + fsi_environmentid) stays stable.
+            $botId = $bot.botid
+            $botName = $bot.name
             if ([string]::IsNullOrWhiteSpace($botName)) { $botName = $botId }
 
             $agentRecord = @{
@@ -490,28 +551,29 @@ foreach ($env in $environments) {
                 fsi_isorphaned         = $false
             }
 
-            # Owner UPN — required column. If the API doesn't return one,
-            # populate a placeholder so the create succeeds; orphan detection
-            # will flag the record on the next compliance pass.
-            if ($bot.properties.owner -and $bot.properties.owner.userPrincipalName) {
-                $agentRecord["fsi_ownerupn"] = $bot.properties.owner.userPrincipalName
+            # Owner UPN — required column. Resolved from the expanded owning
+            # user (domainname is the user's UPN/logon). If absent, populate a
+            # placeholder so the create succeeds; orphan detection will flag the
+            # record on the next compliance pass.
+            $ownerUpn = $null
+            if ($bot.owninguser) {
+                $ownerUpn = $bot.owninguser.domainname
+                if ([string]::IsNullOrWhiteSpace($ownerUpn)) {
+                    $ownerUpn = $bot.owninguser.internalemailaddress
+                }
+            }
+            if (-not [string]::IsNullOrWhiteSpace($ownerUpn)) {
+                $agentRecord["fsi_ownerupn"] = $ownerUpn
             } else {
                 $agentRecord["fsi_ownerupn"] = "unknown@unassigned.local"
                 $agentRecord["fsi_isorphaned"] = $true
             }
 
-            # Published status — required column. Default to Draft if absent.
-            if ($bot.properties.publishedStatus) {
-                $mappedStatus = $script:PublishedStatusMap[$bot.properties.publishedStatus]
-                if ($null -ne $mappedStatus) {
-                    $agentRecord["fsi_publishedstatus"] = $mappedStatus
-                } else {
-                    Write-AuditLog "  Unknown publishedStatus '$($bot.properties.publishedStatus)' for $botName — defaulting to Draft" -Level WARN
-                    $agentRecord["fsi_publishedstatus"] = $script:PublishedStatusMap["Draft"]
-                }
-            } else {
-                $agentRecord["fsi_publishedstatus"] = $script:PublishedStatusMap["Draft"]
-            }
+            # Published status — required column. The `bot` table does not
+            # expose a Copilot Studio "published" lifecycle value; statecode
+            # only reflects record active/inactive. Default to Draft and let
+            # the registration flow govern published state from there.
+            $agentRecord["fsi_publishedstatus"] = $script:PublishedStatusMap["Draft"]
 
             if ($PSCmdlet.ShouldProcess("$botName ($botId) in $envName", "Upsert agent inventory record")) {
                 try {

--- a/agent-registry-automation/scripts/create_connection_references.py
+++ b/agent-registry-automation/scripts/create_connection_references.py
@@ -9,7 +9,7 @@ Connection References:
   - fsi_cr_dataverse_agentregistry: Core data operations
   - fsi_cr_teams_agentregistry: Approval cards and alert notifications
   - fsi_cr_office365_agentregistry: Business day calculation for SLA
-  - fsi_cr_http_agentregistry: Power Platform Bots API and Graph API calls
+  - fsi_cr_http_agentregistry: BAP environment enumeration and Microsoft Graph calls
 """
 
 import argparse
@@ -59,8 +59,8 @@ CONNECTION_REF_DEFINITIONS = [
         "connector_id": "shared_webcontents",
         "description": (
             "HTTP with Microsoft Entra ID connection for Agent Registry Automation. "
-            "Used for Power Platform Bots API calls and Microsoft Graph "
-            "Agent ID API calls."
+            "Used for BAP environment enumeration, Microsoft Graph, and "
+            "Microsoft Entra Agent ID API calls."
         ),
     },
 ]


### PR DESCRIPTION
## What

Static lab-readiness validation of **agent-registry-automation** (v2.1.1; controls 1.2, 1.7, 2.1, 2.13). The central finding: agent discovery rested on an unverifiable/fabricated Power Platform "Bots API" surface. This PR replaces it with authoritative, Microsoft-documented APIs and fixes the dependent docs/permissions.

## Why

`api.powerplatform.com/appmanagement/environments/{id}/bots?api-version=2022-03-01-preview` is not a documented route — the AppManagement namespace is scoped to Microsoft-provided application packages. The endpoint had been guessed twice in prior versions and never verified. Permissions `Bot.Read.All` / `Environment.Read.All` and the field `properties.botFrameworkEndpoint` do not exist.

## Key fixes

- **Environment enumeration** → BAP admin API: `GET https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments?api-version=2020-10-01` (audience `https://service.powerapps.com/`).
- **Agent enumeration** → per-environment Dataverse `bot` table (entity set `bots`, PK `botid`, name `name`); audience = each environment's `instanceUrl`.
- Removed `botFrameworkEndpoint` mapping (no such column); `fsi_agentendpointurl` left blank at discovery.
- Removed fabricated PP-API permissions; documented Power Platform Admin role + Dataverse `bot`-table read role instead.
- Corrected token audiences; updated baseline script, flow-configuration, prerequisites, troubleshooting, README, delivery checklist, `.ralph-config.json`, CHANGELOG.
- Added `LAB-VALIDATION.md` evidence report.

## Authoritative sources

Power Platform REST API reference; BAP "List environments"; Dataverse `bot` table reference; Copilot Studio Agent Inventory; Power Platform programmability authentication; `ILinkedEnvironmentMetadata.instanceUrl`. Exact URLs in `LAB-VALIDATION.md`.

## Runtime-only caveats (no live tenant)

Owner-expand path (`owninguser.domainname`) and `statecode` semantics; exact `linkedEnvironmentMetadata.instanceUrl` JSON path in the admin payload; per-environment Dataverse role requirements; Entra Agent ID (Flow 3) preview availability. All flagged in docs.

## Verification

- `python -m py_compile` on all changed `.py` — pass.
- PowerShell `Parser::ParseFile` on both `.ps1` — 0 errors.
- Language-rule grep (`ensures|guarantees|will prevent|eliminates risk`) — clean.
- `manifest.yaml` untouched.

## Follow-up

These corrections warrant a **minor version bump (suggested 2.2.0)** plus the standard 4-file root catalog sync + `manifest.yaml` update, intentionally left out of this validation pass (out of solution-folder scope).