### PR TITLE
docs(compliance-dashboard): lab-readiness validation and corrections

### DIFF
--- a/compliance-dashboard/CHANGELOG.md
+++ b/compliance-dashboard/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to the Compliance Dashboard solution.
 
 ### Fixed
 
+- **Doc accuracy (lab validation):** Corrected the Microsoft 365 Copilot usage report endpoint guidance in `README.md` ("Microsoft Learn 2026-Q2 integration notes") and `docs/flow-configuration.md` (CD-EvidenceCollector "Microsoft 365 usage reports" section). Both previously claimed `getMicrosoft365CopilotUserCountSummary` was available on a v1.0 `/copilot/reports/...` path. Per Microsoft Learn, that report API exists **only under `/beta`** (`/beta/copilot/reports/...` and `/beta/reports/...`) as of 2026-Q2 and is not supported for production; `getOffice365ActiveUserDetail` remains GA on v1.0. Guidance now reflects the actual API surface. (lab validation)
+- **Doc consistency:** `docs/deployment-checklist.md` referenced the notification environment variable as `CD_NotificationEmail`; aligned it to the schema name `fsi_CD_NotificationEmail` used in `docs/flow-configuration.md`. (lab validation)
 - **Wave 6 P4b:** Empty catch blocks now log via `Write-Verbose` instead of silently swallowing errors. Output is unchanged unless caller passes `-Verbose`.
 ## [1.0.5] - 2026-05-23
 

--- a/compliance-dashboard/LAB-VALIDATION.md
+++ b/compliance-dashboard/LAB-VALIDATION.md
@@ -1,0 +1,115 @@
+# Compliance Dashboard — Lab Validation Report
+
+> **Scope:** Static (no live tenant) lab-readiness validation of the `compliance-dashboard`
+> solution (v1.0.5). Validation = parse-validity + authoritative-source verification +
+> documentation completeness. Runtime behaviors that require a Dataverse environment,
+> Exchange Online tenant, or Power BI capacity are flagged as runtime-only caveats.
+
+## Purpose & Controls
+
+Aggregated compliance reporting across the 78-control FSI Agent Governance Framework
+baseline, surfaced through a Power BI dashboard over Dataverse, with optional Exchange
+Online evidence collection. Primary framework controls: **3.3, 3.1, 3.2, 3.4**
+(monitoring / reporting pillar). Supports internal reporting referenced for **SOX §404**
+ICFR monitoring, **FINRA Rule 3120(a)(1)** supervisory control reporting, and
+**OCC Bulletin 2011-12 / FRB SR 11-7** model-risk governance where applicable.
+
+## What Was Checked
+
+| Area | Method | Result |
+|------|--------|--------|
+| Python scripts (`create_cd_dataverse_schema.py`, `load_sample_data.py`) | `python -m py_compile` | Pass (exit 0) |
+| PowerShell collector (`Get-ExchangeComplianceData.ps1`) | `Parser::ParseFile` | Pass (0 errors) |
+| Schema doc drift | `create_cd_dataverse_schema.py --output-docs` + `git status` | No drift |
+| Language rules | grep for the four prohibited compliance-overclaim phrases (excl. CHANGELOG) | 0 hits |
+| Dataverse column logical names | Cross-checked OData/DAX/flow refs against `create_cd_dataverse_schema.py` | Consistent |
+| Option-set values (1-6 vs 100000000+) | Cross-checked schema, DAX, sample data, loader, deployment checklist | Consistent + explicitly caveated |
+| CLI flags in docs (`--export`, `--force`, `--controls-only`, `--assessments-only`) | Cross-checked against argparse | All exist |
+| Exchange/Graph API endpoints & permissions | Microsoft Learn (authoritative) | Verified; 1 correction made |
+| Power BI DAX functions | Reviewed against standard DAX surface | Valid |
+
+## Authoritative Sources Cited
+
+1. **mailboxSettings `userPurpose`** — confirms `userPurpose` is a real property with
+   value `shared` (also `user`, `linked`, `room`, `equipment`, `others`).
+   https://learn.microsoft.com/graph/api/resources/mailboxsettings?view=graph-rest-1.0
+2. **Security alerts (alerts_v2)** — confirms `GET https://graph.microsoft.com/v1.0/security/alerts_v2`
+   is the GA v1.0 List alerts endpoint, and `SecurityAlert.Read.All` is the current
+   (non-legacy) read permission.
+   https://learn.microsoft.com/graph/api/security-list-alerts_v2?view=graph-rest-1.0
+   https://learn.microsoft.com/graph/api/resources/security-api-overview?view=graph-rest-1.0
+3. **Microsoft 365 Copilot usage report** — confirms `getMicrosoft365CopilotUserCountSummary`
+   is **beta-only** (`graph-rest-beta`); HTTP request is
+   `GET https://graph.microsoft.com/beta/copilot/reports/getMicrosoft365CopilotUserCountSummary`.
+   No v1.0 variant exists as of 2026-Q2. `/beta` APIs are documented as "subject to change…
+   not supported" for production.
+   https://learn.microsoft.com/graph/api/reportroot-getmicrosoft365copilotusercountsummary?view=graph-rest-beta
+4. **Office 365 active user detail report** — `getOffice365ActiveUserDetail` is GA on v1.0
+   `/reports/` with `Reports.Read.All`.
+   https://learn.microsoft.com/graph/api/reportroot-getoffice365activeuserdetail?view=graph-rest-1.0
+
+## Gaps Found & Fixes Applied
+
+### 1. Copilot usage report endpoint mislabeled as v1.0 (doc accuracy) — FIXED
+`README.md` ("Microsoft Learn 2026-Q2 integration notes") and `docs/flow-configuration.md`
+(CD-EvidenceCollector → "Microsoft 365 usage reports (Graph)") asserted that
+`getMicrosoft365CopilotUserCountSummary` is served from a v1.0 `/copilot/reports/...`
+path and that beta endpoints "should not be used." Authoritative Microsoft Learn shows the
+opposite: the Copilot usage report APIs exist **only under `/beta`** today. The inline
+`GET` sample and surrounding guidance were corrected to use the beta path and to label
+Copilot usage signals as preview (subject to change, unsupported for production), while
+keeping `getOffice365ActiveUserDetail` on its correct v1.0 path. This source is in the
+**planned, not-yet-implemented** `CD-EvidenceCollector` flow design, so the fix is
+documentation-only with no script impact.
+
+### 2. Notification env-var naming inconsistency (doc consistency) — FIXED
+`docs/deployment-checklist.md` referenced `CD_NotificationEmail`; `docs/flow-configuration.md`
+uses the publisher-prefixed schema name `fsi_CD_NotificationEmail`. Aligned the checklist to
+`fsi_CD_NotificationEmail`.
+
+### Items Verified as Already Correct (no change needed)
+- **`Get-ExchangeComplianceData.ps1`** uses `Invoke-MgGraphRequest` (not a raw token),
+  honors `Retry-After` on 429/503, paginates `@odata.nextLink`, supports sovereign-cloud
+  base URLs, and disconnects in `finally`. Auth is certificate-based app-only or
+  interactive — no client secret. Required scopes match `docs/prerequisites.md`.
+- **`mailboxSettings/userPurpose eq 'shared'` $filter** on `/users` is best-effort: the
+  property is real, but server-side filtering of mailboxSettings across the `/users`
+  collection is not guaranteed. The script already wraps it in try/catch with a
+  documented disabled-account fallback (consistent with `.ralph-config.json`).
+- **Option-set integer values (1-6)** are used consistently across schema, DAX, sample
+  data, and loader, with prominent deployment warnings that the maker-portal default of
+  100000000+ must be overridden. `fsi_cd_evidencetype = 5` (Test Result) is intentionally
+  coupled to `cross-solution-integration`.
+- **DAX measures** use only standard functions (`CALCULATE`, `DATESINPERIOD`, `EOMONTH`,
+  `DATEADD`, `DATESYTD`, `SUMMARIZE`, `ADDCOLUMNS`, `ALLEXCEPT`, `DATATABLE`). Lookup
+  columns correctly referenced via `_<schemaname>_value`; `PillarDimension` counts
+  (29/26/14/9 = 78) match the shipped sample.
+- **`load_sample_data.py`** uses `DefaultAzureCredential` first with a clearly marked
+  legacy client-secret fallback; documents the unimplemented lookup-binding limitation.
+
+## Runtime-Only Caveats (cannot be validated statically)
+
+- Server-side support for the `mailboxSettings/userPurpose` and `assignedLicenses/$count`
+  advanced-query filters depends on tenant/directory state; exercise the fallback paths.
+- `category eq 'DataLossPrevention'` filtering on `alerts_v2` depends on the connected
+  Defender/Purview detection sources; the script already degrades gracefully on failure.
+- Power BI requires the option sets to be created with explicit integer values (1-6) — an
+  authoring step that cannot be verified without a live environment.
+- The `CD-EvidenceCollector` flow remains **planned / not shipped**; Exchange and other
+  evidence must be imported manually until it exists.
+- `load_sample_data.py` `--assessments-only`/`--export` POST path for assessments and
+  exceptions requires lookup-binding work (documented in-script) before it will be
+  accepted by Dataverse.
+
+## Lab-Readiness Assessment
+
+**Lab-ready.** Scripts parse cleanly, documentation is complete and internally consistent,
+and the data-source/API guidance now matches authoritative Microsoft Learn references after
+the one substantive correction (Copilot usage report API version). Remaining limitations are
+clearly documented, intentional, or runtime-only. A deploying admin can follow the
+deployment checklist to a working dashboard, with the noted manual steps (option-set integer
+values, manual evidence import, lookup-binding for assessment loads).
+
+---
+
+*Validated against framework version v1.6.0 · Solution v1.0.5*

--- a/compliance-dashboard/README.md
+++ b/compliance-dashboard/README.md
@@ -205,7 +205,7 @@ The `Get-ExchangeComplianceData.ps1` script collects Exchange Online compliance 
 
 ### Microsoft Learn 2026-Q2 integration notes
 
-- Use Microsoft Graph Reports APIs with `Reports.Read.All` for Microsoft 365 usage signals. Microsoft 365 Copilot usage reports are available under the v1.0 `/copilot/reports/...` path where available; legacy `/beta/reports/...` endpoints should not be used for production dashboards.
+- Use Microsoft Graph Reports APIs with `Reports.Read.All` for Microsoft 365 usage signals. General-availability usage reports such as `getOffice365ActiveUserDetail` are served from the v1.0 `/reports/...` path. Microsoft 365 Copilot usage reports (for example `getMicrosoft365CopilotUserCountSummary`) are currently available **only under `/beta`** (both `/beta/copilot/reports/...` and `/beta/reports/...`); per Microsoft Learn, `/beta` APIs are subject to change and are not supported for production use, so treat Copilot usage signals as preview until a v1.0 endpoint is published.
 - Compliance Manager assessment and improvement-action exports remain portal-driven Excel exports in current Microsoft Learn guidance. Treat those files as evidence inputs until Microsoft publishes a supported Graph API or SDK for assessment score export.
 - Use Power BI semantic model refresh APIs for automation (`Dataset.ReadWrite.All`) and poll refresh status for API-triggered refreshes. For embedded or paginated compliance reporting, use embed token v2 and paginated `exportToFile` only on supported capacity SKUs.
 - Use Dataverse FetchXML aggregate queries or Web API `$apply=groupby(...,aggregate(...))` for cross-table score rollups, and partition large aggregations because Dataverse aggregate queries evaluate up to 50,000 records per query.

--- a/compliance-dashboard/docs/deployment-checklist.md
+++ b/compliance-dashboard/docs/deployment-checklist.md
@@ -45,7 +45,7 @@ This solution does not ship a packaged `.zip` file. Create all Dataverse tables,
 
 - [ ] Follow [Flow Configuration](flow-configuration.md) to manually build CD-ScoreCalculator and CD-ExceptionMonitor flows in Power Automate designer
 - [ ] Configure connection references (Dataverse, Office 365 Outlook, Microsoft Teams) during flow creation
-- [ ] Set the `CD_NotificationEmail` environment variable to the compliance administrator email address
+- [ ] Set the `fsi_CD_NotificationEmail` environment variable to the compliance administrator email address
 
 ---
 

--- a/compliance-dashboard/docs/flow-configuration.md
+++ b/compliance-dashboard/docs/flow-configuration.md
@@ -202,12 +202,15 @@ Recommended interim pattern:
 
 **Microsoft 365 usage reports (Graph)**
 ```http
-GET https://graph.microsoft.com/v1.0/copilot/reports/getMicrosoft365CopilotUserCountSummary(period='D30')?$format=application/json
+# Microsoft 365 Copilot usage reports are currently BETA-only (subject to change, not supported for production):
+GET https://graph.microsoft.com/beta/copilot/reports/getMicrosoft365CopilotUserCountSummary(period='D30')?$format=application/json
+
+# General-availability M365 usage detail is served from v1.0:
 GET https://graph.microsoft.com/v1.0/reports/getOffice365ActiveUserDetail(period='D30')
 Authorization: Bearer {token}
 ```
 
-Use `Reports.Read.All` and the least-privileged Microsoft Entra role required for delegated reads. For production dashboards, prefer the v1.0 `/copilot/reports/...` APIs when available instead of legacy beta `/reports/...` Copilot endpoints.
+Use `Reports.Read.All` and the least-privileged Microsoft Entra role required for delegated reads. The Copilot usage report APIs (`getMicrosoft365CopilotUserCountSummary` and related) exist only on `/beta` as of 2026-Q2 — per Microsoft Learn, `/beta` endpoints are subject to change and are not supported in production, so treat Copilot usage signals as preview until Microsoft publishes a v1.0 equivalent.
 
 **Power Platform Environments**
 ```http


### PR DESCRIPTION
## Summary
Lab-readiness validation of the **compliance-dashboard** solution (v1.0.5). Static validation only (no live tenant): script parse-checks, authoritative Microsoft Learn source verification, and documentation completeness.

## What & why
- **Copilot usage report API correction (substantive):** `README.md` and `docs/flow-configuration.md` claimed `getMicrosoft365CopilotUserCountSummary` is available on a v1.0 `/copilot/reports/...` path and that beta should be avoided. Per Microsoft Learn this report API is **beta-only** (`/beta/copilot/reports/...` and `/beta/reports/...`) as of 2026-Q2 and is not supported for production; `getOffice365ActiveUserDetail` is the GA v1.0 report. Guidance corrected to match the real API surface (documentation-only; this is in the *planned, not-yet-shipped* CD-EvidenceCollector design).
- **Doc consistency:** deployment checklist env-var reference aligned to schema name `fsi_CD_NotificationEmail`.
- **Evidence report:** added `compliance-dashboard/LAB-VALIDATION.md` (what was checked, sources, gaps/fixes, runtime caveats, verdict).
- CHANGELOG `[Unreleased]` updated.

## Authoritative sources
- mailboxSettings `userPurpose` (value `shared` confirmed) — learn.microsoft.com/graph/api/resources/mailboxsettings
- `security/alerts_v2` GA on v1.0 + `SecurityAlert.Read.All` — learn.microsoft.com/graph/api/security-list-alerts_v2
- Copilot usage report is **beta-only** — learn.microsoft.com/graph/api/reportroot-getmicrosoft365copilotusercountsummary?view=graph-rest-beta
- `getOffice365ActiveUserDetail` GA v1.0 — learn.microsoft.com/graph/api/reportroot-getoffice365activeuserdetail

## Verified
- `python -m py_compile` on both `.py` scripts — pass
- PowerShell `Parser::ParseFile` on `Get-ExchangeComplianceData.ps1` — 0 errors
- `create_cd_dataverse_schema.py --output-docs` — no schema-doc drift
- Language-rule grep (excl. CHANGELOG) — clean
- `manifest.yaml` not modified

## Caveats (runtime-only)
Advanced-query `` support (`mailboxSettings/userPurpose`, `assignedLicenses/\`), `alerts_v2` DLP-category filtering, explicit option-set integer values (1-6), and the unimplemented CD-EvidenceCollector flow / assessment lookup-binding cannot be validated statically.

**Verdict: lab-ready.**