### PR TITLE
fix(content-moderation-monitor): lab-readiness validation and corrections

### DIFF
--- a/content-moderation-monitor/CHANGELOG.md
+++ b/content-moderation-monitor/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Content Moderation Monitor.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Major**: `correlate_purview_events.py` passed invalid `recordTypeFilters` values (`CopilotInteraction`, `PowerPlatform`) to the Microsoft Graph `auditLogQuery` API. Neither is a valid `microsoft.graph.security.auditLogRecordType` enum member, so the query would be rejected. Copilot interactions are now selected via `operationFilters: ["CopilotInteraction"]` (unified audit log RecordType 261), the documented way to target Copilot interaction events. Added `operation_filters` support to `create_audit_log_query` and updated the README correlation description. (lab-readiness validation)
+
 ## [1.1.2] - 2026-05-22
 
 ### Fixed

--- a/content-moderation-monitor/LAB-VALIDATION.md
+++ b/content-moderation-monitor/LAB-VALIDATION.md
@@ -1,0 +1,99 @@
+# Lab Validation Report — Content Moderation Monitor
+
+> **Solution:** content-moderation-monitor · **Version:** v1.1.2
+> **Validated:** 2026-06-04 · **Mode:** Static (no live tenant)
+> **Controls:** 1.27 (primary — AI Agent Content Moderation Enforcement), 1.8 (complementary — Runtime Protection and External Threat Detection)
+
+## Purpose
+
+Per-agent validation that Copilot Studio agents meet their governance zone's
+minimum content-moderation level. The monitor enumerates Power Platform
+environments, reads each bot's moderation configuration from Dataverse, compares
+against zone minimums, and persists immutable evidence (validation history,
+violations, baselines) for regulatory examination. A supplementary Python script
+correlates persisted violations with Microsoft Purview unified audit log signals.
+
+## What Was Checked
+
+| Area | Method | Result |
+|------|--------|--------|
+| Python parse validity | `python -m py_compile` on all 6 `scripts/*.py` | PASS |
+| PowerShell parse validity | `Parser::ParseFile` on all 13 `*.ps1`/`*.psm1` | PASS (0 errors) |
+| Language rules | grep for the four prohibited overclaim phrases per `fsi-language-rules` (excl. CHANGELOG) | PASS (0 hits) |
+| Dataverse column naming | grep for snake_case `fsi_*_*` outside known prefixes; cross-check vs `create_dataverse_schema.py` | PASS — all references use logical names |
+| Option-set value drift | Verified `fsi_acv_zone` = 100000000+ in docs and code | PASS |
+| Graph audit API surface | Authoritative Microsoft Learn verification | **1 bug found and fixed** |
+| Copilot Studio moderation naming | Authoritative Microsoft Learn verification | PASS — README scope notes accurate |
+
+## Authoritative Sources Cited
+
+1. **Create auditLogQuery (Graph)** — `POST /security/auditLog/queries`; permission `AuditLogsQuery.Read.All` (Application). Least-privileged service-scoped variants (e.g. `AuditLogsQuery-CRM.Read.All`) also supported.
+   https://learn.microsoft.com/graph/api/security-auditcoreroot-post-auditlogqueries?view=graph-rest-1.0
+2. **auditLogQuery resource** — confirms body properties `filterStartDateTime`, `filterEndDateTime`, `recordTypeFilters`, `operationFilters`; `status` enum (`notStarted`/`running`/`succeeded`/`failed`/`cancelled`); `records` navigation.
+   https://learn.microsoft.com/graph/api/resources/security-auditlogquery?view=graph-rest-1.0
+3. **auditLogRecordType enum** — canonical member list. `MicrosoftTeams` and `PowerPlatformServiceActivity` are valid; **`CopilotInteraction` and `PowerPlatform` are NOT members.**
+   https://learn.microsoft.com/graph/api/resources/security-auditlogrecordtype?view=graph-rest-1.0
+4. **Copilot in the audit log** — Copilot interactions log with **Operation `CopilotInteraction`, RecordType 261**.
+   https://learn.microsoft.com/purview/audit-copilot
+5. **Copilot Studio content moderation** — moderation levels range from **Lowest** to **Highest** (not Low/Medium/High).
+   https://learn.microsoft.com/microsoft-copilot-studio/nlu-boost-node ·
+   https://learn.microsoft.com/microsoft-copilot-studio/knowledge-copilot-studio
+
+## Gaps Found & Fixes Applied
+
+### FIX 1 — Invalid Graph `recordTypeFilters` values (Major; runtime-breaking)
+
+`correlate_purview_events.py` defined
+`COPILOT_RECORD_TYPES = ["CopilotInteraction", "MicrosoftTeams", "PowerPlatform"]`
+and passed them as `recordTypeFilters` to the Graph `auditLogQuery` POST.
+
+- `recordTypeFilters` is a typed `auditLogRecordType` enum collection (source 3).
+- `CopilotInteraction` is **not** an enum member — it is an *operation* name (RecordType 261, source 4).
+- `PowerPlatform` is **not** an enum member — valid Power Platform members are `PowerPlatformServiceActivity`, `PowerPlatformAdminEnvironment`, `PowerPlatformAdminDlp`, etc.
+
+Passing unknown enum members would cause the Graph API to reject the query, breaking the correlation pipeline at runtime.
+
+**Fix:** Added `operation_filters` support to `create_audit_log_query` and switched the call to
+`operationFilters: ["CopilotInteraction"]`, the documented way to target Copilot interaction events.
+The record-type filter is intentionally omitted because `auditLogQuery` filters are AND-combined and the
+Graph enum exposes no Copilot record type. README correlation description and CHANGELOG updated to match.
+
+### Verified-correct (no change needed)
+
+- **Moderation label normalization.** README "Scope and Limitations" already states Copilot Studio uses
+  **Lowest–Highest** and that CMM maps `Lowest→Low` / `Highest→High` onto its three-level evidence scale.
+  Verified accurate against source 5. `Get-ExpectedModerationLevel.ps1` and `Get-BotModerationLevel`
+  implement this mapping consistently.
+- **Graph permission claim.** `AuditLogsQuery.Read.All` (Application) is a valid permission for the audit
+  query API (source 1). README now also notes the least-privileged service-scoped variants.
+- **Dataverse schema references.** All `$select`/`$filter` columns across scripts and docs match
+  `create_dataverse_schema.py` logical names (e.g. `fsi_actuallevel`, `fsi_environmentguid`,
+  `fsi_validationtime`); the explicit singular entity set `fsi_moderationvalidationhistory` and the
+  auto-plural `fsi_moderationviolations` are used correctly (consistent with `.ralph-config.json`).
+- **Auth posture.** Managed-identity-first ordering documented; client-secret paths carry the
+  `# legacy: dev-only` marker; `Get-AzAccessToken` SecureString handling is present in
+  `Connect-EnvironmentDataverse.ps1` and `CMMClient.psm1`.
+
+## Runtime-Only Caveats (not verifiable without a live tenant)
+
+1. **Undocumented moderation source field.** The monitor parses the unstructured `bot.configuration`
+   JSON for several candidate keys (`ContentModeration`, `contentModeration`, ...). Copilot Studio exposes
+   no documented public field for the agent-default moderation level. If the internal key changes, agents
+   report `Unknown` — the scan emits a warning and should be treated as **unverified, not compliant**.
+   This is honestly documented in the README and TROUBLESHOOTING.md. Confirm against a live agent before
+   relying on results.
+2. **Correlation user-matching quality.** `correlate_purview_events.py` matches moderation-violation
+   `ownerid` (a Dataverse systemuser GUID = the scan operator) against audit `UserId` (a UPN = the runtime
+   end user). These identifiers differ in both type and subject, so match yield will be low; the script is
+   positioned as supplementary enrichment, not a primary 1.8 control. A future enhancement could resolve
+   `ownerid → UPN` via the `User.Read.All` grant and correlate on end-user identity. Validate empirically.
+3. **AND-combined audit filters.** With `operationFilters: ["CopilotInteraction"]` only, the query returns
+   Copilot interaction events in the window. Verify volume/throttling behavior on a production-sized tenant.
+
+## Lab-Readiness Assessment
+
+**READY for lab deployment** with the documented caveats. All scripts parse and compile, schema
+references are internally consistent, language and naming conventions pass, and the one runtime-breaking
+Graph enum defect has been corrected and grounded in authoritative Microsoft documentation. The
+remaining items are inherent runtime/data-quality characteristics that require a live tenant to exercise
+and are already disclosed to operators in the README and troubleshooting guide.

--- a/content-moderation-monitor/README.md
+++ b/content-moderation-monitor/README.md
@@ -201,11 +201,11 @@ python scripts/correlate_purview_events.py \
 
 **Correlation logic:**
 1. Pulls moderation violation records from the `fsi_moderationviolations` Dataverse table
-2. Creates a Purview audit log query via Graph `auditLogQuery` API targeting CopilotInteraction, MicrosoftTeams, and PowerPlatform record types
+2. Creates a Purview audit log query via the Microsoft Graph `auditLogQuery` API filtered to the `CopilotInteraction` operation (unified audit log RecordType 261). The Graph `auditLogRecordType` enum does not expose a dedicated Copilot record type, so Copilot interactions are selected by operation filter rather than record-type filter.
 3. Matches events by user principal name + timestamp proximity (5-minute window)
 4. Extracts DSPM context: sensitivity labels, sensitive info types, DLP policy matches, and Copilot interaction metadata
 
-**Required Graph permissions:** `AuditLogsQuery.Read.All` (application), `User.Read.All` (application)
+**Required Graph permissions:** `AuditLogsQuery.Read.All` (application; least-privileged service-scoped variants such as `AuditLogsQuery-CRM.Read.All` are also supported), `User.Read.All` (application)
 
 **Output:** JSON file with enriched events and correlation summary.
 

--- a/content-moderation-monitor/scripts/correlate_purview_events.py
+++ b/content-moderation-monitor/scripts/correlate_purview_events.py
@@ -128,10 +128,22 @@ def create_audit_log_query(
     start_time: datetime,
     end_time: datetime,
     record_types: Optional[list[str]] = None,
+    operation_filters: Optional[list[str]] = None,
 ) -> str:
     """Create a Purview auditLogQuery and return the query ID.
 
-    Reference: https://learn.microsoft.com/graph/api/security-auditlogquery-post
+    ``record_types`` values must be valid ``auditLogRecordType`` enum members
+    (for example ``MicrosoftTeams`` or ``PowerPlatformServiceActivity``);
+    ``operation_filters`` values are activity names such as
+    ``CopilotInteraction``. Copilot interactions are logged with the operation
+    ``CopilotInteraction`` (numeric RecordType 261) and are not exposed as a
+    dedicated ``auditLogRecordType`` enum member, so they are selected via the
+    operation filter rather than the record-type filter.
+
+    References:
+      - https://learn.microsoft.com/graph/api/resources/security-auditlogquery
+      - https://learn.microsoft.com/graph/api/resources/security-auditlogrecordtype
+      - https://learn.microsoft.com/purview/audit-copilot
     """
     body: dict[str, Any] = {
         "displayName": f"CMM-PurviewCorrelation-{datetime.now(tz=timezone.utc).strftime('%Y%m%d%H%M%S')}",
@@ -140,6 +152,8 @@ def create_audit_log_query(
     }
     if record_types:
         body["recordTypeFilters"] = record_types
+    if operation_filters:
+        body["operationFilters"] = operation_filters
 
     result = _graph_request(token, "POST", AUDIT_LOG_QUERY_URL, body=body)
     query_id = result.get("id")
@@ -259,8 +273,14 @@ def pull_moderation_events(
 # Correlation engine
 # ---------------------------------------------------------------------------
 
-# Copilot-related Purview record types
-COPILOT_RECORD_TYPES = ["CopilotInteraction", "MicrosoftTeams", "PowerPlatform"]
+# Copilot interactions are recorded in the unified audit log with the operation
+# "CopilotInteraction" (numeric RecordType 261). The Microsoft Graph
+# auditLogRecordType enum does not expose a dedicated Copilot record type, so the
+# operation filter is used to target Copilot interaction events directly.
+# auditLogQuery filters are combined with AND semantics, so a record-type filter
+# is intentionally omitted to avoid narrowing past Copilot interaction events.
+# Ref: https://learn.microsoft.com/graph/api/resources/security-auditlogrecordtype
+COPILOT_OPERATION_FILTERS = ["CopilotInteraction"]
 TIMESTAMP_TOLERANCE_SECONDS = 300  # 5-minute window for event correlation
 
 
@@ -457,7 +477,7 @@ def main() -> int:
 
     logger.info("Creating Purview audit log query: %s to %s", start_time, end_time)
     query_id = create_audit_log_query(
-        token, start_time, end_time, record_types=COPILOT_RECORD_TYPES
+        token, start_time, end_time, operation_filters=COPILOT_OPERATION_FILTERS
     )
 
     # 4. Poll and retrieve audit records


### PR DESCRIPTION
## Summary
Lab-readiness validation of **content-moderation-monitor** (v1.1.2; controls 1.27 primary, 1.8 complementary). Static validation only — no live tenant. All scripts parse/compile; language and Dataverse naming conventions pass.

## Key fix (Major, runtime-breaking)
`correlate_purview_events.py` passed invalid `recordTypeFilters` values to the Microsoft Graph `auditLogQuery` API:
- `CopilotInteraction` and `PowerPlatform` are **not** members of the `microsoft.graph.security.auditLogRecordType` enum, so the query would be rejected.
- Copilot interactions are logged with **operation `CopilotInteraction` (RecordType 261)**.

**Fix:** added `operation_filters` to `create_audit_log_query` and switched to `operationFilters: ["CopilotInteraction"]`; record-type filter omitted because `auditLogQuery` filters are AND-combined and the enum exposes no Copilot record type. README correlation description + Graph permission note updated.

## Verified correct (no change)
- Copilot Studio moderation scale is **Lowest–Highest**; README scope notes and the Lowest→Low / Highest→High mapping are accurate.
- Dataverse `\`/`\` columns match `create_dataverse_schema.py` logical names.
- `AuditLogsQuery.Read.All` (Application) is valid; least-privileged service-scoped variants noted.
- Managed-identity-first auth posture; `# legacy: dev-only` markers present; SecureString token handling present.

## Authoritative sources
- Graph auditLogQuery resource + create + auditLogRecordType enum (learn.microsoft.com/graph)
- Purview audit Copilot (Operation CopilotInteraction / RecordType 261)
- Copilot Studio content moderation (Lowest–Highest)

## Runtime-only caveats (see LAB-VALIDATION.md)
1. Moderation source is the undocumented `bot.configuration` JSON — agents may report `Unknown` (disclosed; treat as unverified).
2. Correlation matches violation `ownerid` (operator GUID) vs audit `UserId` (end-user UPN) — low match yield; supplementary enrichment only.
3. AND-combined audit filter volume/throttling unverified on production-sized tenants.

## Verdict
**READY for lab deployment** with documented caveats.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
