### PR TITLE
fix(copilot-studio-analytics): lab-readiness validation and corrections

### DIFF
--- a/copilot-studio-analytics/CHANGELOG.md
+++ b/copilot-studio-analytics/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this solution are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Critical — Dataverse column names did not match the official `msdyn_botsession` schema.** The sync `$select`/`$filter`/`$orderby` and all session reads used `msdyn_sessioncreatedon`, `msdyn_sessionclosedon`, `msdyn_sessionoutcome`, and `msdyn_sessionoutcomereason`. Per the official entity reference (https://learn.microsoft.com/en-us/dynamics365/developer/reference/entities/msdyn_botsession) the attribute logical names are `msdyn_startedon`, `msdyn_endedon`, `msdyn_outcome`, and `msdyn_outcomereason` (the `msdyn_sessionoutcome*` strings are the *global choice* names, not column logical names). The prior names would cause Dataverse Web API `$select` to reject the query (HTTP 400). Corrected in `sync_dataverse_sessions.py`, `architecture.md`, `docs/dataverse-data-sources.md`, `docs/agent-assisted-hours-methodology.md`, `docs/viva-insights-parity-matrix.md`, and `tests/test_sync_dataverse_sessions.py`. The v1.1.1 change that aligned docs *to the script* propagated the script's incorrect names; this corrects both to the authoritative schema.
+- **Critical — Session-outcome option-set integers were wrong.** `SESSION_OUTCOMES`/`SESSION_OUTCOME_REASONS` used the `192350001..192350004` / `192350100..192350106` series, which appears in no Microsoft entity reference. The documented values are `419550000` (none) / `419550001` (resolved) / `419550002` (escalated) / `419550003` (abandoned) for `msdyn_outcome`, and `419560000..419560008` for `msdyn_outcomereason`. With the old integers every outcome mapped to "Unknown" against real data. Maps and the `dataverse-data-sources.md` option-set tables corrected; the downstream KQL friendly-label contract (`Resolved`/`Escalated`/`Abandoned`/`Success`/`Failure`) is unchanged.
+- **`msdyn_channelid` / `msdyn_conversationid` are not columns on `msdyn_botsession`.** Both were referenced in the `$select` and docs. `msdyn_botsession` exposes no channel column in its documented schema, so channel-derived `usageType` (Internal/External) is not derivable in Tier 1; the invalid columns were removed from the query, `usageType` now emits `"Unknown"`, and `classify_usage_type()` / docs note this Tier 2 limitation honestly.
+
+### Notes
+
+- This is a corrections-only change validated by static + authoritative-source review (no live tenant). Hard-coded option-set integers remain Microsoft-managed; operators should still verify against their environment's metadata. See `LAB-VALIDATION.md` for the full evidence report and cited sources.
+- Maintainers cutting the next release should bump to **v2.0.3** across the root catalog files (`README.md`, `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`) and `manifest.yaml`.
+
 ## [2.0.2] - 2026-05-22
 
 ### Fixed

--- a/copilot-studio-analytics/LAB-VALIDATION.md
+++ b/copilot-studio-analytics/LAB-VALIDATION.md
@@ -31,7 +31,7 @@ management reporting (not standalone regulator-grade evidence — see `queries/g
 | Agent classification (`componenttype = 17`) | Verified against `botcomponent` entity reference | ✅ Code correct; wording already honest |
 | Auth / token audience | Reviewed managed-identity-first auth + Dataverse scope | ✅ Correct (scope = environment URL `/.default`) |
 | SDK status | `applicationinsights` (maintenance) vs `azure-monitor-opentelemetry`; `LogsQueryClient.query_workspace`/`query_resource` | ✅ Consistent with docs |
-| Language rules | Grepped `ensures|guarantees|will prevent|eliminates risk` (excluding CHANGELOG history) | ✅ Zero hits |
+| Language rules | Grepped for the FSI-prohibited compliance-absolute phrases (per `fsi-language-rules.instructions.md`, excluding CHANGELOG history) | ✅ Zero hits |
 | PowerShell parse | N/A — solution contains no `.ps1` files | — |
 
 ## 3. Authoritative Sources Cited

--- a/copilot-studio-analytics/LAB-VALIDATION.md
+++ b/copilot-studio-analytics/LAB-VALIDATION.md
@@ -1,0 +1,138 @@
+# Lab Validation Report — Copilot Studio Analytics
+
+> **Scope:** Static, authoritative-source validation of the `copilot-studio-analytics`
+> solution for a lab-ready steady state. No live tenant was available, so this report
+> covers parse-validity, authoritative-source verification of every external API/schema
+> claim, documentation completeness, and corrections applied. Runtime-only behaviors are
+> called out explicitly.
+>
+> **Date:** 2026-06-04 · **Solution version:** v2.0.2 (corrections staged under `[Unreleased]`)
+> **Primary control:** 3.2 — Usage Analytics and Activity Monitoring
+
+## 1. Purpose & Controls
+
+Copilot Studio Analytics (CSA) syncs Copilot Studio session outcomes from Dataverse
+(`msdyn_botsession`) into Application Insights as `CopilotSessionOutcome` custom events,
+and ships a KQL query library plus Azure Monitor Workbooks for session-outcome, CSAT,
+Agent Assisted Hours (AAH), and ROI analytics. It supports **Control 3.2** (business-impact
+analytics) and contributes supporting context to FINRA 3110, SOX 404, and OCC 2011-12
+management reporting (not standalone regulator-grade evidence — see `queries/governance-queries.md`).
+
+## 2. What Was Checked
+
+| Area | Method | Result |
+|------|--------|--------|
+| Python scripts parse | `python -m py_compile` on all 3 scripts | ✅ Pass |
+| Unit tests | `pytest tests/` | ✅ 3 passed |
+| Dataverse column names | Cross-checked every `$select`/`$filter`/read against the official `msdyn_botsession` entity reference | ❌ → ✅ Fixed (see §4) |
+| Option-set integer values | Cross-checked `SESSION_OUTCOMES`/`SESSION_OUTCOME_REASONS` against entity reference | ❌ → ✅ Fixed (see §4) |
+| KQL schema (classic + workspace) | Verified `customEvents`/`timestamp`/`customDimensions` and `AppEvents`/`TimeGenerated`/`Name`/`Properties` | ✅ Correct |
+| KQL `summarize`/`bin` projection bug | Grepped all queries + workbook templates for `X = timestamp` after `summarize` | ✅ None remain (v2.0.2 fixed; trend queries correctly project `Timestamp = SessionTime`) |
+| Agent classification (`componenttype = 17`) | Verified against `botcomponent` entity reference | ✅ Code correct; wording already honest |
+| Auth / token audience | Reviewed managed-identity-first auth + Dataverse scope | ✅ Correct (scope = environment URL `/.default`) |
+| SDK status | `applicationinsights` (maintenance) vs `azure-monitor-opentelemetry`; `LogsQueryClient.query_workspace`/`query_resource` | ✅ Consistent with docs |
+| Language rules | Grepped `ensures|guarantees|will prevent|eliminates risk` (excluding CHANGELOG history) | ✅ Zero hits |
+| PowerShell parse | N/A — solution contains no `.ps1` files | — |
+
+## 3. Authoritative Sources Cited
+
+1. `msdyn_botsession` table/entity reference (column logical names + option-set integers):
+   https://learn.microsoft.com/en-us/dynamics365/developer/reference/entities/msdyn_botsession
+2. `botcomponent` table/entity reference (`componenttype` choices; value 17 = "External Trigger"):
+   https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/botcomponent
+3. Azure Monitor Logs standard columns (`Timestamp` for classic vs `TimeGenerated` for workspace):
+   https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-standard-columns
+4. `AppEvents` table reference (`TimeGenerated`, `Name`, `Properties`):
+   https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/appevents
+5. Kusto `summarize` operator (result keeps only `by` columns + aggregates):
+   https://learn.microsoft.com/en-us/kusto/query/summarize-operator
+6. Copilot Studio + Application Insights telemetry events (`BotMessageSend`/`BotMessageReceived`/`GenerativeAnswers`):
+   https://learn.microsoft.com/en-us/dynamics365/guidance/resources/copilot-studio-appinsights
+7. `LogsQueryClient` (`query_workspace` vs `query_resource`):
+   https://learn.microsoft.com/en-us/python/api/azure-monitor-query/azure.monitor.query.logsqueryclient
+8. Dataverse OAuth scope (`<environment-url>/.default`):
+   https://learn.microsoft.com/en-us/power-apps/developer/data-platform/authenticate-oauth
+9. App Insights classic SDK retirement / OpenTelemetry migration direction:
+   https://learn.microsoft.com/en-us/previous-versions/azure/azure-monitor/app/classic-api
+10. `Get-AzAccessToken` SecureString default (context for repo auth standard):
+    https://learn.microsoft.com/en-us/powershell/module/az.accounts/get-azaccesstoken
+
+## 4. Gaps Found & Fixes Applied
+
+### 4.1 🔴 Critical — Wrong Dataverse column logical names
+The sync read sessions via `msdyn_sessioncreatedon`, `msdyn_sessionclosedon`,
+`msdyn_sessionoutcome`, `msdyn_sessionoutcomereason`. The official `msdyn_botsession`
+entity reference shows the attribute **logical names** are `msdyn_startedon`,
+`msdyn_endedon`, `msdyn_outcome`, `msdyn_outcomereason`. The `msdyn_sessionoutcome*`
+strings are the **global choice (option set) names**, not column identifiers. A Dataverse
+Web API `$select` on a non-existent property returns HTTP 400, so the pipeline would fail
+on the first fetch in any real environment.
+
+**Root cause:** the CHANGELOG `[1.1.1]` entry aligned the docs *to the sync script* rather
+than to the schema, propagating the script's incorrect names. Two prior council reviews
+validated script↔doc internal consistency but never compared against the external Microsoft
+schema — exactly the gap this validation targeted.
+
+**Fix:** corrected `scripts/sync_dataverse_sessions.py` (`fetch_sessions` select/filter/orderby,
+`get_session_created_timestamp`, `get_session_effective_timestamp`, `transform_session`),
+the test fixtures, and all four docs.
+
+### 4.2 🔴 Critical — Wrong option-set integers
+`SESSION_OUTCOMES` used `192350001..192350004` and `SESSION_OUTCOME_REASONS` used
+`192350100..192350106`. Neither series exists in the Microsoft entity reference, which
+documents `419550000..419550003` for `msdyn_outcome` and `419560000..419560008` for
+`msdyn_outcomereason`. With the old integers, **every** outcome would map to `"Unknown"`
+against live data, zeroing out all outcome-dependent analytics.
+
+**Fix:** replaced both maps with the documented values; preserved the capitalized
+friendly labels (`Resolved`/`Escalated`/`Abandoned`) that the KQL data contract depends on.
+`419550000` ("none") maps to `Unengaged` to preserve existing downstream semantics.
+Updated the option-set tables in `docs/dataverse-data-sources.md`.
+
+### 4.3 🟡 Medium — Non-existent channel/conversation columns
+The `$select` and docs referenced `msdyn_channelid` and `msdyn_conversationid`, which are
+**not** columns on `msdyn_botsession` (no channel column exists in the documented schema).
+Including them would also cause a 400. `usageType` (Internal/External) therefore cannot be
+derived in Tier 1.
+
+**Fix:** removed the invalid columns from the query; `classify_usage_type()` now returns
+`"Unknown"` when no channel data is present (instead of silently labeling everything
+`"Internal"`); the transform emits `usageType = "Unknown"`; code comments and docs note that
+channel-based usage typing is planned for Tier 2 (transcript parsing).
+
+### 4.4 ✅ Verified-correct (no change)
+- KQL classic/workspace dual-schema union, `summarize`/`bin` projections, and the v2.0.2
+  `Timestamp = SessionTime` fixes are all correct.
+- `botcomponent.componenttype = 17` = "External Trigger"; the existing code/README wording
+  ("External Trigger / Event-Driven … integer `componenttype`, not `componenttypename`") is
+  accurate. Note this counts trigger-definition components as an autonomous-agent proxy.
+- Managed-identity-first auth, Dataverse `/.default` scope, and `LogsQueryClient`
+  workspace-vs-resource routing match Microsoft guidance.
+
+## 5. Runtime-Only Caveats (cannot be verified statically)
+
+- **Option-set integers are environment-dependent.** Microsoft manages these values and may
+  renumber them across Copilot Studio releases. Operators should confirm via
+  `GET …/EntityDefinitions(LogicalName='msdyn_botsession')/Attributes(LogicalName='msdyn_outcome')/Microsoft.Dynamics.CRM.PicklistAttributeMetadata?$expand=OptionSet`.
+- **Standalone vs Customer Service schema.** The `msdyn_botsession` reference is documented in
+  the Dynamics 365 developer reference (Customer Service / Omnichannel context). Standalone
+  Copilot Studio provisions the same managed table, but a runtime metadata check is still the
+  authoritative confirmation for a given tenant.
+- **`TelemetryClient.track_event` send-time stamping** (the reason KQL re-bins on
+  `customDimensions['sessionClosedOn']`) is an SDK behavior asserted by the code; not
+  independently documented by Microsoft, but consistent with the maintenance status of the
+  `applicationinsights` package. Migration to `azure-monitor-opentelemetry` remains the
+  documented remediation.
+- **Copilot Studio standalone App Insights event names** (`BotMessageSend`, etc.) are
+  confirmed in the Dynamics 365 Customer Service guidance; a dedicated standalone Copilot
+  Studio event-schema page was not locatable on Microsoft Learn at validation time.
+
+## 6. Lab-Readiness Assessment
+
+**Verdict: Lab-ready (corrected).** Before this validation the solution would have failed at
+the first Dataverse fetch (HTTP 400 from invalid `$select` columns) and produced all-`Unknown`
+outcomes even if the query had succeeded. With the column-name and option-set corrections, the
+sync's documented data contract now matches the authoritative `msdyn_botsession` schema, and
+the KQL/workbook layer (which consumes only the emitted `customDimensions`) is unaffected and
+verified. Remaining items are runtime-only confirmations (§5), appropriate for a tenant smoke
+test rather than static review.

--- a/copilot-studio-analytics/architecture.md
+++ b/copilot-studio-analytics/architecture.md
@@ -92,9 +92,9 @@ Tier 1 provides session-level outcome data sufficient for most analytics:
 
 | Data Point | Source | Notes |
 |-----------|--------|-------|
-| Session outcome | msdyn_botsession.msdyn_sessionoutcome | Resolved, Escalated, Abandoned, Unengaged |
+| Session outcome | msdyn_botsession.msdyn_outcome | Resolved, Escalated, Abandoned, Unengaged (global choice `msdyn_sessionoutcome`) |
 | CSAT score | msdyn_botsession.msdyn_csatscore | 1-5 scale when survey enabled |
-| Session duration | msdyn_botsession timestamps | `msdyn_sessioncreatedon` and `msdyn_sessionclosedon` |
+| Session duration | msdyn_botsession timestamps | `msdyn_startedon` and `msdyn_endedon` |
 | Agent ID | msdyn_botsession.msdyn_botid | Joined with bot table for name |
 | Agent type | botcomponent.componenttype (integer) | Optionset value `17` = External Trigger (autonomous). The integer `componenttype` column is used; `componenttypename` is the human-readable label and is **not** the column queried. |
 | Knowledge source proxy | `msdyn_topicname` substring heuristic | Tier 1 best-effort heuristic — `hasKnowledgeSource = true` when the topic name contains `generativeanswers` or `knowledge` (case-insensitive). It does **not** correlate with `GenerativeAnswers` Application Insights events; agents whose KS topic uses a custom name will be under-counted. Tier 2 plans actual App Insights correlation. |
@@ -126,7 +126,7 @@ The sync pipeline uses a Dataverse tracking table (`fsi_csasyncwatermark`) to im
 
 1. **Read watermark:** Query fsi_csasyncwatermarks for the last successful sync timestamp per environment
 2. **Check concurrency lock:** Verify no other sync is InProgress (advisory lock with stale timeout)
-3. **Fetch new records:** Query msdyn_botsession where `msdyn_sessioncreatedon >= watermark - lookback_buffer` with `$orderby=msdyn_sessioncreatedon asc`
+3. **Fetch new records:** Query msdyn_botsession where `msdyn_startedon >= watermark - lookback_buffer` with `$orderby=msdyn_startedon asc`
 4. **Enrich records:** Join with bot (agent name) and botcomponent (agent type classification)
 5. **Emit events:** Send CopilotSessionOutcome custom events to Application Insights via Track API
 6. **Update watermark:** Write new watermark timestamp (last session's end time) after successful batch commit
@@ -148,19 +148,19 @@ Each synced session produces a custom event with these properties:
 | customDimensions.recipientId | string | Agent ID (matches AOF `recipientId` format) |
 | customDimensions.sessionId | string | Unique session ID from `msdyn_botsessionid` |
 | customDimensions.sessionOutcome | string | Conversational: Resolved, Escalated, Abandoned; Autonomous: Success, Failure |
-| customDimensions.sessionOutcomeReason | string | Sub-type from `msdyn_sessionoutcomereason` |
+| customDimensions.sessionOutcomeReason | string | Sub-type from `msdyn_outcomereason` |
 | customDimensions.isEngaged | boolean | Engaged session flag from `msdyn_isengaged` |
 | customDimensions.csatScore | number | 1-5 for conversational, empty for autonomous |
-| customDimensions.sessionDurationSeconds | number | Duration computed from `msdyn_sessioncreatedon` and `msdyn_sessionclosedon` |
+| customDimensions.sessionDurationSeconds | number | Duration computed from `msdyn_startedon` and `msdyn_endedon` |
 | customDimensions.hasKnowledgeSource | boolean | Tier 1 best-effort heuristic on `msdyn_topicname` (substring match for `generativeanswers`/`knowledge`); does **not** correlate with App Insights GenerativeAnswers events |
 | customDimensions.topicName | string | Primary topic from `msdyn_topicname` |
 | customDimensions.agentMode | string | `Conversational` or `Autonomous` |
-| customDimensions.channelId | string | Channel identifier |
+| customDimensions.usageType | string | `Unknown` in Tier 1 — `msdyn_botsession` has no channel column; channel-derived Internal/External classification is planned for Tier 2 |
 | customDimensions.Zone | string | Governance zone from environment metadata |
 | customDimensions.syncSource | string | `DataverseSync` (distinguishes from native events) |
 | customDimensions.syncTier | string | `Tier1` or `Tier2` |
-| customDimensions.sessionCreatedOn | string (ISO 8601) | True session start (`msdyn_sessioncreatedon`). Re-bin trends on this in KQL — see note on `timestamp` below. |
-| customDimensions.sessionClosedOn | string (ISO 8601) | True session end (`msdyn_sessionclosedon`). Re-bin trends on this in KQL — see note on `timestamp` below. |
+| customDimensions.sessionCreatedOn | string (ISO 8601) | True session start (`msdyn_startedon`). Re-bin trends on this in KQL — see note on `timestamp` below. |
+| customDimensions.sessionClosedOn | string (ISO 8601) | True session end (`msdyn_endedon`). Re-bin trends on this in KQL — see note on `timestamp` below. |
 | timestamp | datetime | **Important:** Application Insights stamps this column with the **send-time** of the sync run, not the actual session time. The `applicationinsights` Python SDK's `TelemetryClient.track_event` does not accept a custom timestamp. KQL queries that need true session time should bin on `customDimensions['sessionClosedOn']`. Migration to `azure-monitor-opentelemetry` (which supports custom timestamps) is planned. |
 
 ## Agent Type Classification

--- a/copilot-studio-analytics/docs/agent-assisted-hours-methodology.md
+++ b/copilot-studio-analytics/docs/agent-assisted-hours-methodology.md
@@ -156,7 +156,7 @@ The accuracy of AAH calculations depends on the data tier available.
 |--------|-------------|-------------|---------------------|
 | Knowledge source citations | GenerativeAnswers (Result = "Success") | conversationtranscript Citation entities *(planned)* | Tier 1 may overcount (one event per generative call, not per citation) |
 | Action execution count | Not available in Tier 1 | conversationtranscript invoke activities *(planned)* | Tier 1 autonomous AAH uses session-level estimates only |
-| Session outcome | msdyn_botsession.msdyn_sessionoutcome | Same | No difference |
+| Session outcome | msdyn_botsession.msdyn_outcome | Same | No difference |
 | CSAT score | msdyn_botsession.msdyn_csatscore | Same | No difference |
 
 ### Impact on AAH Accuracy

--- a/copilot-studio-analytics/docs/dataverse-data-sources.md
+++ b/copilot-studio-analytics/docs/dataverse-data-sources.md
@@ -24,44 +24,53 @@ The primary data source for session outcome analytics. Each record represents on
 
 | Column (Logical Name) | Type | Description | Notes |
 |------------------------|------|-------------|-------|
-| msdyn_botsessionid | Uniqueidentifier | Primary key | Used as operation_Id for deduplication |
-| msdyn_botid | Lookup (bot) | Reference to the agent | Foreign key to bot table |
-| msdyn_sessionoutcome | OptionSet | Session result | See outcome values below |
+| msdyn_botsessionid | Uniqueidentifier | Primary key | Used as session ID for deduplication |
+| msdyn_botid | Lookup (bot) | Reference to the agent | Foreign key to bot table (`_msdyn_botid_value`) |
+| msdyn_outcome | OptionSet | Session result | Global choice `msdyn_sessionoutcome`; see outcome values below |
+| msdyn_outcomereason | OptionSet | Reason for session outcome | Global choice `msdyn_sessionoutcomereason`; see reason values below |
 | msdyn_csatscore | Integer | Customer satisfaction score | 1-5 scale; null if survey not enabled |
-| msdyn_sessioncreatedon | DateTime | Session start timestamp | UTC |
-| msdyn_sessionclosedon | DateTime | Session end timestamp | UTC; used as event timestamp |
-| msdyn_conversationid | String | Conversation identifier | Links to conversationtranscript |
-| msdyn_channelid | String | Channel identifier | Teams, Web, etc. |
-| msdyn_sessionoutcomereason | String | Reason for session outcome | e.g., escalation reason, resolution detail |
+| msdyn_startedon | DateTime | Session start timestamp | UTC; used for the lookback filter and `$orderby` |
+| msdyn_endedon | DateTime | Session end timestamp | UTC; used as event timestamp (falls back to start) |
 | msdyn_isengaged | Boolean | Whether the user engaged with the agent | Filters out non-interactive sessions |
 | msdyn_topicname | String | Topic name associated with the session | Primary topic that handled the session |
-| modifiedon | DateTime | Last modified timestamp | Used for watermark-based sync |
+| msdyn_convtranscriptid | Lookup | Conversation transcript reference | Reserved for Tier 2 transcript parsing |
+| modifiedon | DateTime | Last modified timestamp | |
 | createdon | DateTime | Record creation timestamp | |
 
-**Session Outcome Values (msdyn_sessionoutcome):**
+> **No channel column:** `msdyn_botsession` does not expose a channel identifier in its
+> documented schema, so channel-derived `usageType` (Internal/External) is not available
+> in Tier 1. The sync emits `usageType = "Unknown"`; channel classification is planned for
+> Tier 2 (conversation-transcript parsing). Source of truth for this table's columns is the
+> [official `msdyn_botsession` entity reference](https://learn.microsoft.com/en-us/dynamics365/developer/reference/entities/msdyn_botsession).
 
-The following integer optionset values are what the sync code (`scripts/sync_dataverse_sessions.py` `SESSION_OUTCOMES`) reads and what Microsoft Customer Service / Copilot Studio actually emit:
+**Session Outcome Values (`msdyn_outcome`, global choice `msdyn_sessionoutcome`):**
 
-| Value | Label | Description |
-|-------|-------|-------------|
-| 192350001 | Resolved | Session completed successfully -- user's intent was addressed |
-| 192350002 | Escalated | Session transferred to a human agent |
-| 192350003 | Abandoned | User left the session without resolution |
-| 192350004 | Unengaged | Session started but no meaningful interaction occurred |
+The following integer optionset values are documented in the official `msdyn_botsession`
+entity reference and are what the sync code (`scripts/sync_dataverse_sessions.py`
+`SESSION_OUTCOMES`) reads:
 
-**Session Outcome Reason Values (msdyn_sessionoutcomereason):**
+| Value | Label (Microsoft) | Mapped label | Description |
+|-------|-------------------|--------------|-------------|
+| 419550000 | none | Unengaged | No outcome recorded -- typically an unengaged session |
+| 419550001 | resolved | Resolved | Session completed successfully -- user's intent was addressed |
+| 419550002 | escalated | Escalated | Session transferred to a human agent |
+| 419550003 | abandoned | Abandoned | User left the session without resolution |
 
-| Value | Label |
-|-------|-------|
-| 192350100 | TopicResolved |
-| 192350101 | UserEndedConversation |
-| 192350102 | HandoffInitiated |
-| 192350103 | AgentTransfer |
-| 192350104 | Timeout |
-| 192350105 | UserAbandoned |
-| 192350106 | NoEngagement |
+**Session Outcome Reason Values (`msdyn_outcomereason`, global choice `msdyn_sessionoutcomereason`):**
 
-> **Note:** Optionset values may vary slightly across Copilot Studio releases. Verify against your environment's option set metadata using `GET /api/data/v9.2/EntityDefinitions(LogicalName='msdyn_botsession')/Attributes(LogicalName='msdyn_sessionoutcome')/Microsoft.Dynamics.CRM.PicklistAttributeMetadata?$expand=OptionSet`.
+| Value | Label (Microsoft) |
+|-------|-------------------|
+| 419560000 | noError |
+| 419560001 | userError |
+| 419560002 | systemError |
+| 419560003 | userExit |
+| 419560004 | agentTransferWithoutError |
+| 419560005 | agentTransferRequestedByUser |
+| 419560006 | resolved |
+| 419560007 | agentTransferConfiguredByAuthor |
+| 419560008 | agentTransferFromQuestionMaxAttempts |
+
+> **Note:** Optionset values are Microsoft-managed and may change across Copilot Studio releases. Verify against your environment's option set metadata using `GET /api/data/v9.2/EntityDefinitions(LogicalName='msdyn_botsession')/Attributes(LogicalName='msdyn_outcome')/Microsoft.Dynamics.CRM.PicklistAttributeMetadata?$expand=OptionSet`.
 
 ### bot
 
@@ -118,7 +127,7 @@ Per-topic session data. Each record represents the execution of a specific topic
 | msdyn_botsessionid | Lookup (msdyn_botsession) | Parent session | Join key to session table |
 | msdyn_botcomponentid | Lookup (botcomponent) | Topic/dialog executed | |
 | msdyn_topicname | String | Topic display name | |
-| msdyn_sessionoutcome | OptionSet | Topic-level outcome | Same option set as session outcome |
+| msdyn_outcome | OptionSet | Topic-level outcome | Global choice `msdyn_sessionoutcome` (verify per environment) |
 | msdyn_startedon | DateTime | Topic start timestamp | |
 | msdyn_endedon | DateTime | Topic end timestamp | |
 | createdon | DateTime | Record creation timestamp | |
@@ -136,7 +145,7 @@ Full conversation content in JSON format. Contains message-level detail includin
 |------------------------|------|-------------|-------|
 | conversationtranscriptid | Uniqueidentifier | Primary key | |
 | name | String | Transcript display name | |
-| conversationid | String | Conversation identifier | Links to msdyn_botsession.msdyn_conversationid |
+| conversationid | String | Conversation identifier | Correlate via `msdyn_botsession.msdyn_convtranscriptid` lookup |
 | content | Memo (large text) | JSON conversation content | Requires JSON parsing -- see schema below |
 | schematype | String | Content schema identifier | Indicates JSON structure version |
 | createdon | DateTime | Transcript creation timestamp | Subject to 30-day bulk delete |
@@ -213,11 +222,11 @@ Custom Dataverse table created by `create_csa_dataverse_schema.py`. Tracks sync 
 
 ```
 GET /api/data/v9.2/msdyn_botsessions
-  ?$filter=msdyn_sessioncreatedon ge {watermark}
-  &$select=msdyn_botsessionid,msdyn_sessionoutcome,msdyn_csatscore,
-           msdyn_sessioncreatedon,msdyn_sessionclosedon,_msdyn_botid_value,
-           msdyn_conversationid,msdyn_channelid,modifiedon
-  &$orderby=msdyn_sessioncreatedon asc
+  ?$filter=msdyn_startedon ge {watermark}
+  &$select=msdyn_botsessionid,msdyn_outcome,msdyn_outcomereason,msdyn_csatscore,
+           msdyn_startedon,msdyn_endedon,_msdyn_botid_value,
+           msdyn_isengaged,msdyn_topicname
+  &$orderby=msdyn_startedon asc
   &$top=5000
 ```
 
@@ -243,8 +252,8 @@ GET /api/data/v9.2/botcomponents
 GET /api/data/v9.2/msdyn_botcomponentsessions
   ?$filter=createdon gt {watermark}
   &$select=msdyn_botcomponentsessionid,_msdyn_botsessionid_value,
-           msdyn_topicname,msdyn_sessionoutcome,
-           msdyn_sessioncreatedon,msdyn_sessionclosedon
+           msdyn_topicname,msdyn_outcome,
+           msdyn_startedon,msdyn_endedon
   &$orderby=createdon asc
   &$top=5000
 ```

--- a/copilot-studio-analytics/docs/viva-insights-parity-matrix.md
+++ b/copilot-studio-analytics/docs/viva-insights-parity-matrix.md
@@ -17,7 +17,7 @@ This matrix documents what CSA covers, what it partially covers, and what remain
 | Agent inventory | KQL: Agent Inventory query + Agent Overview workbook | Near parity | CSA adds agent type classification (conversational/autonomous) |
 | Active agent trend | KQL: Active Agent Trend query | Near parity | Same data source (msdyn_botsession), same calculation |
 | Session volume | KQL: Top Agents by Volume query | Near parity | CSA correlates with native BotMessageSend events |
-| Session outcomes (conversational) | KQL: Conversational Outcomes query | Near parity | Same msdyn_sessionoutcome data |
+| Session outcomes (conversational) | KQL: Conversational Outcomes query | Near parity | Same msdyn_outcome data |
 | Session outcomes (autonomous) | KQL: Autonomous Outcomes query | Near parity | CSA separates autonomous from conversational outcomes |
 | CSAT distribution | KQL: CSAT Distribution query | Near parity | Same msdyn_csatscore source |
 | Resolution rate | KQL: Resolution Matrix query | Near parity | CSA adds outcome weighting by agent type |

--- a/copilot-studio-analytics/scripts/sync_dataverse_sessions.py
+++ b/copilot-studio-analytics/scripts/sync_dataverse_sessions.py
@@ -58,23 +58,35 @@ from applicationinsights import TelemetryClient
 # Configure logging
 logger = logging.getLogger("csa-sync")
 
-# Dataverse session outcome option set values
+# Dataverse session outcome option set values.
+# Attribute logical name: msdyn_outcome (global choice name: msdyn_sessionoutcome).
+# Integer values per the official msdyn_botsession entity reference:
+#   https://learn.microsoft.com/en-us/dynamics365/developer/reference/entities/msdyn_botsession
+# The friendly labels below intentionally preserve the downstream KQL data contract
+# (queries compare Outcome == "Resolved"/"Escalated"/"Abandoned"). 419550000 is the
+# documented "none" value (no outcome recorded — typically unengaged sessions).
+# Option-set integers are Microsoft-managed; verify against your environment's
+# metadata if a future Copilot Studio release renumbers them.
 SESSION_OUTCOMES = {
-    192350001: "Resolved",
-    192350002: "Escalated",
-    192350003: "Abandoned",
-    192350004: "Unengaged",
+    419550000: "Unengaged",
+    419550001: "Resolved",
+    419550002: "Escalated",
+    419550003: "Abandoned",
 }
 
-# Dataverse session outcome reason option set values
+# Dataverse session outcome reason option set values.
+# Attribute logical name: msdyn_outcomereason (global choice: msdyn_sessionoutcomereason).
+# Integer values and labels per the official msdyn_botsession entity reference (see above).
 SESSION_OUTCOME_REASONS = {
-    192350100: "TopicResolved",
-    192350101: "UserEndedConversation",
-    192350102: "HandoffInitiated",
-    192350103: "AgentTransfer",
-    192350104: "Timeout",
-    192350105: "UserAbandoned",
-    192350106: "NoEngagement",
+    419560000: "NoError",
+    419560001: "UserError",
+    419560002: "SystemError",
+    419560003: "UserExit",
+    419560004: "AgentTransferWithoutError",
+    419560005: "AgentTransferRequestedByUser",
+    419560006: "Resolved",
+    419560007: "AgentTransferConfiguredByAuthor",
+    419560008: "AgentTransferFromQuestionMaxAttempts",
 }
 
 # CSA Sync watermark table constants
@@ -111,12 +123,12 @@ def parse_iso_datetime(value: Any) -> Optional[datetime]:
 
 def get_session_created_timestamp(session: dict[str, Any]) -> Optional[datetime]:
     """Return the session creation timestamp used by the Dataverse lookback filter."""
-    return parse_iso_datetime(session.get("msdyn_sessioncreatedon"))
+    return parse_iso_datetime(session.get("msdyn_startedon"))
 
 
 def get_session_effective_timestamp(session: dict[str, Any]) -> Optional[datetime]:
     """Return the session timestamp used for watermark advancement."""
-    return parse_iso_datetime(session.get("msdyn_sessionclosedon")) or get_session_created_timestamp(session)
+    return parse_iso_datetime(session.get("msdyn_endedon")) or get_session_created_timestamp(session)
 
 
 def get_latest_session_timestamp(sessions: list[dict[str, Any]], fallback: datetime) -> datetime:
@@ -638,17 +650,16 @@ def fetch_sessions(
         select=[
             "msdyn_botsessionid",
             "_msdyn_botid_value",
-            "msdyn_sessionoutcome",
-            "msdyn_sessionoutcomereason",
-            "msdyn_sessioncreatedon",
-            "msdyn_sessionclosedon",
+            "msdyn_outcome",
+            "msdyn_outcomereason",
+            "msdyn_startedon",
+            "msdyn_endedon",
             "msdyn_isengaged",
             "msdyn_csatscore",
             "msdyn_topicname",
-            "msdyn_channelid",
         ],
-        filter_expr=f"msdyn_sessioncreatedon ge {start_iso}",
-        orderby="msdyn_sessioncreatedon asc",
+        filter_expr=f"msdyn_startedon ge {start_iso}",
+        orderby="msdyn_startedon asc",
     )
 
     logger.info("Fetched %d sessions from Dataverse", len(sessions))
@@ -712,14 +723,23 @@ def classify_usage_type(channel_id: str) -> str:
     """
     Classify usage type from the session channel identifier.
 
+    Tier 1 LIMITATION: the ``msdyn_botsession`` table does not expose a channel
+    column in its documented schema (see the official entity reference:
+    https://learn.microsoft.com/en-us/dynamics365/developer/reference/entities/msdyn_botsession),
+    so ``channel_id`` is currently always empty and this function returns
+    "Unknown". Channel-derived Internal/External classification is planned for
+    Tier 2 (conversation-transcript parsing). The keyword matching below is
+    retained for that future source and for callers that can supply a channel
+    identifier from another table.
+
     Args:
-        channel_id: The msdyn_channelid value from the session record
+        channel_id: A channel identifier, if available from a Tier 2 source.
 
     Returns:
-        "Internal" or "External"
+        "Internal", "External", or "Unknown" when no channel data is available.
     """
     if not channel_id:
-        return "Internal"
+        return "Unknown"
 
     channel_lower = channel_id.lower()
 
@@ -731,7 +751,7 @@ def classify_usage_type(channel_id: str) -> str:
     if any(kw in channel_lower for kw in internal_keywords):
         return "Internal"
 
-    return "Internal"
+    return "Unknown"
 
 
 def resolve_zone(environment_url: str, zone_mapping: dict[str, str]) -> str:
@@ -791,7 +811,7 @@ def transform_session(
     agent_mode = agent_classifications.get(bot_id, "Conversational")
 
     # Map session outcome
-    raw_outcome = session.get("msdyn_sessionoutcome")
+    raw_outcome = session.get("msdyn_outcome")
     outcome_str = SESSION_OUTCOMES.get(raw_outcome, "Unknown")
 
     # Map outcome differently for autonomous agents
@@ -802,12 +822,12 @@ def transform_session(
             outcome_str = "Failure"
 
     # Map outcome reason
-    raw_reason = session.get("msdyn_sessionoutcomereason")
+    raw_reason = session.get("msdyn_outcomereason")
     reason_str = SESSION_OUTCOME_REASONS.get(raw_reason, "Unknown")
 
     # Calculate session duration
-    created_on = session.get("msdyn_sessioncreatedon", "")
-    closed_on = session.get("msdyn_sessionclosedon", "")
+    created_on = session.get("msdyn_startedon", "")
+    closed_on = session.get("msdyn_endedon", "")
     duration_seconds = None
     if created_on and closed_on:
         try:
@@ -825,8 +845,11 @@ def transform_session(
     # Knowledge source
     has_ks = ks_map.get(session_id, False)
 
-    # Derive usage type from channel
-    channel_id = session.get("msdyn_channelid", "") or ""
+    # Derive usage type from channel.
+    # NOTE: msdyn_botsession has no channel column in its documented schema, so
+    # no channel identifier is available in Tier 1; usageType resolves to
+    # "Unknown" until Tier 2 transcript parsing supplies channel data.
+    channel_id = ""
     usage_type = classify_usage_type(channel_id)
 
     # Build customDimensions

--- a/copilot-studio-analytics/tests/test_sync_dataverse_sessions.py
+++ b/copilot-studio-analytics/tests/test_sync_dataverse_sessions.py
@@ -53,10 +53,10 @@ def make_session(session_id: str, created_on: str, closed_on: str | None = None)
     """Build a minimal Dataverse session fixture."""
     session = {
         "msdyn_botsessionid": session_id,
-        "msdyn_sessioncreatedon": created_on,
+        "msdyn_startedon": created_on,
     }
     if closed_on is not None:
-        session["msdyn_sessionclosedon"] = closed_on
+        session["msdyn_endedon"] = closed_on
     return session
 
 


### PR DESCRIPTION
## Summary

Lab-readiness validation of **copilot-studio-analytics** (Control 3.2). Static, authoritative-source review (no live tenant). Found and fixed a **critical schema mismatch** that would have made the Dataverse session sync fail on its first fetch and produce all-`Unknown` outcomes even if it had succeeded.

## What & why

The sync read `msdyn_botsession` using column names and option-set integers that do not match the official Microsoft schema:

| Was (wrong) | Now (authoritative) |
|---|---|
| `msdyn_sessioncreatedon` / `msdyn_sessionclosedon` | `msdyn_startedon` / `msdyn_endedon` |
| `msdyn_sessionoutcome` / `msdyn_sessionoutcomereason` (these are **global choice** names, not columns) | `msdyn_outcome` / `msdyn_outcomereason` |
| outcome ints `192350001..192350004` (undocumented) | `419550000..419550003` |
| reason ints `192350100..192350106` (undocumented) | `419560000..419560008` |
| `msdyn_channelid` / `msdyn_conversationid` in `$select` | removed — not columns on `msdyn_botsession`; `usageType` now emits `Unknown` in Tier 1 |

A Dataverse Web API `$select` on a non-existent property returns **HTTP 400**, so the prior code could not run in a real tenant. With the wrong integers, every outcome mapped to `Unknown`. Root cause: the v1.1.1 "align docs to script" change propagated the script's incorrect names; two prior council reviews validated script↔doc internal consistency but never checked the external Microsoft schema.

KQL queries and workbooks consume only the emitted `customDimensions` and are **unaffected**. The downstream friendly-label contract (`Resolved`/`Escalated`/`Abandoned`/`Success`/`Failure`) is preserved.

## Files changed
- `scripts/sync_dataverse_sessions.py` — option-set maps, `$select`/`$filter`/`$orderby`, session reads, `classify_usage_type` honesty
- `tests/test_sync_dataverse_sessions.py` — fixture column names
- `architecture.md`, `docs/dataverse-data-sources.md`, `docs/agent-assisted-hours-methodology.md`, `docs/viva-insights-parity-matrix.md`
- `CHANGELOG.md` — `[Unreleased]` entry
- `LAB-VALIDATION.md` — full evidence report (new)

## Verification
- `python -m py_compile` ✅ · `pytest tests/` ✅ (3 passed)
- Language-rule scan (`ensures|guarantees|will prevent|eliminates risk`, excl. CHANGELOG): ✅ clean
- `manifest.yaml` **not** modified (per task guidance). Maintainers should bump to **v2.0.3** across the four root catalog files + `manifest.yaml` when releasing.

## Key sources
- `msdyn_botsession` entity reference — https://learn.microsoft.com/en-us/dynamics365/developer/reference/entities/msdyn_botsession
- `botcomponent` entity reference (componenttype 17 = External Trigger) — https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/botcomponent
- `AppEvents` table / classic `customEvents` columns; Kusto `summarize`; Dataverse OAuth scope — see `LAB-VALIDATION.md` §3

## Caveats (runtime-only)
- Option-set integers are Microsoft-managed; confirm via entity metadata per tenant.
- `msdyn_botsession` is documented in the D365 Customer Service reference; standalone Copilot Studio provisions the same managed table but a tenant metadata check remains authoritative.
