### PR TITLE
fix(cross-tenant-external-sharing-governance): lab-readiness validation and corrections

### DIFF
--- a/cross-tenant-external-sharing-governance/CHANGELOG.md
+++ b/cross-tenant-external-sharing-governance/CHANGELOG.md
@@ -6,6 +6,27 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed (lab-readiness validation)
+
+- **`Scan-ManagedEnvBotSharingBaseline.ps1` used non-existent governance
+  properties.** The script evaluated `extendedSettings.botSharingAccessControl`,
+  `extendedSettings.botSharingSharingApproval`, and
+  `extendedSettings.botSharingMaxShareLimit` — none of which exist in the Power
+  Platform Managed Environments `governanceConfiguration` schema. Against a live
+  tenant every environment would have been flagged non-compliant on all three
+  checks because the property lookups always returned `$null`. Replaced with the
+  documented agent-sharing properties from the Managed Environments "Limit
+  sharing" control:
+  `bot-limitSharingMode` (not `noLimit`; expected
+  `ExcludeSharingToSecurityGroups`), `bot-authoringSharingDisabled` (expected
+  `True`), and `bot-maxLimitUserSharing` (positive viewer limit; `-1` means
+  unlimited). Also removed the invented "sharing approval workflow" check
+  (Managed Environments has no such property) and repurposed it to the documented
+  editor-sharing toggle. Source:
+  https://learn.microsoft.com/power-platform/admin/managed-environment-sharing-limits
+  The `BaselinePolicy` parameter default changed from `Restricted` to the
+  documented enum value `ExcludeSharingToSecurityGroups`.
+
 ## [1.1.0] - 2026-05-23 [BREAKING DEPLOY]
 
 ### Changed (BREAKING)

--- a/cross-tenant-external-sharing-governance/LAB-VALIDATION.md
+++ b/cross-tenant-external-sharing-governance/LAB-VALIDATION.md
@@ -1,0 +1,130 @@
+# Lab-Readiness Validation — Cross-Tenant External Sharing Governance
+
+> **Solution version:** v1.1.0
+> **Validation date:** 2026-06-04
+> **Validation type:** Static (no live tenant) — parse-validity, authoritative-source
+> verification of every API/permission/feature assertion, and documentation completeness.
+
+## Purpose and controls
+
+Three-layer cross-tenant access governance for Power Platform AI agents in FSI
+environments: **Layer 1** Power Platform Tenant Isolation, **Layer 2** Microsoft
+Entra Cross-Tenant Access (CTA) policies, **Layer 3** Copilot Studio agent shares.
+Primary framework controls: **1.1, 1.18, 2.1, 2.8, 1.7, 1.11**.
+
+## What was checked
+
+| Area | Method | Result |
+|------|--------|--------|
+| Python scripts (5) | `python -m py_compile` | All compile cleanly |
+| PowerShell scripts (3) | `Parser::ParseFile` zero-error check | All parse cleanly |
+| Dataverse schema docs | Regenerated via `create_ctsg_dataverse_schema.py --output-docs` | No drift (git clean) |
+| Column references in scripts | Cross-checked against `docs/dataverse-schema.md` (source of truth) | All logical names correct |
+| Language rules | Grep for prohibited compliance-overclaim phrases (excl. CHANGELOG) | Zero violations |
+| Graph CTA endpoints/permissions/properties | Microsoft Learn | Confirmed authentic |
+| Power Platform tenant isolation cmdlet | Microsoft Learn | Confirmed authentic |
+| Managed Environment detection + sharing properties | Microsoft Learn | **One defect found & fixed** |
+| Power Platform connector logical IDs | Microsoft Learn (prior council fix re-verified) | Correct (V2 / HTTP-with-Entra) |
+
+## Authoritative sources cited
+
+1. crossTenantAccessPolicyConfigurationDefault / Partner resource types, methods, and
+   properties (`b2bCollaborationInbound/Outbound`, `b2bDirectConnectInbound/Outbound`,
+   `inboundTrust`, `automaticUserConsentSettings`, `isServiceProvider`,
+   `isInMultiTenantOrganization`, `tenantRestrictions`) —
+   https://learn.microsoft.com/graph/api/resources/crosstenantaccesspolicyconfigurationpartner
+   and https://learn.microsoft.com/graph/api/resources/crosstenantaccesspolicyconfigurationdefault
+2. Cross-tenant access policy Graph permissions `Policy.Read.All` and
+   `Policy.ReadWrite.CrossTenantAccess` — Microsoft Graph permissions reference and the
+   crossTenantAccessPolicy API pages (confirmed both present).
+3. Power Platform tenant isolation cmdlet `Get-PowerAppTenantIsolationPolicy` —
+   https://learn.microsoft.com/power-platform/admin/cross-tenant-restrictions
+   (Microsoft.PowerApps.Administration.PowerShell).
+4. Managed Environments protection level (`Standard` = enabled) via `pac admin
+   set-governance-config --protection-level` —
+   https://learn.microsoft.com/power-platform/developer/cli/reference/admin
+5. **Managed Environments "Limit sharing" agent-sharing properties** —
+   https://learn.microsoft.com/power-platform/admin/managed-environment-sharing-limits
+   (authoritative property names: `bot-limitSharingMode`, `bot-maxLimitUserSharing`,
+   `bot-authoringSharingDisabled`; values `noLimit` / `ExcludeSharingToSecurityGroups`,
+   `-1` = unlimited).
+6. `Get-AzAccessToken` SecureString behavior (Az.Accounts) —
+   https://learn.microsoft.com/powershell/azure/manage-secrets-with-azure-powershell
+   (confirms the `-AsSecureString` pattern already pinned via `#Requires Az.Accounts 2.17.0`).
+
+## Gaps found and fixes applied
+
+### Scripts
+
+- **`Scan-ManagedEnvBotSharingBaseline.ps1` — invented governance property names
+  (functional defect).** The three baseline checks read
+  `extendedSettings.botSharingAccessControl`, `…botSharingSharingApproval`, and
+  `…botSharingMaxShareLimit`. None of these exist in the documented Managed
+  Environments `governanceConfiguration` schema, so every property lookup returned
+  `$null` and the scanner would flag **every** environment non-compliant on all
+  three checks against a real tenant (false positives). Replaced with the
+  authoritative agent-sharing properties:
+  - `bot-limitSharingMode` — flagged when unset or `noLimit` (expected
+    `ExcludeSharingToSecurityGroups`), compared case-insensitively because
+    Microsoft docs show mixed casing.
+  - `bot-authoringSharingDisabled` — flagged when not `True` (editor-level agent
+    sharing should be disabled). Replaces the non-existent "sharing approval
+    workflow" property.
+  - `bot-maxLimitUserSharing` — flagged when `<= 0` or unset (`-1` = unlimited).
+  The `BaselinePolicy` parameter default changed from the undocumented
+  `Restricted` to the documented enum `ExcludeSharingToSecurityGroups`; synopsis,
+  parameter help, and the emitted `BotSharingConfig` keys were updated to match.
+
+### Verified correct (no change required)
+
+- **Graph Layer 2** — `/policies/crossTenantAccessPolicy`, `/default`, and
+  `/partners` endpoints, pagination via `@odata.nextLink`, and all partner/default
+  property reads are authentic and correctly versioned (`v1.0`).
+- **Layer 1 BAP endpoints** — `…/scopes/admin/tenantSettings` and
+  `…/crossTenantConnectionAllowPolicy` (api-version `2020-10-01`) with token
+  audience `https://service.powerapps.com/`. These remain heavily caveated in-script
+  and in `DELIVERY-CHECKLIST.md`; the documented validation path
+  (`Get-PowerAppTenantIsolationPolicy`) is correct and present in prerequisites.
+- **Auth** — managed-identity-first across all three PowerShell scripts;
+  `Get-AzAccessToken -AsSecureString` + `ConvertFrom-SecureString -AsPlainText` with
+  `#Requires Az.Accounts 2.17.0`; the single `ClientSecret` branch is marked
+  `# legacy: dev-only`.
+- **Connector logical IDs** — `shared_powerplatformforadmins` (V2 admin),
+  `shared_webcontents` (HTTP with Entra ID), `shared_commondataserviceforapps`,
+  `shared_approvals`, `shared_teams`, `shared_office365` — all correct.
+- **Dataverse column logical names** and **option-set values** (100000000-based,
+  with the documented `fsi_acv_zone` 0-based carve-out) — consistent across schema
+  script, generated schema doc, scripts, and flow docs.
+
+### Documentation / dependencies
+
+- No documentation referenced the old invented property names (confirmed by grep);
+  no further doc edits required.
+- `requirements.txt`, required PowerShell modules
+  (`Az.Accounts`, `Microsoft.PowerApps.Administration.PowerShell`), Graph
+  permissions, and Entra roles in `docs/prerequisites.md` are complete and match the
+  scripts.
+
+## Runtime-only caveats (cannot be validated statically)
+
+- **Layer 1 BAP response shape** — exact property name for the isolation flag
+  (`isolationEnabled` vs `tenantIsolationEnabled`) and the allow-list `value[]`
+  schema must be confirmed against a live tenant response; the script already
+  detects and reports schema mismatches and adds delivery-checklist items.
+- **Managed Environment `extendedSettings` payload** — whether `bot-*` keys are
+  present depends on whether the "Limit sharing" agent controls were ever
+  configured in the environment; absent keys are treated (correctly) as
+  non-compliant. The casing returned by the BAP API (`excludeSharingToSecurityGroups`
+  vs `ExcludeSharingToSecurityGroups`) is handled case-insensitively.
+- **Dataverse entity-set pluralization and option-set integers** — confirm against
+  the deployed solution XML before activating flows, as already documented in the
+  script `.NOTES` and `DELIVERY-CHECKLIST.md`.
+
+## Final lab-readiness assessment
+
+**Lab-ready.** All scripts parse/compile; documentation is internally consistent and
+schema-aligned; every external API, permission, and feature assertion was verified
+against authoritative Microsoft sources. One genuine functional defect (the Managed
+Environment bot-sharing property names) was found and corrected. Remaining
+unverifiable items are inherent live-tenant response-shape confirmations, which the
+scripts already surface as delivery-checklist actions rather than silent assumptions.

--- a/cross-tenant-external-sharing-governance/scripts/governance/Scan-ManagedEnvBotSharingBaseline.ps1
+++ b/cross-tenant-external-sharing-governance/scripts/governance/Scan-ManagedEnvBotSharingBaseline.ps1
@@ -7,11 +7,20 @@
 
 .DESCRIPTION
     Enumerates Power Platform Managed Environments and evaluates each environment's
-    bot-sharing governance settings against the recommended baseline:
+    agent (bot) sharing governance settings against the recommended baseline. The
+    settings live under properties.governanceConfiguration.settings.extendedSettings
+    and use the documented Managed Environments "Limit sharing" agent-sharing
+    properties:
 
-      - Bot sharing should NOT be unrestricted (accesscontrolpolicy != None)
-      - Approval workflows should be configured for sharing requests
-      - Sharing limits should be enforced per Copilot Studio admin controls
+      - bot-limitSharingMode      should NOT be 'noLimit' (sharing should be
+                                  restricted, e.g. 'ExcludeSharingToSecurityGroups')
+      - bot-authoringSharingDisabled should be True (editor-level agent sharing
+                                  is turned off)
+      - bot-maxLimitUserSharing   should be a positive viewer limit (a value of
+                                  -1 means unlimited)
+
+    Source: Managed Environments "Limit sharing"
+    https://learn.microsoft.com/power-platform/admin/managed-environment-sharing-limits
 
     Deviations are reported as structured JSON findings to support downstream
     compliance reporting and integration with the CTSG governance pipeline.
@@ -45,8 +54,10 @@
     File path for the scan results JSON. Defaults to .\output\bot-sharing-baseline-{timestamp}.json.
 
 .PARAMETER BaselinePolicy
-    Expected bot-sharing access control policy. Default: 'Restricted'.
-    Environments with a less restrictive policy generate a deviation finding.
+    Expected value for the agent (bot) limit-sharing mode
+    (extendedSettings.'bot-limitSharingMode'). Default: 'ExcludeSharingToSecurityGroups'.
+    Environments where the mode is unset or 'noLimit' generate a deviation finding.
+    Documented values: 'noLimit', 'ExcludeSharingToSecurityGroups'.
 
 .EXAMPLE
     .\Scan-ManagedEnvBotSharingBaseline.ps1
@@ -80,7 +91,7 @@ param(
     [string]$OutputPath,
 
     [Parameter()]
-    [string]$BaselinePolicy = 'Restricted'
+    [string]$BaselinePolicy = 'ExcludeSharingToSecurityGroups'
 )
 
 Set-StrictMode -Version Latest
@@ -179,9 +190,14 @@ function Test-BotSharingBaseline {
     $envId = $Environment.name
     $govConfig = $Environment.properties.governanceConfiguration
 
-    # Check 1: Bot sharing access control policy
-    $botSharing = $govConfig.settings.extendedSettings.botSharingAccessControl
-    if (-not $botSharing -or $botSharing -ne $ExpectedPolicy) {
+    # Check 1: Agent (bot) limit-sharing mode
+    # extendedSettings.'bot-limitSharingMode' — 'noLimit' (or unset) means agents
+    # can be shared without restriction. A restrictive value such as
+    # 'ExcludeSharingToSecurityGroups' is expected. Compared case-insensitively
+    # because Microsoft documentation shows mixed casing.
+    $botSharing = $govConfig.settings.extendedSettings.'bot-limitSharingMode'
+    $isRestricted = $botSharing -and ($botSharing -ne 'noLimit') -and ($botSharing -ieq $ExpectedPolicy)
+    if (-not $isRestricted) {
         $findings.Add([PSCustomObject]@{
             FindingType   = 'BOT_SHARING_UNRESTRICTED'
             Severity      = 'High'
@@ -189,41 +205,45 @@ function Test-BotSharingBaseline {
             Environment   = $envName
             Expected      = $ExpectedPolicy
             Actual        = if ($botSharing) { $botSharing } else { 'NotConfigured' }
-            Description   = "Bot sharing access control is not set to '$ExpectedPolicy'. " +
-                            'Unrestricted bot sharing may expose agents to unauthorized cross-tenant access.'
-            Remediation   = "Set bot sharing access control to '$ExpectedPolicy' in the Managed Environment settings."
+            Description   = "Agent limit-sharing mode (bot-limitSharingMode) is not set to '$ExpectedPolicy'. " +
+                            'Unrestricted agent sharing may expose agents to unauthorized cross-tenant access.'
+            Remediation   = "Set the agent sharing limit (bot-limitSharingMode) to '$ExpectedPolicy' in the Managed Environment 'Limit sharing' settings."
         })
     }
 
-    # Check 2: Sharing approval workflow
-    $sharingApproval = $govConfig.settings.extendedSettings.botSharingSharingApproval
-    if (-not $sharingApproval -or $sharingApproval -ne 'Required') {
+    # Check 2: Agent editor-sharing disabled
+    # extendedSettings.'bot-authoringSharingDisabled' — when True, owners/editors
+    # cannot share agents with individuals as Editors. A defensible posture
+    # disables broad editor-level sharing.
+    $editorSharingDisabled = $govConfig.settings.extendedSettings.'bot-authoringSharingDisabled'
+    if ($editorSharingDisabled -ne $true) {
         $findings.Add([PSCustomObject]@{
-            FindingType   = 'BOT_SHARING_APPROVAL_MISSING'
+            FindingType   = 'BOT_EDITOR_SHARING_ENABLED'
             Severity      = 'Medium'
             EnvironmentId = $envId
             Environment   = $envName
-            Expected      = 'Required'
-            Actual        = if ($sharingApproval) { $sharingApproval } else { 'NotConfigured' }
-            Description   = 'Bot sharing approval workflow is not configured. ' +
-                            'Agents can be shared without governance review.'
-            Remediation   = 'Enable the bot sharing approval workflow in Managed Environment settings.'
+            Expected      = 'True'
+            Actual        = if ($null -ne $editorSharingDisabled) { [string]$editorSharingDisabled } else { 'NotConfigured' }
+            Description   = 'Editor-level agent sharing is not disabled (bot-authoringSharingDisabled is not True). ' +
+                            'Owners and editors can grant Editor permissions when sharing agents.'
+            Remediation   = "Set 'bot-authoringSharingDisabled' to True in the Managed Environment 'Limit sharing' agent settings."
         })
     }
 
-    # Check 3: Sharing limits
-    $sharingLimit = $govConfig.settings.extendedSettings.botSharingMaxShareLimit
-    if (-not $sharingLimit -or [int]$sharingLimit -le 0) {
+    # Check 3: Agent viewer sharing limit
+    # extendedSettings.'bot-maxLimitUserSharing' — a value of -1 means unlimited.
+    $sharingLimit = $govConfig.settings.extendedSettings.'bot-maxLimitUserSharing'
+    if ($null -eq $sharingLimit -or [int]$sharingLimit -le 0) {
         $findings.Add([PSCustomObject]@{
             FindingType   = 'BOT_SHARING_LIMIT_MISSING'
             Severity      = 'Low'
             EnvironmentId = $envId
             Environment   = $envName
             Expected      = 'PositiveInteger'
-            Actual        = if ($sharingLimit) { $sharingLimit } else { 'NotConfigured' }
-            Description   = 'No bot sharing limit is configured. ' +
-                            'Agents may be shared with an unbounded number of principals.'
-            Remediation   = 'Configure a bot sharing limit in Managed Environment settings.'
+            Actual        = if ($null -ne $sharingLimit) { [string]$sharingLimit } else { 'NotConfigured' }
+            Description   = 'No agent viewer sharing limit is configured (bot-maxLimitUserSharing <= 0 or unset; -1 means unlimited). ' +
+                            'Agents may be shared with an unbounded number of viewers.'
+            Remediation   = 'Configure a positive agent viewer sharing limit (bot-maxLimitUserSharing) in Managed Environment settings.'
         })
     }
 
@@ -234,9 +254,9 @@ function Test-BotSharingBaseline {
         FindingCount    = $findings.Count
         Findings        = $findings
         BotSharingConfig = @{
-            AccessControl   = if ($botSharing) { $botSharing } else { $null }
-            SharingApproval = if ($sharingApproval) { $sharingApproval } else { $null }
-            MaxShareLimit   = if ($sharingLimit) { $sharingLimit } else { $null }
+            LimitSharingMode        = if ($botSharing) { $botSharing } else { $null }
+            AuthoringSharingDisabled = $editorSharingDisabled
+            MaxLimitUserSharing     = if ($null -ne $sharingLimit) { $sharingLimit } else { $null }
         }
     }
 }


### PR DESCRIPTION
## Summary

Lab-readiness validation of **cross-tenant-external-sharing-governance** (v1.1.0) with authoritative Microsoft-source verification of every API, permission, and feature assertion. No live tenant — static validation (parse/compile, source verification, doc completeness).

## Key fix

`Scan-ManagedEnvBotSharingBaseline.ps1` evaluated three **non-existent** Managed Environment `governanceConfiguration` properties (`botSharingAccessControl`, `botSharingSharingApproval`, `botSharingMaxShareLimit`). Against a real tenant these lookups always return `$null`, so the scanner would flag **every** environment non-compliant on all three checks (universal false positives).

Replaced with the documented Managed Environments "Limit sharing" agent properties:
- `bot-limitSharingMode` (expected `ExcludeSharingToSecurityGroups`, not `noLimit`)
- `bot-authoringSharingDisabled` (expected `True`) — replaces the invented "sharing approval workflow" check, which has no corresponding platform property
- `bot-maxLimitUserSharing` (positive viewer limit; `-1` = unlimited)

`BaselinePolicy` default changed from undocumented `Restricted` to the documented enum `ExcludeSharingToSecurityGroups`. Synopsis, parameter help, and emitted config keys updated.

Source: https://learn.microsoft.com/power-platform/admin/managed-environment-sharing-limits

## Verified correct (no change needed)

- Graph CTA Layer 2 endpoints/permissions/properties (`/policies/crossTenantAccessPolicy`, `/default`, `/partners`; `Policy.Read.All`, `Policy.ReadWrite.CrossTenantAccess`; partner/default property reads).
- Layer 1 BAP endpoints + `Get-PowerAppTenantIsolationPolicy` validation path; managed-identity-first auth with `Get-AzAccessToken -AsSecureString`; corrected V2 connector IDs.
- Dataverse logical column names, option-set values (100000000-based with documented `fsi_acv_zone` carve-out), schema docs regenerate with no drift.

## Evidence

See `cross-tenant-external-sharing-governance/LAB-VALIDATION.md` for the full report (sources, checks, runtime-only caveats).

## Caveats (runtime-only)

Live-tenant BAP response shapes (isolation flag property name, `extendedSettings` payload presence/casing) and deployed option-set integers must be confirmed against a tenant — the scripts already surface these as delivery-checklist items.

## Verification

- All 3 PowerShell scripts parse (zero errors); all 5 Python scripts compile.
- Schema docs regenerate with no git drift.
- Language rules pass (zero prohibited-phrase violations).
