### PR TITLE
Lab-readiness validation: deny-event-correlation-report (App Insights retirement date fix)

### DIFF
--- a/deny-event-correlation-report/CHANGELOG.md
+++ b/deny-event-correlation-report/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the Deny Event Correlation Report are documented here.
 
 ## [Unreleased]
 
+### Changed
+
+- **App Insights query API-key retirement date corrected to September 30, 2026.**
+  Microsoft extended the Application Insights query API-key (`x-api-key`)
+  retirement from the originally announced March 31, 2026 to **September 30,
+  2026** (Azure Update "Retirement: Transition to Entra ID … by September 30,
+  2026", modified 2026-04-21). Updated `docs/prerequisites.md`,
+  `docs/troubleshooting.md`, `docs/architecture.md`, and the header notes in
+  `scripts/Export-RaiTelemetry.ps1` so they no longer state the API key was
+  removed on the (now past) March 31, 2026 date. The extractor already uses
+  Entra ID authentication and is unaffected by the retirement either way.
+- Added `LAB-VALIDATION.md` documenting static lab-readiness validation against
+  authoritative Microsoft sources (Graph `runHuntingQuery`, `Search-UnifiedAuditLog`
+  status, Defender `CloudAppEvents` schema, App Insights query API-key retirement).
+
 ### Fixed
 
 - **Wave 6 P4b:** Empty catch blocks now log via `Write-Verbose` instead of silently swallowing errors. Output is unchanged unless caller passes `-Verbose`.

--- a/deny-event-correlation-report/LAB-VALIDATION.md
+++ b/deny-event-correlation-report/LAB-VALIDATION.md
@@ -1,0 +1,130 @@
+# Lab Validation — Deny Event Correlation Report
+
+> **Validation date:** 2026-06-04
+> **Solution version:** v2.0.4 (Unreleased changes pending)
+> **Validation type:** Static — parse-validity, authoritative-source verification, and
+> documentation completeness. No live tenant was used; runtime behavior against real
+> Purview/Defender/Application Insights data was not exercised.
+
+## Purpose and Controls
+
+Daily operational reporting that correlates "deny / no-content-returned" events for
+Microsoft 365 Copilot and Copilot Studio across four Microsoft data sources (Purview
+Unified Audit Log, Purview DLP, Application Insights RAI telemetry, and optional
+Defender CloudAppEvents). Supports compliance evidence for **Control 1.5** (DLP and
+sensitivity labels), **Control 1.7** (comprehensive audit logging), **Control 1.8**
+(runtime protection and external threat detection), and **Control 3.4** (incident
+reporting). Regulatory alignment: helps support FINRA 4511, SEC 17a-3/17a-4, GLBA
+501(b), and supervisory guidance under FINRA 24-09 / 25-07 and OCC 2011-12 / Fed SR
+11-7 (the solution is one ancillary record source, not a complete compliance program).
+
+## What Was Checked
+
+| Area | Method | Result |
+|------|--------|--------|
+| PowerShell parse validity (6 scripts) | `Parser::ParseFile` | All 6 parse with **zero** errors |
+| `Search-UnifiedAuditLog` status | Microsoft Learn + Azure/M365 messaging | Cmdlet is **current**, not retired; correct production extractor |
+| Graph `runHuntingQuery` endpoint + permission | Microsoft Learn (graph-rest-1.0) | Script endpoint and scope **match** the GA contract |
+| Defender `CloudAppEvents` schema | Microsoft Learn (advanced hunting schema) | `RawEventData` is `dynamic` raw JSON; `ThreatCategory` correctly treated as tenant-verify |
+| Application Insights query API-key retirement date | Microsoft release communications | Date was **outdated** (March 31, 2026) — corrected to September 30, 2026 |
+| `Get-AzAccessToken -ResourceUrl … -AsSecureString` | Az.Accounts 5.x behavior | Correct SecureString contract, defensive plaintext fallback present |
+| Language rules (no compliance-overclaim phrasing) | grep across solution | **Zero** violations |
+| KQL parse-coherence (5 query files) | Manual review | Coherent; ingestion-pattern caveats already documented |
+
+## Authoritative Sources Cited
+
+1. **security: runHuntingQuery (Microsoft Graph v1.0)** — confirms
+   `POST /security/runHuntingQuery` is GA and the least-privileged permission is
+   `ThreatHunting.Read.All` (delegated and application).
+   <https://learn.microsoft.com/graph/api/security-security-runhuntingquery?view=graph-rest-1.0>
+2. **CloudAppEvents (Defender XDR advanced hunting schema)** — confirms `RawEventData`
+   is a `dynamic` column carrying raw source JSON (so `ThreatCategory` is not a
+   first-class column and must be verified per tenant).
+   <https://learn.microsoft.com/defender-xdr/advanced-hunting-cloudappevents-table>
+3. **Search-UnifiedAuditLog (Exchange Online PowerShell)** — the cmdlet remains the
+   supported unified-audit extractor; the retired cmdlets are
+   `Search-MailboxAuditLog` / `New-MailboxAuditLogSearch` (retired end-2025), not
+   `Search-UnifiedAuditLog`.
+   <https://learn.microsoft.com/powershell/module/exchangepowershell/search-unifiedauditlog>
+4. **Azure Update — "Retirement: Transition to Entra ID … to query data from Azure
+   Monitor Application Insights by September 30, 2026"** (Microsoft Release
+   Communications; modified 2026-04-21). States: *"Previously announced to be retired
+   March 31, 2026. We have extended the retirement date to September 30, 2026."*
+   <https://www.microsoft.com/releasecommunications/api/v2/Azure/rss/transition-to-azure-ad-to-query-data-from-azure-monitor-application-insights-by-31-march-2026>
+5. **Microsoft Entra authentication for Application Insights** — Entra ID is the
+   supported query authentication path (the method the extractor already uses).
+   <https://learn.microsoft.com/azure/azure-monitor/app/azure-ad-authentication>
+
+## Gaps Found and Fixes Applied
+
+### Fixed — outdated Application Insights API-key retirement date (documentation)
+
+The docs and one script header stated the `x-api-key` query path was deprecated/removed
+on **March 31, 2026** — a date that is now in the past and, per Microsoft, no longer the
+actual retirement date. Microsoft **extended** the retirement to **September 30, 2026**.
+Statements such as "no longer functional as of March 31, 2026" were factually incorrect
+as of this validation (the API key still functions until September 30, 2026).
+
+Corrected occurrences in:
+- `docs/prerequisites.md` (deprecation table row, retirement warning, timeline table)
+- `docs/troubleshooting.md` (issue #2 banner and historical diagnostic comment)
+- `docs/architecture.md` (authentication table row)
+- `scripts/Export-RaiTelemetry.ps1` (migration header note)
+
+The wording now states the September 30, 2026 retirement and references the original
+March 31, 2026 date only as historical context. **No runtime code path changed** —
+`Export-RaiTelemetry.ps1` already authenticates with Entra ID via `Connect-AzAccount` /
+`Get-AzAccessToken`, so it is unaffected by the API-key retirement regardless of date.
+
+### Verified — no change required
+
+- **Graph Defender extractor** (`Export-DefenderCopilotEvents.ps1`): uses the GA
+  `https://graph.microsoft.com/v1.0/security/runHuntingQuery` endpoint with
+  `ThreatHunting.Read.All`, matching the authoritative v1.0 contract.
+- **Unified audit extractors** (`Export-CopilotDenyEvents.ps1`,
+  `Export-DlpCopilotEvents.ps1`): `Search-UnifiedAuditLog` with `RecordType`
+  `CopilotInteraction` / `DlpRuleMatch` is the correct, current path. The Graph
+  `/security/auditLog/queries` beta is accurately described as a not-yet-production
+  migration path.
+- **DLP Workload literals** `Copilot` / `MicrosoftCopilotStudio` are used consistently
+  across script and KQL (the incorrect `MicrosoftCopilot` literal was already removed in
+  v2.0.2).
+- **KQL ingestion caveats**: the Log Analytics queries already document the
+  `OfficeActivity` flattening limitation and point operators to the PowerShell
+  extractors as the recommended path.
+- **Language rules**: no prohibited compliance-overclaim phrasing.
+
+## Runtime-Only Caveats (not verifiable without a live tenant)
+
+These items are correctly caveated in the solution docs/scripts and require tenant-side
+validation before production reliance:
+
+1. **Defender `CloudAppEvents` Copilot fields** — `ActionType == "CopilotInteraction"`
+   and `RawEventData.ThreatCategory` values (`PromptInjection`, `Jailbreak`, `XPIA`) are
+   raw-event-shaped and tenant/licensing dependent. Validate in your tenant's Advanced
+   Hunting before relying on results. (Already flagged in `cloud-app-events.kql` and the
+   script `.NOTES`.)
+2. **CopilotInteraction audit deny indicators** — presence of
+   `AccessedResources[].Status == "failure"` / `PolicyDetails` depends on actual Copilot
+   usage and DLP policy configuration; cannot be exercised offline.
+3. **Application Insights ContentFiltered telemetry** — depends on per-agent App
+   Insights configuration in Copilot Studio and on the resource being classic
+   (`customEvents`) vs workspace-based (`AppEvents`). The normalization block handles
+   both shapes, but live emission was not observed.
+4. **Exchange Online unattended auth** — managed identity (`Exchange.ManageAsApp`) and
+   certificate app-only paths were not exercised against a tenant.
+5. **Graph `runHuntingQuery` Timespan vs in-query filter** — the extractor embeds the
+   date window in the KQL `where Timestamp between(...)` clause; the API applies the
+   shorter of the query filter and the default 30-day timespan, which is the intended
+   1-day window.
+
+## Lab-Readiness Assessment
+
+**Lab-ready (static validation passed).** All six PowerShell scripts parse cleanly, the
+external API contracts the scripts depend on (Graph `runHuntingQuery`,
+`Search-UnifiedAuditLog`, Application Insights query API, Az.Accounts token acquisition)
+were verified against authoritative Microsoft sources, and the one factual drift found
+(an outdated, now-past retirement date) was corrected. Remaining open items are
+genuinely runtime-only and require a licensed tenant with Copilot, DLP, App Insights,
+and (optionally) Defender for Cloud Apps to exercise end-to-end. No blocking issues
+were found for lab deployment.

--- a/deny-event-correlation-report/docs/architecture.md
+++ b/deny-event-correlation-report/docs/architecture.md
@@ -207,7 +207,7 @@ Power Automate Flow
 | Component | Authentication Method | Deprecation Status |
 |-----------|----------------------|-------------------|
 | Exchange Online | Managed identity (Azure Automation) or certificate-based app-only; interactive only for admin workstations | Active |
-| Application Insights | Managed identity or Entra ID (OAuth 2.0); ~~API key~~ removed | x-api-key no longer functional after March 31, 2026 |
+| Application Insights | Managed identity or Entra ID (OAuth 2.0); ~~API key~~ removed | x-api-key query auth retiring September 30, 2026 (extended from March 31, 2026) |
 | Defender CloudAppEvents | Microsoft Graph (managed identity/certificate where available; delegated interactive for testing) | Active |
 | Azure Storage | Managed identity preferred; SAS token only for constrained legacy jobs | Active |
 | Power BI | Microsoft Entra ID | Active |

--- a/deny-event-correlation-report/docs/prerequisites.md
+++ b/deny-event-correlation-report/docs/prerequisites.md
@@ -43,9 +43,9 @@
 |------------|-------|----------|
 | **Reader** | App Insights resource | Query telemetry |
 | **Monitoring Reader** | App Insights resource | Managed identity / Entra ID authentication (recommended) |
-| ~~**API Key (Read)**~~ | ~~App Insights resource~~ | ~~REST API access~~ (deprecated March 31, 2026) |
+| ~~**API Key (Read)**~~ | ~~App Insights resource~~ | ~~REST API access~~ (query API keys retiring September 30, 2026) |
 
-> ⚠️ **Deprecation Warning:** API key authentication (`x-api-key`) is deprecated and will be removed **March 31, 2026**. See [Authentication Migration](#authentication-migration) for Entra ID setup.
+> ⚠️ **Retirement Notice:** API key authentication (`x-api-key`) for querying Application Insights is being retired **September 30, 2026** (Microsoft extended this from the originally announced March 31, 2026). See [Authentication Migration](#authentication-migration) for Entra ID setup. This solution already uses Entra ID authentication, so no API key is required.
 
 ### Defender for Cloud Apps (Optional)
 
@@ -228,8 +228,8 @@ union isfuzzy=true
 | Date | Event |
 |------|-------|
 | **Now** | Use managed identity-first authentication for Azure Automation runbooks |
-| **March 31, 2026** | x-api-key authentication permanently disabled |
-| **After March 31, 2026** | Runbooks that still depend on API keys fail until migrated |
+| **September 30, 2026** | x-api-key query authentication retired (extended from March 31, 2026) |
+| **After September 30, 2026** | Runbooks that still depend on API keys for querying fail until migrated |
 
 ### Migration Steps
 

--- a/deny-event-correlation-report/docs/troubleshooting.md
+++ b/deny-event-correlation-report/docs/troubleshooting.md
@@ -30,11 +30,11 @@ Search-UnifiedAuditLog -StartDate (Get-Date).AddDays(-7) -EndDate (Get-Date) -Re
 
 ### 2. Application Insights Query Fails
 
-> **Note:** API key authentication is deprecated. Use Entra ID authentication for all new deployments. As of March 31, 2026 the x-api-key path is no longer functional.
+> **Note:** API key authentication is deprecated. Use Entra ID authentication for all new deployments. Microsoft is retiring the x-api-key query path on **September 30, 2026** (extended from the originally announced March 31, 2026).
 >
-> **⚠️ Warning: x-api-key Removed (March 31, 2026)**
+> **⚠️ Warning: x-api-key query authentication retiring (September 30, 2026)**
 >
-> If you are troubleshooting API key authentication issues, note that this authentication method is **no longer functional** as of March 31, 2026. Organizations should migrate to Entra ID authentication rather than continuing to troubleshoot API key issues.
+> If you are troubleshooting API key authentication issues, note that this authentication method is **scheduled for retirement on September 30, 2026** (Microsoft extended this from March 31, 2026). Organizations should migrate to Entra ID authentication rather than continuing to troubleshoot API key issues.
 >
 > **Migration Path:**
 >
@@ -44,7 +44,7 @@ Search-UnifiedAuditLog -StartDate (Get-Date).AddDays(-7) -EndDate (Get-Date) -Re
 >
 > See [Authentication Migration](prerequisites.md#authentication-migration) for complete migration steps.
 >
-> *Last verified: 2026-05-25*
+> *Last verified: 2026-06-04*
 
 **Symptoms:**
 - REST API returns 401/403 error
@@ -63,7 +63,7 @@ Search-UnifiedAuditLog -StartDate (Get-Date).AddDays(-7) -EndDate (Get-Date) -Re
 **Diagnostic Steps (API Key - Deprecated):**
 
 ```powershell
-# Historical only: API key connectivity test (no longer functional after March 31, 2026)
+# Historical only: API key connectivity test (x-api-key query auth retiring September 30, 2026)
 $headers = @{ "x-api-key" = "your-key" }
 $uri = "https://api.applicationinsights.io/v1/apps/your-app-id/query?query=customEvents|take 1"
 Invoke-RestMethod -Uri $uri -Headers $headers -Method Get

--- a/deny-event-correlation-report/scripts/Export-RaiTelemetry.ps1
+++ b/deny-event-correlation-report/scripts/Export-RaiTelemetry.ps1
@@ -59,7 +59,9 @@
   Migration completed: February 4, 2026
 
   The deprecated x-api-key authentication method has been removed.
-  This script will continue working after March 31, 2026.
+  This script uses Entra ID authentication and is unaffected by the
+  Application Insights query API-key retirement (September 30, 2026,
+  extended by Microsoft from the originally announced March 31, 2026).
 
   Prerequisites:
   - Install Az.Accounts module: Install-Module Az.Accounts -Force


### PR DESCRIPTION
## Summary

Lab-readiness validation for **deny-event-correlation-report** (v2.0.4). Static validation only (no live tenant): PowerShell parse-checks, authoritative Microsoft-source verification of every external API contract, and documentation completeness.

## Key fix

**Outdated Application Insights query API-key retirement date.** Docs/scripts stated the x-api-key query path was deprecated/removed **March 31, 2026** — now a past date and factually wrong. Microsoft **extended** the retirement to **September 30, 2026** (Azure Update *"Retirement: Transition to Entra ID … by September 30, 2026"*, modified 2026-04-21). Corrected across `docs/prerequisites.md`, `docs/troubleshooting.md`, `docs/architecture.md`, and the `Export-RaiTelemetry.ps1` header; original date kept as historical context. **No runtime code path changed** — the extractor already authenticates with Entra ID via `Connect-AzAccount` / `Get-AzAccessToken`.

## Verified correct (no change needed)

- **Graph Defender extractor** uses GA `v1.0/security/runHuntingQuery` + `ThreatHunting.Read.All` — matches the [authoritative v1.0 contract](https://learn.microsoft.com/graph/api/security-security-runhuntingquery?view=graph-rest-1.0).
- **`Search-UnifiedAuditLog`** is current (NOT retired — the retired cmdlets are `Search-MailboxAuditLog` / `New-MailboxAuditLogSearch`).
- **Defender `CloudAppEvents.RawEventData`** is `dynamic` raw JSON — `ThreatCategory` correctly caveated as tenant-verify.
- No compliance-overclaim language; `manifest.yaml` untouched.

## Evidence

Full report committed at [`deny-event-correlation-report/LAB-VALIDATION.md`](https://github.com/judeper/FSI-AgentGov-Solutions/blob/validation/deny-event-correlation-report/deny-event-correlation-report/LAB-VALIDATION.md) with cited sources, gaps/fixes, and runtime-only caveats.

## Verification
- All 6 PowerShell scripts parse with **zero** errors.
- Prohibited-language grep: clean.

## Runtime-only caveats
Defender Copilot `ActionType`/`ThreatCategory` fields, CopilotInteraction deny indicators, App Insights ContentFiltered emission, and Exchange unattended auth require a licensed tenant to exercise end-to-end.

**Lab-ready verdict: ready** (static validation passed; no blocking issues).