### PR TITLE
docs(dr-testing-framework): lab-readiness validation and corrections

### DIFF
--- a/dr-testing-framework/CHANGELOG.md
+++ b/dr-testing-framework/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to the DR Readiness Validation Framework.
 ### Fixed
 
 - **Wave 6 P4b:** Empty catch blocks now log via `Write-Verbose` instead of silently swallowing errors. Output is unchanged unless caller passes `-Verbose`.
+- **Lab validation (docs):** Corrected the Power Platform backup-retention note in `README.md` to the current Microsoft Managed Environments model — default 7 days for all production and nonproduction environments, extendable to 7/14/21/28 days only for production Managed Environments. The prior text incorrectly tied 28-day retention to "Dynamics 365 applications" presence. Verified against Microsoft Learn *Back up and restore environments*.
+- **Lab validation (docs):** Aligned sample audit-log filenames in `docs/evidence-export.md` and `templates/dr-evidence-metadata.sample.json` to the actual format emitted by `Invoke-DRTest.ps1` (`dr-audit-<yyyyMMdd-HHmmss>-<correlationid>.log`); the examples previously embedded the TestType, which the script does not.
+- **Lab validation:** Added `LAB-VALIDATION.md` evidence report (static validation: 3 Python compile, 4 PowerShell parse, 57/57 Pester, no schema drift, authoritative-source verification of all Power Platform / Dataverse API and backup claims).
+
 ## [2.0.2] - 2026-05-22
 
 ### Fixed

--- a/dr-testing-framework/LAB-VALIDATION.md
+++ b/dr-testing-framework/LAB-VALIDATION.md
@@ -1,0 +1,79 @@
+# Lab Validation Report — DR Testing Framework
+
+> **Solution:** dr-testing-framework · **Version:** v2.0.2
+> **Validation date:** 2026-06-04 · **Mode:** Static validation (no live tenant)
+> **Primary controls:** 2.4 (Business Continuity & Disaster Recovery), 2.1 (Managed Environments), 1.9 (Data Retention)
+
+## Purpose and scope
+
+This solution provides **post-recovery validation and evidence packaging** for AI agent
+environments in Microsoft Power Platform — not recovery execution. It runs read-only checks
+(agent component count, statecode, connection references, `WhoAmI`, Dataverse-row hash
+snapshot) against an already-restored environment and persists each check as an
+`fsi_drtestresult` row for FFIEC BCP / FINRA Rule 4370 / OCC Heightened Standards /
+SEC Rule 17a-4(f) supervisory review.
+
+The validation focused on parse-validity, authoritative-source verification of every
+Power Platform / Dataverse API and capability claim, and documentation completeness.
+
+## What was checked
+
+| Area | Method | Result |
+|------|--------|--------|
+| Python scripts (3) | `python -m py_compile` | ✅ all compile |
+| PowerShell scripts (4, incl. tests) | `Parser::ParseFile` zero-error parse | ✅ all parse |
+| Pester unit tests | `Invoke-Pester scripts` (Pester 5.7.1) | ✅ 57 passed, 0 failed |
+| Dataverse schema docs | `create_drt_dataverse_schema.py --output-docs` regen | ✅ no drift |
+| Dataverse column references | grep script `$select`/`$filter` vs `create_drt_dataverse_schema.py` | ✅ logical names consistent |
+| Option-set values | `fsi_drt_teststatus` (1=Pass, 2=Fail) | ✅ matches script + `.ralph-config.json` note |
+| Language rules | grep for prohibited overclaim phrases in `.md` (excl. CHANGELOG) | ✅ no violations |
+| Templates | JSON parse | ✅ both valid |
+
+## Authoritative sources cited
+
+1. **Power Platform backup retention / restore mechanics** — Microsoft Learn, *Back up and restore environments*: <https://learn.microsoft.com/en-us/power-platform/admin/backup-restore-environments>
+   - System and manual backups retained **7 days** by default for all production and nonproduction environments.
+   - Production **Managed Environments**: retention extendable to 7/14/21/**28 days** via PPAC or PowerShell.
+   - Restore must be in the **same region** as the backup; **1 GB** free capacity required to restore; manual backups take ~10–15 min before they are available.
+2. **`Backup-PowerAppEnvironment`** — Microsoft Learn (Microsoft.PowerApps.Administration.PowerShell): <https://learn.microsoft.com/powershell/module/microsoft.powerapps.administration.powershell/backup-powerappenvironment?view=pa-ps-latest> — cmdlet exists; backs up an environment.
+3. **`Copy-PowerAppEnvironment`** — Microsoft Learn (same module): <https://learn.microsoft.com/powershell/module/microsoft.powerapps.administration.powershell/copy-powerappenvironment?view=pa-ps-latest> — copies source→target; `MinimalCopy`/`SkipAuditData` options confirmed.
+4. **`botcomponent` table / `parentbotid` lookup** — Microsoft Learn, *Copilot component (botcomponent) table reference*: confirms `parentbotid` lookup to the `bot` table (script uses `_parentbotid_value`).
+5. **`Get-AzAccessToken` SecureString change** — Microsoft Learn, *Protect secrets in Azure PowerShell*: <https://learn.microsoft.com/powershell/azure/protect-secrets> (and `Get-AzAccessToken` reference: <https://learn.microsoft.com/powershell/module/az.accounts/get-azaccesstoken>) — `Get-AzAccessToken` returns `SecureString` from **Az.Accounts 5.0.0 / Az 14.0.0**. `docs/prerequisites.md` already handles both `SecureString` and `String` defensively.
+6. **Emergency access (break-glass) accounts** — Microsoft Learn, *Manage emergency access accounts*: <https://learn.microsoft.com/entra/identity/role-based-access-control/security-emergency-access> — referenced by `docs/emergency-access-drill.md` (≥2 cloud-only accounts, monitored sign-ins, regular validation drills).
+
+## Gaps found and fixes applied
+
+| # | Severity | File | Gap | Fix |
+|---|----------|------|-----|-----|
+| 1 | Minor (accuracy) | `README.md` (Power Platform backup notes) | Backup-retention claim used the **outdated** model ("production environments *with Dynamics 365 applications* have up to 28 days; others 7 days"). Microsoft's current model ties extended retention (7/14/21/28 days) to **production Managed Environments**, not Dynamics 365 app presence. | Rewrote to the current Managed Environments model with the correct admin roles, verified against source #1. |
+| 2 | Cosmetic (doc accuracy) | `docs/evidence-export.md` (2 places) | Example audit-log filenames embedded the `TestType` (e.g. `dr-audit-AgentReadinessCheck-...`), but the real filename emitted by `Invoke-DRTest.ps1` is `dr-audit-<yyyyMMdd-HHmmss>-<correlationid>.log`. An operator following the doc would mis-predict filenames and the `-TestRunId` glob (`dr-audit-*-<id>.log`). | Replaced examples with the actual format. |
+| 3 | Cosmetic (doc accuracy) | `templates/dr-evidence-metadata.sample.json` | Same outdated audit-log filename format in `AuditLogFiles`. | Aligned to actual format. |
+
+No script logic, API call, auth flow, column name, or option-set value required correction —
+the v2.0.0 reframe + council-review remediations (M-1/M-2/m-5/m-6) had already brought the
+code to a high standard.
+
+## Verified-correct items (no change needed)
+
+- **API surface:** `bots`, `botcomponents` (`_parentbotid_value`), `connectionreferences`, `organizations`, `WhoAmI`, `fsi_drtestresults` Web API v9.2 paths are valid; `$count=true&$top=0` + `@odata.nextLink` pagination patterns are correct.
+- **Honest scope framing:** README explicitly disclaims that the script initiates restores, fails over regions, or computes regulator-grade RTO/RPO — matching the platform reality verified in source #1 (customer scripts cannot back up / restore tenant-bound environment metadata).
+- **Auth:** managed-identity-first guidance; client-secret paths marked `# legacy: dev-only` with `SuppressMessageAttribute` + justification; secret zeroized in `finally`. Sovereign-cloud authority mapping (`.dynamics.cn`, `.microsoftdynamics.us`, `.appsplatform.us`) is correct.
+- **Token audience:** `"$Environment/.default"` scope targets the Dataverse org — correct audience.
+
+## Runtime-only caveats (cannot be verified statically)
+
+- Live `bot`/`botcomponent`/`fsi_drtestresult` reads, `WhoAmI`, and PATCH writes require a real
+  Dataverse environment with the application user provisioned and roles granted.
+- Actual probe-duration and 429/`Retry-After` retry behavior depend on live service latency/throttling.
+- `Backup-PowerAppEnvironment` / `Copy-PowerAppEnvironment` and PPAC restore are **operator-run,
+  out-of-scope** prerequisites; this framework only validates the post-recovery state.
+- KQL queries require Application Insights connected to Dataverse / Azure Monitor with the
+  expected tables (`requests`, `dependencies`, `customEvents`, `AzureActivity`).
+
+## Lab-readiness assessment
+
+**Lab-ready.** All static checks pass (compile, parse, 57/57 Pester, no schema drift, no
+language violations). Three documentation-accuracy gaps were corrected — the most material
+being the outdated backup-retention model now realigned to the current Microsoft Managed
+Environments model. Live-tenant execution paths remain unverified by design (no tenant in this
+validation) and are clearly enumerated above as runtime-only caveats.

--- a/dr-testing-framework/README.md
+++ b/dr-testing-framework/README.md
@@ -286,7 +286,7 @@ Validation Success Rate = (Passed Validations / Total Validations) × 100
 
 ## Power Platform backup, restore, and regional notes (Microsoft Learn 2026-Q2)
 
-- Power Platform and Dataverse system backups are Microsoft-managed for environments with a database. Production environments with Dynamics 365 applications have up to 28 days of system backup retention; production environments without Dynamics 365 applications and nonproduction environments default to seven days unless eligible Managed Environment retention is extended.
+- Power Platform and Dataverse system backups are Microsoft-managed for environments that have a database. By default, both system and manual backups are retained for seven days across all production and nonproduction environments. For production **Managed Environments**, a tenant admin (Power Platform Admin, Entra Global Admin, or Dynamics 365 admin) can extend the retention period to 7, 14, 21, or up to 28 days through the Power Platform admin center or PowerShell; the configured value applies to both system and manual backups.
 - Manual backups are operator-initiated, may take 10-15 minutes before they are available for restore, do not count against storage capacity, and require at least 1 GB of available capacity to restore.
 - Manual backups are restored in the same region where the environment was backed up. Do not treat Azure region pairs as customer-controlled failover for Power Platform environments.
 - Use the current Power Apps admin module cmdlet `Backup-PowerAppEnvironment` for operator-initiated environment backups. `Copy-PowerAppEnvironment` copies source to target, but copied custom connectors receive new identifiers and flows may need connector rebinding.

--- a/dr-testing-framework/docs/evidence-export.md
+++ b/dr-testing-framework/docs/evidence-export.md
@@ -58,8 +58,8 @@ evidence/
 ├── dr-evidence-20260315-143022.json
 ├── dr-evidence-20260315-143022.json.sha256
 └── audit-logs/
-    ├── dr-audit-AgentReadinessCheck-abc12345.log
-    └── dr-audit-DataverseAccessCheck-abc12345.log
+    ├── dr-audit-20260315-130145-abc12345.log
+    └── dr-audit-20260315-141507-abc12345.log
 ```
 
 ## Metadata JSON Format
@@ -70,8 +70,8 @@ evidence/
   "Environment": "https://contoso.crm.dynamics.com",
   "TestRunId": "abc12345",
   "AuditLogFiles": [
-    "dr-audit-AgentReadinessCheck-20260315-abc12345.log",
-    "dr-audit-DataverseAccessCheck-20260315-abc12345.log"
+    "dr-audit-20260315-130145-abc12345.log",
+    "dr-audit-20260315-141507-abc12345.log"
   ],
   "TestResults": [
     {

--- a/dr-testing-framework/templates/dr-evidence-metadata.sample.json
+++ b/dr-testing-framework/templates/dr-evidence-metadata.sample.json
@@ -3,8 +3,8 @@
   "Environment": "https://contoso.crm.dynamics.com",
   "TestRunId": "abc12345",
   "AuditLogFiles": [
-    "dr-audit-AgentReadinessCheck-20260315-abc12345.log",
-    "dr-audit-DataverseAccessCheck-20260315-abc12345.log"
+    "dr-audit-20260315-130145-abc12345.log",
+    "dr-audit-20260315-141507-abc12345.log"
   ],
   "TestResults": [
     {


### PR DESCRIPTION
## Summary

Static **lab-readiness validation** of the DR Testing Framework (v2.0.2). The solution was already in excellent shape after its v2.0.0 honesty reframe and council-review remediations — code, auth flows, Dataverse column names, and option-set values all verified correct. Only **documentation-accuracy** gaps were found and fixed.

## Changes (docs/templates only — no code logic touched)

1. **README backup-retention note corrected** — was the outdated model ("production environments with Dynamics 365 applications = 28 days; others 7 days"). Microsoft's current model: default **7 days** for all production/nonproduction; extendable to **7/14/21/28 days** only for **production Managed Environments**.
2. **Audit-log filename examples aligned** in docs/evidence-export.md (2 places) and templates/dr-evidence-metadata.sample.json to the real format dr-audit-<yyyyMMdd-HHmmss>-<correlationid>.log emitted by Invoke-DRTest.ps1.
3. **Added LAB-VALIDATION.md** evidence report.

## Authoritative sources verified

- Back up and restore environments: https://learn.microsoft.com/en-us/power-platform/admin/backup-restore-environments (retention, same-region restore, 1 GB capacity, 10-15 min manual backup).
- Backup-PowerAppEnvironment / Copy-PowerAppEnvironment (Microsoft.PowerApps.Administration.PowerShell).
- botcomponent/parentbotid Dataverse reference; Get-AzAccessToken SecureString change (Az.Accounts 5.x); emergency-access accounts guidance.

## Verification

- python -m py_compile - 3/3 OK
- PowerShell Parser::ParseFile - 4/4 zero errors
- Pester 5.7.1 - **57/57 pass**
- create_drt_dataverse_schema.py --output-docs - no schema drift
- No language-rule violations

## Runtime caveats

Live Dataverse reads/writes, WhoAmI, retry/throttling, operator-run PPAC restore/Backup-PowerAppEnvironment, and KQL (App Insights) paths are unverified by design (no tenant) — enumerated in LAB-VALIDATION.md.