### PR TITLE
fix(generative-ai-config-auditor): lab-readiness validation and corrections

### DIFF
--- a/generative-ai-config-auditor/CHANGELOG.md
+++ b/generative-ai-config-auditor/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the Generative AI Config Auditor are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **`Connect-EnvironmentDataverse.ps1` SecureString token handling** — `Get-AzAccessToken` returns the access token as a `SecureString` by default on Az.Accounts 5.x (older versions return a plain `String`). The interactive auth path returned `$tokenResult.Token` verbatim, so on current Az.Accounts the bearer token became the literal string `System.Security.SecureString`, producing `401 Unauthorized` on every per-environment and ELM Dataverse call made by `Get-AgentGenAISettings.ps1`. The token is now normalized to plain text via `[System.Net.NetworkCredential]`, matching the existing handling in `GACClient.psm1`, `Get-PurviewDLPEvidence.ps1`, and `Import-ApprovedAoaiConnections.ps1`. Reference: [Get-AzAccessToken](https://learn.microsoft.com/powershell/module/az.accounts/get-azaccesstoken) ("the default output type has been changed from a plain text `String` to `SecureString`").
+
+### Documentation
+
+- **`docs/prerequisites.md` API permissions corrected** — Removed the inaccurate "Microsoft Graph `Environment.Read.All` (Application)" row; environment enumeration is performed by `Microsoft.PowerApps.Administration.PowerShell` (`Get-AdminPowerAppEnvironment`) against the Power Platform Admin (BAP) API and is governed by the admin roles already listed, not a Microsoft Graph scope. Documented the Graph permission that `Get-PurviewDLPEvidence.ps1` actually requires: `InformationProtectionPolicy.Read` (Delegated) / `InformationProtectionPolicy.Read.All` (Application). Reference: [List informationProtection labels](https://learn.microsoft.com/graph/api/informationprotectionpolicy-list-labels).
+- **`docs/prerequisites.md` module list** — Added `Microsoft.Graph.Authentication` (required by `Get-PurviewDLPEvidence.ps1` for `Invoke-MgGraphRequest`) and `ExchangeOnlineManagement` (optional, for `Get-DlpCompliancePolicy` / `Get-Label`), plus their install commands. Noted that Az.Accounts 5.x SecureString tokens are handled automatically.
+- **`docs/flow-configuration.md` Parse JSON schema aligned to runbook output** — The `GAC-DailyAudit` Parse JSON schema documented violation fields (`Feature`, `ExpectedPolicy`, `ActualConfig`) and a `Drift.DriftDetected` property that `Start-GenAIConfigValidationRunbook.ps1` does not emit. Corrected the violation item properties to the actual fields (`AzureOpenAIEnabled`, `OrchestrationMode`, `GenerativeAnswersNodeCount`) and the `Drift` object to `HasDrift` / `IsFirstRun` / `DriftedAgents` / `Details`.
+
 ## [1.2.1] - 2026-05-19
 
 ### Changed

--- a/generative-ai-config-auditor/LAB-VALIDATION.md
+++ b/generative-ai-config-auditor/LAB-VALIDATION.md
@@ -1,0 +1,70 @@
+# Lab Validation Report — Generative AI Config Auditor (GAC)
+
+> **Validation date:** 2026-06-04
+> **Branch:** `validation/generative-ai-config-auditor`
+> **Solution version:** v1.2.1 (fixes recorded under CHANGELOG `[Unreleased]`)
+> **Validation type:** Static — parse-validity + authoritative-source verification + documentation completeness. No live tenant was used.
+
+## Purpose & Controls
+
+The Generative AI Config Auditor validates that Copilot Studio agents comply with zone-specific generative AI governance policies — Azure OpenAI integration, generative orchestration, generative answers nodes, knowledge sources, **Allow ungrounded responses** (AI general knowledge), and **Work IQ** (semantic search).
+
+- **Primary control:** 2.24 — Agent Feature Enablement Governance
+- **Supporting:** 1.8 (Runtime Protection), 2.1 (Managed Environments / zone source), 3.8 (Copilot Hub / evidence export)
+- **Regulatory context referenced by the solution:** FINRA Rule 3110(a)(1), SOX Section 404, GLBA Section 501(b); audit-trail tables support FINRA Rule 4511 / SEC Rule 17a-3/4 record-keeping.
+
+## What Was Checked
+
+| Area | Method | Result |
+|------|--------|--------|
+| PowerShell parse validity (all 14 `.ps1`) | `Parser::ParseFile` | 0 errors |
+| Python compile (all 5 `.py`) | `python -m py_compile` | All OK |
+| Token-acquisition correctness (Az.Accounts SecureString) | Source review + Microsoft Learn | **1 bug found & fixed** |
+| Dataverse logical column names | Grep vs `create_dataverse_schema.py` | Consistent (no snake_case drift) |
+| Entity-set names (incl. explicit-singular `fsi_gacvalidationhistory`) | Grep vs schema `entity_set_name` | Consistent |
+| Option-set values (100000000+) | Schema vs docs | Consistent (no 0/1/2 drift) |
+| Copilot Studio GenAI feature naming (current) | Microsoft Learn | All terms current |
+| API permissions / required modules | Source review vs docs | **2 doc gaps fixed** |
+| Flow Parse JSON schema vs runbook output | Source review | **2 mismatches fixed** |
+| Regulatory language rules (prohibited overclaim phrases) | Grep (non-CHANGELOG `.md`) | 0 violations |
+
+## Authoritative Sources Cited
+
+1. `Get-AzAccessToken` default output type changed to `SecureString` — https://learn.microsoft.com/powershell/module/az.accounts/get-azaccesstoken (and "Protect secrets in Azure PowerShell" https://go.microsoft.com/fwlink/?linkid=2258844). Also confirmed `-ResourceUri` is an **alias** of `-ResourceUrl` (aliases: `Resource, ResourceUri`).
+2. Copilot Studio **Allow ungrounded responses** and **generative orchestration** — https://learn.microsoft.com/microsoft-copilot-studio/advanced-generative-actions and Knowledge sources summary.
+3. Copilot Studio **Turn on Work IQ** (semantic search) — https://learn.microsoft.com/microsoftsearch/semantic-index-for-copilot (referenced from the Generative AI settings page).
+4. Tenant setting **Publish Copilots with AI features** — https://learn.microsoft.com/microsoft-copilot-studio/security-and-governance.
+5. Microsoft Graph permission for `informationProtection/policy/labels` — `InformationProtectionPolicy.Read` (Delegated) / `InformationProtectionPolicy.Read.All` (Application): https://learn.microsoft.com/graph/api/informationprotectionpolicy-list-labels.
+6. DLP for Microsoft 365 Copilot location — https://learn.microsoft.com/purview/dlp-microsoft365-copilot-location-learn-about (already cited in-script).
+
+## Gaps Identified & Fixes Applied
+
+### Scripts
+
+1. **`scripts/private/Connect-EnvironmentDataverse.ps1` — SecureString token bug (functional, high impact).**
+   The interactive `Get-AzAccessToken` path returned `$tokenResult.Token` directly. On Az.Accounts 5.x this property is a `SecureString`, so the downstream `Authorization: Bearer <token>` header rendered as the literal text `System.Security.SecureString`, causing `401 Unauthorized` on every per-environment and ELM Dataverse call made by `Get-AgentGenAISettings.ps1` (the core agent-enumeration script). Fixed by normalizing to plain text via `[System.Net.NetworkCredential]`, matching the pattern already present in `GACClient.psm1`, `Get-PurviewDLPEvidence.ps1`, and `Import-ApprovedAoaiConnections.ps1`. This was the one token-acquisition site missed when the SecureString fix was rolled out in v1.1.0/v1.2.1.
+
+### Documentation
+
+2. **`docs/prerequisites.md` — inaccurate Graph permission.** Replaced the "Microsoft Graph `Environment.Read.All` (Application)" row (no such Graph scope is used; `Get-AdminPowerAppEnvironment` uses the Power Platform Admin / BAP API governed by the admin roles already listed) with the Graph permission actually required by `Get-PurviewDLPEvidence.ps1`: `InformationProtectionPolicy.Read` / `.Read.All`.
+3. **`docs/prerequisites.md` — missing module prerequisites.** Added `Microsoft.Graph.Authentication` (required by `Get-PurviewDLPEvidence.ps1`'s `#Requires` / `Invoke-MgGraphRequest`) and optional `ExchangeOnlineManagement`, with install commands.
+4. **`docs/flow-configuration.md` — Parse JSON schema drift vs runbook output.** Violation items documented `Feature`/`ExpectedPolicy`/`ActualConfig` and `Drift.DriftDetected`, none of which `Start-GenAIConfigValidationRunbook.ps1` emits. Aligned the schema to the actual emitted fields: violation `AzureOpenAIEnabled`/`OrchestrationMode`/`GenerativeAnswersNodeCount`, and `Drift` = `HasDrift`/`IsFirstRun`/`DriftedAgents`/`Details`. (Power Automate Parse JSON tolerates non-required property differences, so this was a correctness/clarity fix rather than a hard runtime break.)
+
+### Verified-correct (no change needed)
+
+- GenAI feature terminology (Allow ungrounded responses, Work IQ, generative orchestration/answers) is current per Microsoft Learn.
+- `-ResourceUri`/`-ResourceUrl` try/catch fallback is harmless — they are the same parameter (alias), so the pattern binds on any Az.Accounts version.
+- Dataverse logical column names, entity-set names, and option-set integer values match `create_dataverse_schema.py`.
+- The 3 evidence/runbook scripts (`Export-GenAIConfigEvidence.ps1`, `Invoke-GenAIBaselineCapture.ps1`, `Start-GenAIConfigValidationRunbook.ps1`) acquire tokens via MSAL.PS `.AccessToken` (plain text) — not affected by the Az SecureString change.
+
+## Runtime-Only Caveats (cannot be verified without a live tenant)
+
+- Actual Dataverse read/write against `bot`, `botcomponent`, `bot_botsettings`, and the five `fsi_GAC*` tables (auth, role assignment, table existence).
+- `bot_botsettings` is an **optional extension table**; fall-through behavior when customers have not added platform-side `fsi_*` columns is by-design (per CHANGELOG 1.1.0) and only observable live.
+- Power Platform environment enumeration behavior and zone classification via the shared `Get-ZoneClassification.ps1` module (external dependency at `scripts/shared/`).
+- Microsoft Graph / Security & Compliance cmdlet availability and consent state for the Purview evidence script.
+- `manifest.yaml` build verification (`build-manifest.py --check`) could not run in this worktree — it requires a sibling `fsi-agentgov` checkout providing `controls.json`. `manifest.yaml` was **not** modified, so no manifest drift is introduced.
+
+## Lab-Readiness Assessment
+
+**Ready for lab use, with the SecureString fix applied.** Before this change, the core enumeration path (`Get-AgentGenAISettings.ps1`) would have failed authentication on any host running Az.Accounts 5.x — a likely default in a fresh lab. With the fix plus the prerequisite/permission corrections, an operator following `docs/prerequisites.md` can install the correct modules, grant the correct permissions, and exercise the scan/baseline/evidence flows. Live functional execution against a tenant remains the only outstanding verification and is outside the scope of this static validation.

--- a/generative-ai-config-auditor/docs/flow-configuration.md
+++ b/generative-ai-config-auditor/docs/flow-configuration.md
@@ -131,9 +131,9 @@ Add these **Initialize variable** actions immediately after the trigger:
                     "EnvironmentName": { "type": "string" },
                     "Zone": { "type": "string" },
                     "ViolationType": { "type": "string" },
-                    "Feature": { "type": "string" },
-                    "ExpectedPolicy": { "type": "string" },
-                    "ActualConfig": { "type": "string" },
+                    "AzureOpenAIEnabled": { "type": "boolean" },
+                    "OrchestrationMode": { "type": "string" },
+                    "GenerativeAnswersNodeCount": { "type": "integer" },
                     "Severity": { "type": "string" },
                     "RegulatoryContext": { "type": "string" }
                 }
@@ -142,7 +142,9 @@ Add these **Initialize variable** actions immediately after the trigger:
         "Drift": {
             "type": "object",
             "properties": {
-                "DriftDetected": { "type": "boolean" },
+                "HasDrift": { "type": "boolean" },
+                "IsFirstRun": { "type": "boolean" },
+                "DriftedAgents": { "type": "integer" },
                 "Details": { "type": "array" }
             }
         }
@@ -368,7 +370,7 @@ After either branch (use a common action after the condition):
 
 - The Parse_Results schema must match the runbook output structure exactly
 - If the runbook output changes (e.g., new fields added), update the schema in the flow
-- Key GAC schema differences from CMM: `ViolationType` and `Feature` fields per violation, `ExpectedPolicy`/`ActualConfig` instead of `ExpectedModerationLevel`/`ActualModerationLevel`
+- Key GAC schema differences from CMM: each violation includes `ViolationType` plus the generative AI configuration fields `AzureOpenAIEnabled`, `OrchestrationMode`, and `GenerativeAnswersNodeCount` (instead of CMM's `ExpectedModerationLevel`/`ActualModerationLevel`)
 
 ### Flow Errors (Scope_Catch)
 

--- a/generative-ai-config-auditor/docs/prerequisites.md
+++ b/generative-ai-config-auditor/docs/prerequisites.md
@@ -7,9 +7,11 @@ Requirements for deploying the Generative AI Config Auditor (GAC) solution.
 | Requirement | Version | Purpose |
 |-------------|---------|---------|
 | PowerShell | 7.4+ | Core runtime matching the solution scripts' `#Requires -Version 7.4` declarations |
-| Microsoft.PowerApps.Administration.PowerShell | 2.0.180+ | Power Platform environment enumeration |
-| Az.Accounts | 2.0+ | Dataverse token acquisition (interactive mode) |
+| Microsoft.PowerApps.Administration.PowerShell | 2.0.180+ | Power Platform environment enumeration (`Get-AdminPowerAppEnvironment`) |
+| Az.Accounts | 2.0+ | Dataverse token acquisition (interactive mode). Az.Accounts 5.x returns `Get-AzAccessToken` tokens as `SecureString` by default; the solution scripts detect and convert these automatically. |
 | MSAL.PS | 4.37+ | Evidence export authentication (`Install-Module MSAL.PS`) |
+| Microsoft.Graph.Authentication | 2.0+ | Required by `Get-PurviewDLPEvidence.ps1` for `Invoke-MgGraphRequest` (sensitivity/information protection label evidence) |
+| ExchangeOnlineManagement | 3.0+ | Optional — enables `Get-DlpCompliancePolicy` / `Get-Label` in `Get-PurviewDLPEvidence.ps1` |
 
 ## Python Requirements
 
@@ -36,6 +38,12 @@ Install-Module -Name Az.Accounts -Force -Scope CurrentUser
 
 # Install MSAL.PS for evidence export
 Install-Module -Name MSAL.PS -Force -Scope CurrentUser
+
+# Install Microsoft.Graph.Authentication for Purview DLP evidence collection
+Install-Module -Name Microsoft.Graph.Authentication -Force -Scope CurrentUser
+
+# Optional: Exchange Online Management for DLP policy / sensitivity label cmdlets
+Install-Module -Name ExchangeOnlineManagement -Force -Scope CurrentUser
 ```
 
 ## Microsoft Entra ID App Registration
@@ -55,10 +63,12 @@ A Microsoft Entra ID app registration is required for both interactive and non-i
 
 | API | Permission | Type | Purpose |
 |-----|-----------|------|---------|
-| Dynamics CRM | `user_impersonation` | Delegated | Dataverse read/write for schema and data |
-| Microsoft Graph | `Environment.Read.All` | Application | Power Platform environment enumeration |
+| Dynamics CRM (`https://<org>.crm.dynamics.com/.default`) | `user_impersonation` | Delegated | Dataverse read/write for schema and data |
+| Microsoft Graph | `InformationProtectionPolicy.Read` | Delegated | Read sensitivity / information protection labels for `Get-PurviewDLPEvidence.ps1`. Use `InformationProtectionPolicy.Read.All` (Application) for non-interactive execution. |
 
 > **Note:** After adding permissions, an admin must grant consent for the tenant.
+>
+> **Environment enumeration** is performed by the `Microsoft.PowerApps.Administration.PowerShell` module (`Get-AdminPowerAppEnvironment`), which authenticates against the Power Platform Admin (BAP) API and is governed by the Power Platform admin **roles** listed under [Permissions](#permissions) below — not a Microsoft Graph application permission. No `Environment.Read.All` Microsoft Graph scope is used by this solution.
 
 ### Certificate Authentication (Recommended for Automation)
 

--- a/generative-ai-config-auditor/scripts/private/Connect-EnvironmentDataverse.ps1
+++ b/generative-ai-config-auditor/scripts/private/Connect-EnvironmentDataverse.ps1
@@ -179,6 +179,18 @@ try {
         $tokenResult = Get-AzAccessToken -ResourceUrl $normalizedUrl -ErrorAction Stop
     }
 
+    # Az.Accounts 5.x changed the default Get-AzAccessToken output type from a
+    # plain-text String to a SecureString (older versions still return a String).
+    # Normalize to a plain bearer string so downstream Authorization headers
+    # ("Bearer <token>") are well-formed rather than the literal text
+    # "System.Security.SecureString". Matches the handling in GACClient.psm1,
+    # Get-PurviewDLPEvidence.ps1, and Import-ApprovedAoaiConnections.ps1.
+    if ($tokenResult.Token -is [System.Security.SecureString]) {
+        $accessToken = [System.Net.NetworkCredential]::new('', $tokenResult.Token).Password
+    } else {
+        $accessToken = $tokenResult.Token
+    }
+
     $expiresOn = if ($tokenResult.ExpiresOn) {
         $tokenResult.ExpiresOn.LocalDateTime
     } else {
@@ -186,12 +198,12 @@ try {
     }
 
     $script:TokenCache[$normalizedUrl] = @{
-        Token     = $tokenResult.Token
+        Token     = $accessToken
         ExpiresOn = $expiresOn
     }
 
     Write-Verbose "Interactive token acquired for $normalizedUrl (expires: $expiresOn)"
-    return $tokenResult.Token
+    return $accessToken
 } catch {
     if ($_.Exception.Message -match 'No Azure context found') {
         throw $_


### PR DESCRIPTION
## Summary
Static lab-readiness validation of **generative-ai-config-auditor** (v1.2.1, control 2.24). No live tenant — parse-validity + authoritative-source (Microsoft Learn) verification + doc completeness. Full evidence in generative-ai-config-auditor/LAB-VALIDATION.md.

## What & why
**Bug fix (functional, high impact)**
- Connect-EnvironmentDataverse.ps1 returned the raw Get-AzAccessToken token. On **Az.Accounts 5.x** that property is a SecureString by default, so the bearer header became the literal `Bearer System.Security.SecureString` → **401 on every per-environment/ELM Dataverse call** made by `Get-AgentGenAISettings.ps1` (the core enumeration script). This was the one token site missed when the SecureString fix shipped in v1.1.0/v1.2.1. Normalized to plain text via `[System.Net.NetworkCredential]`, matching `GACClient.psm1`, `Get-PurviewDLPEvidence.ps1`, and `Import-ApprovedAoaiConnections.ps1`.

**Documentation corrections**
- docs/prerequisites.md: removed the inaccurate Microsoft Graph `Environment.Read.All` row (environment enumeration uses `Get-AdminPowerAppEnvironment` / BAP API governed by admin roles, not a Graph scope); documented the Graph permission `Get-PurviewDLPEvidence.ps1` actually needs (`InformationProtectionPolicy.Read` / `.Read.All`); added required `Microsoft.Graph.Authentication` and optional `ExchangeOnlineManagement` modules.
- docs/flow-configuration.md: aligned the `GAC-DailyAudit` Parse JSON schema to the runbook's real output — violation fields (`AzureOpenAIEnabled`/`OrchestrationMode`/`GenerativeAnswersNodeCount`) and `Drift` (`HasDrift`/`IsFirstRun`/`DriftedAgents`/`Details`).
- CHANGELOG.md: `[Unreleased]` entry. Added LAB-VALIDATION.md.

## Sources (Microsoft Learn)
- Get-AzAccessToken SecureString default (and `-ResourceUri` is an alias of `-ResourceUrl`)
- Copilot Studio: Allow ungrounded responses, generative orchestration, Turn on Work IQ (all current); `Publish Copilots with AI features` tenant setting
- Graph `informationProtection/policy/labels` → `InformationProtectionPolicy.Read`

## Verification
- PowerShell parse: 0 errors (all .ps1). Python `py_compile`: all OK.
- Language-rule grep (non-CHANGELOG .md): clean. Edited flow JSON blocks: valid.
- Logical column names, entity-set names, option-set values: consistent with `create_dataverse_schema.py`.

## Caveats
- Live tenant execution (Dataverse/Graph auth, role assignment, table existence) not exercised.
- `manifest.yaml` **not** modified (no version bump): `build-manifest.py --check` requires a sibling `fsi-agentgov` checkout absent in this worktree; bumping would cascade to root artifacts + catalog files out of scope here. Fixes recorded under CHANGELOG `[Unreleased]` for a maintainer to cut as v1.2.2.
