### PR TITLE
fix(inactivity-timeout-enforcement): lab-readiness validation and corrections

### DIFF
--- a/inactivity-timeout-enforcement/CHANGELOG.md
+++ b/inactivity-timeout-enforcement/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Inactivity Timeout Enforcement are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- **Major (lab-validation):** Inactivity timeout is now read from its authoritative source — the Dataverse `organization` table (`inactivitytimeoutenabled` Boolean / `inactivitytimeoutinmins` **Integer minutes**) — in `Invoke-TimeoutComplianceScan.ps1`. The previous source (BAP Admin API `governanceConfiguration` returning an ISO 8601 `inactivityTimeoutDuration`) is undocumented by Microsoft and is retained only as a clearly-labelled, `try/catch`-guarded fallback. Enumeration now captures each environment's Dataverse instance URL; new `Get-DataverseResourceToken` (per-resource token cache) and `Get-OrganizationInactivityTimeout` helpers perform the read. Result objects gain a `DataSource` field. Source: [Organization table/entity reference](https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/organization). See `LAB-VALIDATION.md`.
+
+### Changed
+- **Doc:** `docs/flow-configuration.md` and `README.md` now document the Dataverse `organization` table as the authoritative inactivity timeout source (integer minutes, no ISO 8601 parsing) and reframe the BAP `governanceConfiguration` shape as an unverified fallback, including the single-Dataverse-connection constraint for a centralized flow.
+
+### Added
+- `LAB-VALIDATION.md` — static lab-readiness validation report with authoritative source citations, the central BAP-vs-organization-table finding, fixes, and runtime-only caveats.
+
 ## [1.1.2] - 2026-05-23
 
 ### Fixed

--- a/inactivity-timeout-enforcement/LAB-VALIDATION.md
+++ b/inactivity-timeout-enforcement/LAB-VALIDATION.md
@@ -1,0 +1,163 @@
+# Lab Validation Report — Inactivity Timeout Enforcement (ITE)
+
+> **Solution version:** v1.1.2 (changes staged under CHANGELOG `[Unreleased]`)
+> **Validation date:** 2026-06-04
+> **Validation type:** Static (no live tenant) — parse-validity + authoritative-source verification + documentation completeness
+> **Primary controls:** 2.22 (Inactivity Timeout), 1.23 (Step-Up / Session Security), 3.7 (PPAC Security Posture), 3.8 (Copilot Hub / Governance Dashboard)
+
+## 1. Purpose and scope
+
+ITE detects whether Power Platform environments have an inactivity timeout
+configured within zone-specific maximum durations (Zone 1 optional ≤120 min;
+Zone 2 required ≤120 min; Zone 3 / Unknown required ≤60 min). It ships:
+
+- A documented daily cloud-flow compliance scanner (`docs/flow-configuration.md`).
+- Standalone PowerShell governance scripts under `scripts/governance/`.
+- A Dataverse schema (`scripts/create_ite_dataverse_schema.py`) with compliance
+  and error-log tables.
+
+## 2. What was checked
+
+| Area | Method |
+|------|--------|
+| Inactivity / session timeout feature + storage location | Microsoft Learn (Power Platform admin + Dataverse `organization` table reference) |
+| Data type of the inactivity timeout value | Dataverse `organization` entity reference |
+| Conditional Access session-control property names | Microsoft Graph v1.0 conditional access docs (cross-check of existing scope notes) |
+| PowerShell parse-validity (5 `.ps1`) | `[Parser]::ParseFile` — 0 errors |
+| Python compile-validity (3 `.py`) | `python -m py_compile` — 0 errors |
+| Prohibited compliance language | grep across `*.md/*.ps1/*.py` (excl. CHANGELOG) — 0 hits |
+| Dataverse logical-name / option-set integer usage | reviewed against `create_ite_dataverse_schema.py` and `.ralph-config.json` |
+| Token audiences / Az.Accounts 5.x SecureString | reviewed scanner + evidence-export auth helpers |
+
+## 3. Authoritative sources cited
+
+1. **Security enhancements for user sessions and access management** (inactivity
+   timeout is a per-environment customer-engagement System Setting; client-side;
+   excludes Power Apps canvas apps) —
+   <https://learn.microsoft.com/power-platform/admin/user-session-management>
+2. **Manage privacy and security settings** (admin-center Privacy + Security:
+   custom session timeout, inactivity timeout) —
+   <https://learn.microsoft.com/power-platform/admin/settings-privacy-security>
+3. **Organization table/entity reference (Microsoft Dataverse)** — the
+   authoritative storage and **data types**: `inactivitytimeoutenabled`
+   (Boolean), `inactivitytimeoutinmins` (**Integer minutes**),
+   `inactivitytimeoutreminderinmins` (Integer); plus `sessiontimeoutenabled`,
+   `sessiontimeoutinmins` —
+   <https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/organization>
+4. **Conditional Access session controls / sign-in frequency** (cross-check of
+   the existing `signInFrequency`, `persistentBrowser`, `cloudAppSecurity`,
+   `applicationEnforcedRestrictions`, `disableResilienceDefaults` references) —
+   Microsoft Graph v1.0 `/identity/conditionalAccess/policies`.
+
+## 4. Central finding (most significant gap)
+
+**The inactivity timeout value is stored as an integer number of minutes on the
+Dataverse `organization` table, not as an ISO 8601 duration returned by the BAP
+Admin API `governanceConfiguration` endpoint.**
+
+Before this validation, both the scanner and the flow docs read inactivity
+timeout from:
+
+```
+GET https://api.bap.microsoft.com/.../environments/{env}/governanceConfiguration?api-version=2021-04-01
+→ properties.settings.inactivityTimeoutEnabled (bool)
+→ properties.settings.inactivityTimeoutDuration (ISO 8601, e.g. PT60M)
+```
+
+Adversarial assessment:
+
+- The BAP `governanceConfiguration` resource is documented for **Managed
+  Environment governance** settings (maker onboarding, sharing limits, solution
+  checker, usage insights). I found **no authoritative Microsoft documentation**
+  that inactivity timeout fields exist on this endpoint or that the value is
+  exposed as an ISO 8601 duration anywhere in the platform.
+- The **only** authoritative source for the inactivity timeout value is the
+  Dataverse `organization` table, where it is an **Integer (`inactivitytimeoutinmins`)**
+  in whole minutes — confirming the ISO 8601 parsing assumption was misplaced
+  for the authoritative path.
+- Consequence if unaddressed: in a real tenant the `governanceConfiguration`
+  call would most likely omit these fields (or 404), so **every** environment
+  would be classified `Unknown`, silently defeating the solution's purpose.
+
+I cannot *disprove* the BAP shape without a live tenant, so it is retained as a
+clearly-labelled fallback rather than deleted.
+
+## 5. Fixes applied
+
+### Scripts (`scripts/governance/Invoke-TimeoutComplianceScan.ps1`)
+
+- **Authoritative primary read added.** Environment enumeration now captures each
+  environment's Dataverse instance URL (`properties.linkedEnvironmentMetadata.instanceUrl`
+  / `instanceApiUrl`). New helpers `Get-DataverseResourceToken` (per-resource
+  token cache) and `Get-OrganizationInactivityTimeout` read
+  `organizations?$select=inactivitytimeoutenabled,inactivitytimeoutinmins` and
+  use the **integer minutes** directly (no ISO 8601 parsing).
+- **BAP path demoted to fallback.** The `governanceConfiguration` call now runs
+  only when the organization-table read is unavailable/fails, and is annotated
+  in-code as unverified. Existing error-classification and Dataverse persistence
+  behavior is unchanged. The change is additive and fully `try/catch`-guarded, so
+  a failed organization read cleanly reverts to prior behavior.
+- **Transparency.** Result objects now carry a `DataSource`
+  (`DataverseOrganization` | `BapGovernanceConfiguration` | `None`) field.
+- Header `.DESCRIPTION` updated to reflect the authoritative-source-first flow.
+
+### Documentation
+
+- `docs/flow-configuration.md` — documents the Dataverse `organization` table as
+  the authoritative source (integer minutes), reframes the BAP shape as an
+  unverified fallback, and notes the single-Dataverse-connection architectural
+  constraint for a centralized flow. ISO 8601 appendix scoped to the fallback.
+- `README.md` — Microsoft Learn scope note updated with the authoritative source
+  and a pointer to this report.
+
+### Dependencies
+
+- No new dependencies required. `scripts/requirements.txt`
+  (`msal`, `requests`, `azure-identity`) and `#Requires -Modules Az.Accounts >= 2.17.0`
+  remain valid. The auth helpers tolerate Az.Accounts 5.x (where
+  `Get-AzAccessToken` returns a `SecureString`) via `ConvertTo-PlainAccessToken`.
+
+## 6. Items verified as already correct
+
+- Dataverse logical-name usage and option-set **integer** values (zone
+  100000001–100000003 / Unknown 100000000; status 100000000–100000002; error
+  type 100000000–100000006) match `create_ite_dataverse_schema.py` and
+  `.ralph-config.json`.
+- BAP environment **enumeration** (`api-version=2016-11-01`) follows
+  `@odata.nextLink` pagination.
+- Managed-identity-first auth with a clearly-marked `# legacy: dev-only`
+  client-secret fallback.
+- Conditional Access session-control property names in the scope notes are
+  current Microsoft Graph v1.0 names.
+- Regulatory citations use name+section form (e.g., `FINRA Rule 4511(a)`,
+  `SOX Section 404`, `GLBA Section 501(b)`).
+
+## 7. Runtime-only caveats (require a live tenant to confirm)
+
+1. **BAP token audience.** The scanner requests `https://service.powerapps.com/`
+   for `api.bap.microsoft.com`. The BAP Admin API is not officially publicly
+   documented; confirm the accepted audience in your tenant.
+2. **`linkedEnvironmentMetadata.instanceUrl` field name** on the 2016-11-01
+   enumeration response — the code reads `instanceUrl` then `instanceApiUrl`;
+   confirm the property actually present for your environments.
+3. **Per-environment Dataverse access.** The managed identity / service principal
+   must be granted an application user with read access to the `organization`
+   table in **each** environment it scans. Without this the scanner falls back to
+   the unverified BAP path (likely `Unknown`).
+4. **Centralized cloud flow** cannot read every environment's `organization`
+   table through one Dataverse connection; the standalone scanner is the
+   reference implementation for the authoritative read.
+
+## 8. Lab-readiness assessment
+
+**Conditionally lab-ready.** Static validation passes (all scripts parse/compile;
+no language violations; schema/option-set names consistent). The core
+data-acquisition correctness gap — reading inactivity timeout from an
+undocumented BAP field instead of the authoritative Dataverse `organization`
+integer-minutes column — has been corrected in the PowerShell scanner and
+documented across the flow guide and README.
+
+Before production use, a maintainer must validate items in §7 against a live
+tenant (especially per-environment Dataverse application-user permissions and
+the BAP token audience). The centralized cloud flow remains documentation-only
+and should be reconciled to the authoritative source in a future release.

--- a/inactivity-timeout-enforcement/README.md
+++ b/inactivity-timeout-enforcement/README.md
@@ -74,7 +74,7 @@ inactivity-timeout-enforcement/
 
 ## Microsoft Learn 2026-Q2 scope notes
 
-- This solution monitors Power Platform environment **Privacy + Security** inactivity timeout settings surfaced through the Business Application Platform (BAP) admin API and Dataverse evidence tables.
+- This solution monitors Power Platform environment **Privacy + Security** inactivity timeout settings. The **authoritative source** for the inactivity timeout value is the Dataverse `organization` table (`inactivitytimeoutenabled` Boolean / `inactivitytimeoutinmins` Integer minutes; see the [Organization table/entity reference](https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/organization)). The standalone PowerShell scanner reads this value per environment; the BAP Admin API governanceConfiguration shape is retained only as an unverified fallback (see `LAB-VALIDATION.md`).
 - Power Platform **session timeout** is a server-side maximum session length; **inactivity timeout** is a client-side sign-out decision after inactivity. Microsoft Learn notes that Power Apps canvas apps are excluded from the customer engagement app inactivity timeout setting.
 - Microsoft Entra Conditional Access sign-in frequency, persistent browser, app-enforced restrictions, Defender for Cloud Apps session controls, and Continuous Access Evaluation (CAE) are complementary identity/session controls. They are not substitutes for the Power Platform environment inactivity timeout setting scanned here.
 - Copilot Studio agent inactivity handling should be implemented with agent/topic lifecycle patterns such as the Teams channel inactivity trigger; those agent conversation resets are outside this environment-level scanner.

--- a/inactivity-timeout-enforcement/docs/flow-configuration.md
+++ b/inactivity-timeout-enforcement/docs/flow-configuration.md
@@ -158,10 +158,12 @@ Environments are classified into governance zones with tailored maximum timeout 
      - Extract environment name (canonical ID) and display name
      - Resolve policy from cached array by environment ID
      - **If policy exists:**
-       - Call the BAP **Governance Configuration** API:
-       `https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/{environmentName}/governanceConfiguration?api-version=2021-04-01`
-     - Parse `properties.settings.inactivityTimeoutEnabled` (boolean) and `properties.settings.inactivityTimeoutDuration` (ISO 8601). For backward compatibility with older API responses, also accept `sessionTimeoutEnabled` / `sessionTimeoutInactivityDuration`.
-       - Convert ISO 8601 duration to minutes (handles `PT60M`, `PT2H`, `PT1H30M` formats)
+       - Determine the inactivity timeout for the environment. **Authoritative source:** the inactivity timeout that administrators configure under Power Platform admin center > Environment > Settings > Product > **Privacy + Security** is persisted on the Dataverse **organization** table as `inactivitytimeoutenabled` (Boolean) and `inactivitytimeoutinmins` (Integer minutes). Reference: [Organization table/entity reference](https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/organization). The value is stored in **whole minutes** -- no ISO 8601 parsing is required.
+       - The standalone PowerShell scanner reads this organization-table value directly per environment. A single centralized cloud flow uses one Dataverse connection bound to one environment, so reading every environment's organization table from one flow requires either (a) a per-environment Dataverse connection, or (b) Microsoft Graph / admin tooling that surfaces the setting tenant-wide.
+       - **Unverified fallback:** the BAP **Governance Configuration** API
+       (`https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/{environmentName}/governanceConfiguration?api-version=2021-04-01`)
+       is documented for Managed Environment governance settings. Microsoft has **not** documented inactivity timeout fields (`inactivityTimeoutEnabled` / `inactivityTimeoutDuration`) on this endpoint; treat it as best-effort and validate against a live tenant before relying on it. See `LAB-VALIDATION.md`.
+       - Convert any ISO 8601 duration to minutes (handles `PT60M`, `PT2H`, `PT1H30M` formats) when reading the BAP fallback shape; organization-table values are already in minutes.
        - **Evaluate compliance:**
          - If timeout not explicitly enabled (disabled or null) → **Non-Compliant**
          - If timeout enabled but duration is null (indeterminate) → **Unknown**
@@ -199,7 +201,7 @@ Microsoft Learn distinguishes several session-control layers that are complement
 | Control layer | Current Microsoft guidance | ITE treatment |
 |---------------|----------------------------|---------------|
 | **Power Platform session timeout** | Server-side maximum session length for customer engagement apps. Defaults include a 1,440-minute maximum session length and a 60-minute minimum session length. | Adjacent absolute timeout. Use PPAC **Privacy + Security** settings for maximum session length; this solution focuses on inactivity timeout evidence. |
-| **Power Platform inactivity timeout** | Client-side sign-out decision after inactivity. Default behavior doesn't enforce inactivity timeout, and Microsoft Learn lists exclusions such as Power Apps canvas apps. | Primary scanned setting through BAP governance configuration (`inactivityTimeoutEnabled` / `inactivityTimeoutDuration`). |
+| **Power Platform inactivity timeout** | Client-side sign-out decision after inactivity. Default behavior doesn't enforce inactivity timeout, and Microsoft Learn lists exclusions such as Power Apps canvas apps. | Primary scanned setting. **Authoritative source:** Dataverse `organization` table (`inactivitytimeoutenabled` Boolean / `inactivitytimeoutinmins` Integer minutes). The BAP governanceConfiguration shape (`inactivityTimeoutEnabled` / `inactivityTimeoutDuration`) is retained only as an unverified fallback. |
 | **Microsoft 365 idle session timeout** | Tenant-wide idle timeout for supported Microsoft 365 web apps; it doesn't affect Microsoft 365 desktop or mobile apps and can be paired with app-enforced restrictions for unmanaged devices. | Complementary evidence source; not scanned by this solution. |
 | **Conditional Access sign-in frequency** | Absolute reauthentication frequency, with `frequencyInterval` values such as `timeBased` and `everyTime` in Microsoft Graph. It isn't an idle timer. | Complementary Conditional Access posture; not a substitute for Power Platform inactivity timeout. |
 | **Conditional Access session controls** | Microsoft Graph v1.0 exposes `signInFrequency`, `persistentBrowser`, `cloudAppSecurity`, `applicationEnforcedRestrictions`, and `disableResilienceDefaults` under `/identity/conditionalAccess/policies`. | Future companion scanner candidate; no current ITE writes or reads from Conditional Access policy objects. |
@@ -743,7 +745,7 @@ Notes: Inactivity timeout is enabled but duration is null — indeterminate stat
 
 ## Appendix: ISO 8601 Duration Parsing
 
-The solution parses ISO 8601 duration strings from the BAP Privacy Settings API response (`inactivityTimeoutDuration` field) and converts them to minutes for compliance evaluation.
+The solution parses ISO 8601 duration strings only when reading the **unverified BAP governanceConfiguration fallback** shape (`inactivityTimeoutDuration` field) and converts them to minutes for compliance evaluation. When reading the authoritative Dataverse `organization` table, the value (`inactivitytimeoutinmins`) is already an integer number of minutes and requires no parsing.
 
 **Supported Formats:**
 

--- a/inactivity-timeout-enforcement/scripts/governance/Invoke-TimeoutComplianceScan.ps1
+++ b/inactivity-timeout-enforcement/scripts/governance/Invoke-TimeoutComplianceScan.ps1
@@ -13,10 +13,14 @@
 
     For each environment the script:
     1. Authenticates to Power Platform Admin API via managed identity by default, with legacy client-secret fallback for development
-    2. Enumerates environments (with optional sandbox exclusion and name filtering)
+    2. Enumerates environments (with optional sandbox exclusion and name filtering), capturing each environment's Dataverse instance URL
     3. Classifies each environment into a governance zone via ELM lookup or naming convention
-    4. Retrieves privacy/governance settings from BAP Admin API
-    5. Parses inactivity timeout configuration (enabled state and ISO 8601 duration)
+    4. Retrieves the inactivity timeout setting -- preferring the authoritative
+       Dataverse organization table (inactivitytimeoutenabled / inactivitytimeoutinmins),
+       and falling back to the BAP Admin API governanceConfiguration endpoint
+       only when the organization table cannot be read
+    5. Normalizes the inactivity timeout to whole minutes (organization table values
+       are already integer minutes; BAP fallback values are parsed from ISO 8601)
     6. Loads zone policy via Get-ExpectedTimeoutPolicy
     7. Evaluates compliance:
        - Compliant: enabled AND duration within zone maximum
@@ -420,10 +424,19 @@ function Invoke-TimeoutComplianceScan {
                 $displayName = if ($props.displayName) { $props.displayName } elseif ($item.displayName) { $item.displayName } else { $envId }
                 $environmentType = if ($props.environmentSku) { $props.environmentSku } elseif ($props.environmentType) { $props.environmentType } elseif ($item.environmentType) { $item.environmentType } else { '' }
 
+                # Dataverse instance (organization) URL for the linked environment.
+                # This is the authoritative source for the inactivity timeout
+                # System Setting (organization.inactivitytimeoutenabled /
+                # organization.inactivitytimeoutinmins). Environments without a
+                # provisioned Dataverse database expose no instance URL.
+                $linked = $props.linkedEnvironmentMetadata
+                $instanceUrl = if ($linked.instanceUrl) { $linked.instanceUrl } elseif ($linked.instanceApiUrl) { $linked.instanceApiUrl } else { $null }
+
                 [void]$allEnvironments.Add([PSCustomObject]@{
                     EnvironmentName = $envId
                     DisplayName     = $displayName
                     EnvironmentType = $environmentType
+                    InstanceUrl     = $instanceUrl
                 })
             }
 
@@ -451,6 +464,91 @@ function Invoke-TimeoutComplianceScan {
     }
 
     Write-Host "  Found $($environments.Count) environment(s) to scan (of $($allEnvironments.Count) total)"
+
+    #endregion
+
+    #region Authoritative Inactivity Timeout Source (Dataverse organization table)
+
+    # Per-resource Dataverse token cache so repeated organization reads across
+    # environments reuse a single token per instance host.
+    $dvResourceTokenCache = @{}
+
+    function Get-DataverseResourceToken {
+        param([Parameter(Mandatory = $true)][string]$ResourceUrl)
+
+        $key = $ResourceUrl.TrimEnd('/')
+        if ($dvResourceTokenCache.ContainsKey($key)) {
+            return $dvResourceTokenCache[$key]
+        }
+
+        $token = $null
+        if ($useManagedIdentityAuth) {
+            $token = Get-IteManagedIdentityToken `
+                -ResourceUrl $key `
+                -TenantId $TenantId `
+                -ManagedIdentityClientId $ManagedIdentityClientId
+        }
+        else {
+            # legacy: dev-only -- replace with managed identity in production
+            $body = @{
+                grant_type    = 'client_credentials'
+                client_id     = $ClientId
+                client_secret = $plainSecret
+                scope         = "$key/.default"
+            }
+            $resp = Invoke-RestMethod `
+                -Uri "https://login.microsoftonline.com/$TenantId/oauth2/v2.0/token" `
+                -Method Post `
+                -ContentType 'application/x-www-form-urlencoded' `
+                -Body $body `
+                -ErrorAction Stop
+            $token = $resp.access_token
+        }
+
+        $dvResourceTokenCache[$key] = $token
+        return $token
+    }
+
+    function Get-OrganizationInactivityTimeout {
+        <#
+        .SYNOPSIS
+            Reads the authoritative inactivity timeout System Setting from a
+            Dataverse environment's organization table.
+        .DESCRIPTION
+            The inactivity timeout that administrators configure under Power
+            Platform admin center > Environment > Settings > Product >
+            Privacy + Security is persisted on the Dataverse organization
+            table as inactivitytimeoutenabled (Boolean) and
+            inactivitytimeoutinmins (Integer minutes). This is the documented
+            source of truth -- the value is stored in whole minutes, not as an
+            ISO 8601 duration. See:
+            https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/organization
+        .OUTPUTS
+            PSCustomObject with Enabled (bool) and Minutes (int; -1 when
+            disabled or unset).
+        #>
+        param([Parameter(Mandatory = $true)][string]$InstanceUrl)
+
+        $base = $InstanceUrl.TrimEnd('/')
+        $token = Get-DataverseResourceToken -ResourceUrl $base
+        $headers = @{
+            'Authorization'    = "Bearer $token"
+            'Accept'           = 'application/json'
+            'OData-MaxVersion' = '4.0'
+            'OData-Version'    = '4.0'
+        }
+        $url = "$base/api/data/v9.2/organizations?`$select=inactivitytimeoutenabled,inactivitytimeoutinmins"
+        $resp = Invoke-RestMethod -Uri $url -Headers $headers -Method Get -ErrorAction Stop
+        $org = @($resp.value)[0]
+
+        $enabled = [bool]$org.inactivitytimeoutenabled
+        $minutes = if ($enabled -and $null -ne $org.inactivitytimeoutinmins) { [int]$org.inactivitytimeoutinmins } else { -1 }
+
+        return [PSCustomObject]@{
+            Enabled = $enabled
+            Minutes = $minutes
+        }
+    }
 
     #endregion
 
@@ -505,12 +603,41 @@ function Invoke-TimeoutComplianceScan {
 
         $policy = & $policyScript -Zone $zone
 
-        # Retrieve governance configuration from BAP Admin API
+        # Retrieve inactivity timeout configuration.
         $timeoutEnabled = $null
         $timeoutDuration = $null
         $timeoutMinutes = -1
         $apiError = $null
+        $dataSource = 'None'
 
+        # Primary (authoritative): read the inactivity timeout System Setting
+        # directly from the environment's Dataverse organization table. The
+        # value is stored as inactivitytimeoutenabled (Boolean) and
+        # inactivitytimeoutinmins (Integer minutes) -- no ISO 8601 parsing is
+        # required. See Get-OrganizationInactivityTimeout for the citation.
+        if ($environment.InstanceUrl) {
+            try {
+                $orgTimeout = Get-OrganizationInactivityTimeout -InstanceUrl $environment.InstanceUrl
+                $timeoutEnabled = $orgTimeout.Enabled
+                if ($orgTimeout.Enabled -and $orgTimeout.Minutes -ge 0) {
+                    $timeoutMinutes  = $orgTimeout.Minutes
+                    $timeoutDuration = "PT$($orgTimeout.Minutes)M"
+                }
+                $dataSource = 'DataverseOrganization'
+                Write-Verbose "  Inactivity timeout read from Dataverse organization table (enabled=$($orgTimeout.Enabled), minutes=$($orgTimeout.Minutes))"
+            }
+            catch {
+                Write-Verbose "  Organization-table read failed for $envName; falling back to BAP governanceConfiguration: $($_.Exception.Message)"
+            }
+        }
+
+        # Fallback (unverified across tenants): the BAP Admin API
+        # governanceConfiguration endpoint. Microsoft has not documented
+        # inactivity timeout fields on this endpoint, so this path is retained
+        # only as a best-effort fallback for environments where the Dataverse
+        # organization table could not be read. Validate against a live tenant
+        # before relying on it. See LAB-VALIDATION.md.
+        if ($dataSource -ne 'DataverseOrganization') {
         try {
             $govConfigUrl = "$($BapApiBaseUrl.TrimEnd('/'))/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/$envId/governanceConfiguration?api-version=2021-04-01"
 
@@ -520,10 +647,7 @@ function Invoke-TimeoutComplianceScan {
                 -Method Get `
                 -ErrorAction Stop
 
-            # Parse governance settings for inactivity timeout. The
-            # `governanceConfiguration` API exposes inactivity timeouts under
-            # `properties.settings` as `inactivityTimeoutEnabled` (boolean) and
-            # `inactivityTimeoutDuration` (ISO 8601 duration). Older responses
+            # Parse governance settings for inactivity timeout. Older responses
             # may use `sessionTimeoutEnabled` / `sessionTimeoutInactivityDuration`,
             # so we accept either to be resilient across API versions.
             $privacySettings = $govResponse.properties.settings
@@ -542,6 +666,7 @@ function Invoke-TimeoutComplianceScan {
                 if ($timeoutEnabled -and $timeoutDuration) {
                     $timeoutMinutes = ConvertFrom-Iso8601Duration -Duration $timeoutDuration
                 }
+                $dataSource = 'BapGovernanceConfiguration'
             }
         }
         catch {
@@ -571,6 +696,7 @@ function Invoke-TimeoutComplianceScan {
                 ErrorTime       = (Get-Date -Format 'o')
             })
         }
+        } # end BAP governanceConfiguration fallback
 
         # Evaluate compliance
         $complianceStatus = 'Unknown'
@@ -624,6 +750,7 @@ function Invoke-TimeoutComplianceScan {
             Severity               = if ($complianceStatus -eq 'NonCompliant') { $policy.ViolationSeverity } elseif ($complianceStatus -eq 'Unknown') { 'Warning' } else { 'Info' }
             RegulatoryContext      = ($policy.RegulatoryContext -join '; ')
             Details                = $details
+            DataSource             = $dataSource
             ScanTime               = $scanStartTime
         }
 


### PR DESCRIPTION
## Summary
Brings **inactivity-timeout-enforcement** (v1.1.2) to a lab-ready steady state via static validation (no live tenant). Full evidence in LAB-VALIDATION.md.

## Central finding & fix
The inactivity timeout value is stored as an **integer number of minutes** on the Dataverse `organization` table (`inactivitytimeoutenabled` Boolean / `inactivitytimeoutinmins` Integer) — **not** as an ISO 8601 duration on the BAP Admin API `governanceConfiguration` endpoint (which Microsoft does not document as carrying inactivity timeout fields). Left unaddressed, a real-tenant scan would classify every environment `Unknown`.

- `Invoke-TimeoutComplianceScan.ps1` now reads the authoritative `organization` table per environment (captures the Dataverse instance URL during enumeration; new `Get-DataverseResourceToken` + `Get-OrganizationInactivityTimeout` helpers; integer minutes, no ISO parsing). The BAP path is retained only as a `try/catch`-guarded, clearly-labelled fallback. Results gain a `DataSource` field.
- `docs/flow-configuration.md` and `README.md` reframed to the authoritative source; ISO 8601 appendix scoped to the fallback.
- Added `LAB-VALIDATION.md`.

## Sources (4)
- Power Platform user-session-management; settings-privacy-security
- Dataverse `organization` table reference (data types)
- Microsoft Graph v1.0 Conditional Access session controls (cross-check)

## Validation
- All 5 `.ps1` parse (0 errors); all 3 `.py` compile; no prohibited compliance language; option-set integers/logical names consistent with schema. `manifest.yaml` untouched.

## Runtime-only caveats
BAP token audience, `linkedEnvironmentMetadata.instanceUrl` field name, and per-environment Dataverse application-user read permissions require live-tenant confirmation. The centralized cloud flow stays documentation-only (single-Dataverse-connection constraint).
