### PR TITLE
fix(model-risk-management-automation): lab-readiness validation and corrections

### DIFF
--- a/model-risk-management-automation/LAB-VALIDATION.md
+++ b/model-risk-management-automation/LAB-VALIDATION.md
@@ -1,0 +1,112 @@
+# Lab Validation Report — Model Risk Management Automation
+
+> **Solution:** `model-risk-management-automation` · **Version:** v1.0.4
+> **Validation date:** 2026-06-04 · **Mode:** Static (no live tenant) — parse-validity, authoritative-source verification, doc completeness
+> **Verdict:** **Lab-ready** with documented runtime-only caveats.
+
+## Purpose & Controls
+
+Automated OCC / Fed model risk management (MRM) workflows for AI agents on Power
+Platform: model inventory submission, risk scoring, independent validation
+workflows, ongoing monitoring, and examiner-facing Agent Card generation.
+
+- **Primary control:** 2.6 — Model Risk Management
+- **Secondary controls:** 2.5, 2.9, 2.11, 2.13, 3.1, 1.2
+
+## What Was Checked
+
+| Area | Method | Result |
+|------|--------|--------|
+| Python scripts (5) | `python -m py_compile` | Pass — all compile |
+| PowerShell scripts (2) | `Parser::ParseFile` (zero errors) | Pass after fixes |
+| Dataverse column / option-set references | Cross-checked every `$select`/`$filter` against `create_mrm_dataverse_schema.py` and `docs/dataverse-schema.md` | Consistent |
+| Option-set value drift (0/1/2 vs 100000000+) | Reviewed all picklist references in scripts and docs | No drift — all use 100000000-base integers |
+| Regulatory citations (OCC / Fed SR) | Authoritative web verification | Accurate (see below) |
+| Language rules (prohibited absolute-compliance phrasing) | grep across all `*.md` | Zero violations |
+| Agent Card generation | Reviewed template + Flow 5 build steps | Internal MRM evidence JSON (not external A2A/manifest schema) — appropriate |
+| Auth model / token audiences | Reviewed both PowerShell scripts + Python shared client | Managed-identity-first; SecureString bug fixed |
+| Graph / Power Platform / Agent 365 API references | Cross-checked against docs; preview APIs feature-flagged | Appropriately hedged |
+
+## Authoritative Sources Cited
+
+- **Federal Reserve SR 26-2** (the agency's own supervisory letter): confirms
+  Revised Interagency Guidance on Model Risk Management, issued April 17, 2026,
+  supersedes/rescinds SR 11-7, and that generative/agentic AI is excluded from
+  scope — https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm
+- **OCC Bulletin 2026-13 / FDIC** corroboration (legal advisories):
+  https://www.sullcrom.com/insights/memo/2026/April/OCC-Fed-FDIC-Issue-Revised-Guidance-Model-Risk-Management ,
+  https://www.davispolk.com/insights/client-update/visual-memo-key-changes-under-federal-banking-agencies-revised-model-risk
+- **`Get-AzAccessToken` returns `SecureString` from Az.Accounts 5.0.0+** —
+  https://learn.microsoft.com/powershell/azure/protect-secrets and
+  https://learn.microsoft.com/powershell/module/az.accounts/get-azaccesstoken
+  (syntax shows `-AsSecureString`). Cross-confirmed by the Microsoft Graph
+  PowerShell IDX14102 troubleshooting article, which states the SecureString
+  change began at Az.Accounts 5.0.0.
+
+The README/manifest's regulatory framing — "OCC Bulletin 2026-13 (formerly OCC
+2011-12) / Fed SR 26-2 (formerly Fed SR 11-7)" with the GenAI/agentic-AI scope
+exclusion note — matches the authoritative sources. No regulatory-citation
+changes were required.
+
+## Gaps Found & Fixes Applied
+
+### Fixed (scripts)
+
+1. **`Deploy-MRM-Baseline.ps1` — broken OData query (functional bug).**
+   Lines building `$agentQuery` used `"?$filter=..."` and `"&$select=..."`
+   inside double-quoted strings, so PowerShell interpolated `$filter`/`$select`
+   as undefined variables (empty), producing a malformed URL
+   (`...?=...&=...`). Backtick-escaped to `` `$filter `` / `` `$select `` so the
+   query renders as `?$filter=...&$select=...`. (The sibling query at the
+   `fsi_modelinventories` step was already correctly escaped.)
+
+2. **`Deploy-MRM-Baseline.ps1` & `Test-MRMCompliance.ps1` — SecureString token
+   handling (auth break on current Az modules).** Both used
+   `(Get-AzAccessToken -ResourceUrl ...).Token` directly in `"Bearer $dvToken"`.
+   On **Az.Accounts 5.0.0+** (current GA), `.Token` is a `SecureString`, which
+   stringifies to `System.Security.SecureString` and breaks the Authorization
+   header. Changed to request `-AsSecureString` explicitly and convert via
+   `[System.Net.NetworkCredential]::new('', $secureToken).Password`. This is
+   forward/backward compatible across module versions and follows the
+   Microsoft-documented conversion guidance.
+
+### Verified clean (no change needed)
+
+- `Test-MRMCompliance.ps1` option-set defaults (`Validated=100000006`,
+  `Severity Critical=100000001`, `Remediation Closed=100000004`,
+  `Tier1=100000001`) all match the schema.
+- Entity-set pluralizations (`fsi_modelinventories`, `fsi_validationcycles`,
+  `fsi_validationfindings`, `fsi_monitoringrecords`, `fsi_mrmcomplianceevents`)
+  are correct.
+- `docs/troubleshooting.md` and `docs/flow-configuration.md` OData queries use
+  correct lookup columns (`_fsi_modelinventory_lookup_value`) and integer
+  option-set values — prior council fixes intact.
+- No prohibited absolute-compliance language anywhere in the solution docs.
+
+## Runtime-Only Caveats (cannot be statically verified)
+
+- **No live tenant** — token acquisition, Dataverse reads/writes, flow execution,
+  SharePoint Agent Card upload, and Word Online generation were not executed.
+- **OptionSet integers are deployment-dependent.** Dataverse may assign
+  different integers if option sets are created in a different order. Both
+  PowerShell scripts and the flow docs already warn operators to confirm values
+  against the deployed solution XML and record them in `DELIVERY-CHECKLIST.md`.
+- **Agent 365 / Microsoft Entra Agent ID enrichment is preview.** Permission
+  names (`CopilotPackages.Read.All`, `AgentInstance.Read.All`) and the beta paths
+  (`/beta/copilot/admin/catalog/packages`, `/agentRegistry/agentInstances`) are
+  emerging surfaces. The solution gates them behind `IsAgent365LifecycleEnabled`
+  (default `false`) and documents "use the API path your tenant has approved" —
+  operators must verify against current Microsoft Learn at deployment time.
+- **`PowerPlatform.Admin.Read.All`** is documented as illustrative; confirm the
+  exact Power Platform API scope your tenant exposes during managed-identity setup.
+
+## Final Assessment
+
+**Lab-ready.** Two genuine defects in the operational PowerShell scripts (a
+malformed OData query and SecureString token handling that would break on the
+current Az.Accounts GA) were repaired and verified. All Dataverse column and
+option-set references are consistent with the schema source of truth, regulatory
+citations are accurate against authoritative agency sources, and there are no
+language-rule violations. Remaining items are runtime/preview verifications that
+require a live tenant and are already flagged for operators in the delivery
+checklist and prerequisites.

--- a/model-risk-management-automation/scripts/Deploy-MRM-Baseline.ps1
+++ b/model-risk-management-automation/scripts/Deploy-MRM-Baseline.ps1
@@ -40,7 +40,12 @@ $ErrorActionPreference = 'Stop'
 # Authenticate via Managed Identity
 Connect-AzAccount -Identity
 
-$dvToken = (Get-AzAccessToken -ResourceUrl $DataverseEnvironmentUrl).Token
+# Az.Accounts 5.0.0+ returns the token as a SecureString by default; request it
+# explicitly and convert for the Authorization header so this works on both the
+# legacy (plain String) and current (SecureString) module versions.
+# Ref: https://learn.microsoft.com/powershell/azure/protect-secrets
+$secureToken = (Get-AzAccessToken -ResourceUrl $DataverseEnvironmentUrl -AsSecureString).Token
+$dvToken = [System.Net.NetworkCredential]::new('', $secureToken).Password
 
 $dvHeaders = @{ Authorization = "Bearer $dvToken"; "Content-Type" = "application/json" }
 
@@ -49,9 +54,11 @@ Write-Warning "DELIVERY-CHECKLIST ITEM: Confirm entity set name 'fsi_agentinvent
 
 # Query agent inventory from agent-registry-automation
 $agentEntitySet = "fsi_agentinventories"
+# Backtick-escape the OData $filter/$select tokens so PowerShell does not treat
+# them as variable interpolation inside the double-quoted strings.
 $agentQuery = "$DataverseEnvironmentUrl/api/data/v9.2/$agentEntitySet" +
-              "?$filter=fsi_registrationstatus eq 100000002" +     # 100000002 = Registered (option set fsi_ara_registrationstatus is 0-based: NotRegistered=100000000, PendingApproval=100000001, Registered=100000002, Quarantined=100000003)
-              "&$select=fsi_agentid,fsi_agentname,fsi_environmentid," +
+              "?`$filter=fsi_registrationstatus eq 100000002" +     # 100000002 = Registered (option set fsi_ara_registrationstatus is 0-based: NotRegistered=100000000, PendingApproval=100000001, Registered=100000002, Quarantined=100000003)
+              "&`$select=fsi_agentid,fsi_agentname,fsi_environmentid," +
               "fsi_ownerupn,fsi_zone,fsi_lastscannedat"    # agent-registry-automation columns: fsi_zone (not fsi_governancezone); fsi_lastscannedat (no fsi_lastactivitydate column exists)
 
 try {

--- a/model-risk-management-automation/scripts/Test-MRMCompliance.ps1
+++ b/model-risk-management-automation/scripts/Test-MRMCompliance.ps1
@@ -64,7 +64,12 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 Connect-AzAccount -Identity
-$dvToken = (Get-AzAccessToken -ResourceUrl $DataverseEnvironmentUrl).Token
+# Az.Accounts 5.0.0+ returns the token as a SecureString by default; request it
+# explicitly and convert for the Authorization header so this works on both the
+# legacy (plain String) and current (SecureString) module versions.
+# Ref: https://learn.microsoft.com/powershell/azure/protect-secrets
+$secureToken = (Get-AzAccessToken -ResourceUrl $DataverseEnvironmentUrl -AsSecureString).Token
+$dvToken = [System.Net.NetworkCredential]::new('', $secureToken).Password
 $dvHeaders = @{ Authorization = "Bearer $dvToken"; "Content-Type" = "application/json" }
 
 # OptionSet dependency warning


### PR DESCRIPTION
## Summary

Static lab-readiness validation of **model-risk-management-automation** (v1.0.4). No live tenant — parse-validity, authoritative-source verification, and doc completeness. Fixes two genuine defects in the operational PowerShell scripts and adds an evidence report (`LAB-VALIDATION.md`).

## Fixes (what & why)

1. **`Deploy-MRM-Baseline.ps1` — malformed OData query.** `?$filter=` and `&$select=` were written without backtick escaping inside double-quoted strings, so PowerShell interpolated ``/`` as undefined variables, producing `...?=...&=...`. Backtick-escaped so the query renders correctly. (Sibling `fsi_modelinventories` query was already escaped.)
2. **`Deploy-MRM-Baseline.ps1` & `Test-MRMCompliance.ps1` — SecureString token.** Both used `(Get-AzAccessToken -ResourceUrl ...).Token` directly in the Bearer header. On **Az.Accounts 5.0.0+** (current GA) `.Token` is a `SecureString` and stringifies to `System.Security.SecureString`, breaking auth. Now request `-AsSecureString` and convert via `NetworkCredential` — compatible across module versions.

## Verified clean (no change needed)

- Every ``/`` column and option-set integer matches `create_mrm_dataverse_schema.py` / `docs/dataverse-schema.md`; entity-set pluralizations correct.
- OCC Bulletin 2026-13 / Fed SR 26-2 citations and the GenAI/agentic-AI scope-exclusion note are **accurate** per the Federal Reserve SR 26-2 letter and corroborating advisories.
- Zero language-rule violations; all Python compiles; both PS scripts parse clean.

## Authoritative sources

- Federal Reserve SR 26-2: https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm
- `Get-AzAccessToken` SecureString change (Az.Accounts 5.0.0+): https://learn.microsoft.com/powershell/azure/protect-secrets

## Caveats (runtime/preview only)

No live tenant — token acquisition, Dataverse I/O, flow execution, SharePoint/Word Agent Card generation untested. OptionSet integers are deployment-dependent (operators confirm against solution XML). Agent 365 / Entra Agent ID enrichment APIs are preview and feature-flagged off by default.

**Verdict: lab-ready.** See `model-risk-management-automation/LAB-VALIDATION.md`.