### PR TITLE
fix(pipeline-governance-cleanup): lab-readiness validation and corrections

### DIFF
--- a/pipeline-governance-cleanup/.ralph-config.json
+++ b/pipeline-governance-cleanup/.ralph-config.json
@@ -2,8 +2,9 @@
   "domainFacts": [
     "The Dataverse deploymentpipeline table has no direct host-environment reference; host association is implicit from the environment where the table resides.",
     "Get-PipelineInventory.ps1 -ProbePipelines output is directional only because pac pipeline list text parsing can produce false negatives; manual validation in Deployment Pipeline Configuration remains required.",
-    "The README optional PipelineCleanupLog table still lists scheduledremovaldate, while notification templates and automation guidance use enforcementdate; future edits should reconcile the column name before adding flow logic.",
-    "Script banner versions lagged the manifest in council review: Get-PipelineInventory.ps1 showed 1.2.0 and Send-OwnerNotifications.ps1 showed 1.1.0 while the solution version was 1.2.1.",
+    "Resolved 2026-06: the README optional PipelineCleanupLog table now uses enforcementdate (was scheduledremovaldate), matching notification templates and automation guidance.",
+    "Resolved 2026-06: script banners aligned to manifest version 1.2.1 (Get-PipelineInventory.ps1 and Send-OwnerNotifications.ps1 previously lagged at 1.2.0 and 1.1.0).",
+    "pac admin set-governance-config requires --protection-level and supports --solution-checker-mode (none/warn/block); it does NOT have --enable-pipelines or --disable-unmanaged-customizations, and there is no pac governance-config get command. Verified against Microsoft Learn pac admin reference 2026-06.",
     "This solution is intentionally PowerShell/manual guidance only and does not ship Dataverse schema generators or Power Platform exported flow JSON."
   ]
 }

--- a/pipeline-governance-cleanup/CHANGELOG.md
+++ b/pipeline-governance-cleanup/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **Lab-readiness validation (2026-06):** Corrected `Set-GovernanceConfig.ps1` to use only valid `pac admin set-governance-config` parameters. The script previously omitted the **required** `--protection-level` parameter and passed two parameters that do not exist in the current `pac` CLI (`--disable-unmanaged-customizations`, `--enable-pipelines`), so every invocation would have failed. Added a `-ProtectionLevel` parameter (Standard/Basic, default Standard), added `none` to the solution-checker mode set, and removed the invalid switches. Verified against [pac admin reference](https://learn.microsoft.com/power-platform/developer/cli/reference/admin#pac-admin-set-governance-config).
+- **Set-GovernanceConfig.ps1 verification step:** Removed the call to `pac admin governance-config get`, which is not a valid `pac` command. The script now directs the operator to verify settings in the Power Platform Admin Center.
+- **docs/automation-guide.md:** Updated the Managed Environment governance section, configuration-flags table, examples, and verification step to match the corrected `Set-GovernanceConfig.ps1` and the supported `pac` parameters; added a scope note clarifying that deployment-pipeline enablement is not performed by this command.
+- **README.md:** Reconciled the optional `PipelineCleanupLog` tracking-table column `scheduledremovaldate` to `enforcementdate`, aligning with the notification templates and automation guidance.
+- **Script banners:** Aligned in-script version banners to the manifest version (`Get-PipelineInventory.ps1` 1.2.0 → 1.2.1; `Send-OwnerNotifications.ps1` 1.1.0 → 1.2.1).
 - **Wave 6 P4b:** Empty catch blocks now log via `Write-Verbose` instead of silently swallowing errors. Output is unchanged unless caller passes `-Verbose`.
 - `Send-OwnerNotifications.ps1` nested `Main` function now declares `SupportsShouldProcess`, preserving `-WhatIf` handling for live email sends.
 

--- a/pipeline-governance-cleanup/LAB-VALIDATION.md
+++ b/pipeline-governance-cleanup/LAB-VALIDATION.md
@@ -1,0 +1,114 @@
+# Lab Validation Report — Pipeline Governance Cleanup
+
+**Solution version:** v1.2.1
+**Validation date:** 2026-06-04
+**Validation type:** Static (no live tenant) — parse-validity, authoritative-source verification, doc completeness
+**Primary controls:** 2.3 (ALM governance), 2.1 (environment governance)
+
+## Purpose
+
+Discover, notify, and clean up personal Power Platform deployment pipelines before
+enforcing centralized ALM governance on a custom pipelines host. The solution is
+intentionally PowerShell + manual-guidance only; force-linking environments to a
+custom host requires UI interaction in the Deployment Pipeline Configuration app and
+cannot be automated.
+
+## What was checked
+
+- Three PowerShell scripts (`Get-PipelineInventory.ps1`, `Send-OwnerNotifications.ps1`,
+  `Set-GovernanceConfig.ps1`) — parse validity and command/API correctness.
+- All documented `pac` CLI commands and parameters against the authoritative
+  Microsoft Learn CLI reference.
+- The Dataverse pipeline-table schema documented in `README.md` (table names,
+  logical column names, option-set values) against the authoritative pipeline
+  table reference.
+- Documentation completeness (README Purpose/Prerequisites/Steps/Outcomes),
+  script↔doc consistency, FSI language rules, and the known column-name and
+  version-banner inconsistencies recorded in `.ralph-config.json`.
+
+## Authoritative sources cited
+
+| Topic | URL |
+|-------|-----|
+| Pipeline table reference (deploymentpipeline / deploymentstage / deploymentenvironment, option sets) | https://learn.microsoft.com/power-platform/developer/pipelines/table-reference |
+| `pac admin` reference (set-governance-config, admin list) | https://learn.microsoft.com/power-platform/developer/cli/reference/admin |
+| `pac pipeline` reference (pipeline list/deploy, `--environment`) | https://learn.microsoft.com/power-platform/developer/cli/reference/pipeline |
+| `pac auth` reference (`auth who`, `auth create --managedIdentity`) | https://learn.microsoft.com/power-platform/developer/cli/reference/auth |
+| Overview of pipelines in Power Platform | https://learn.microsoft.com/power-platform/alm/pipelines |
+| Managed Environments overview | https://learn.microsoft.com/power-platform/admin/managed-environment-overview |
+
+## Verified correct (no change required)
+
+- **Dataverse schema (README).** `deploymentpipeline`, `deploymentstage`,
+  `deploymentenvironment` table names, logical column names (including
+  `previousdeploymentstageid`, `targetdeploymentenvironmentid`), and option-set
+  values match the authoritative table reference exactly:
+  `EnvironmentType` 200000000/200000001, `ValidationStatus`
+  200000000/200000001/200000002, `statuscode` 1/2.
+- **`pac admin list --json`** — valid; used by `Get-PipelineInventory.ps1`.
+- **`pac pipeline list --environment`** — valid; `pac pipeline list` does not
+  support `--json`, so the script's text-parsing approach and its "directional
+  only" caveat are accurate.
+- **`pac auth who`** and **`pac auth create --managedIdentity`** — valid flags.
+- **`Send-OwnerNotifications.ps1`** Microsoft Graph usage (`Send-MgUserMail` with
+  resolved sender, `Mail.Send` scope, transient-retry on HTTP status + Retry-After)
+  is consistent with current Graph PowerShell behavior.
+
+## Gaps found and fixed
+
+### Scripts
+
+1. **CRITICAL — `Set-GovernanceConfig.ps1` would always fail.** The script built
+   `pac admin set-governance-config` **without** the required `--protection-level`
+   parameter and appended two parameters that do not exist in the current `pac`
+   CLI: `--disable-unmanaged-customizations` and `--enable-pipelines`. Fixed by
+   adding a `-ProtectionLevel` parameter (Standard/Basic, default Standard → maps
+   to the required `--protection-level`), adding `none` to the solution-checker
+   set, and removing the two invalid switches.
+2. **`Set-GovernanceConfig.ps1` verification step used a non-existent command**
+   (`pac admin governance-config get`). Replaced with Power Platform Admin Center
+   verification guidance (no `pac` governance-config read command exists).
+3. **Version-banner drift.** `Get-PipelineInventory.ps1` (1.2.0) and
+   `Send-OwnerNotifications.ps1` (1.1.0) banners lagged the manifest; both set to
+   1.2.1.
+
+### Documentation
+
+4. **`docs/automation-guide.md`** propagated the invalid `-EnablePipelines` /
+   `-DisableUnmanagedCustomizations` examples, an invalid flags table, and the
+   non-existent `pac admin governance-config get` verification command. Rewritten
+   to the supported parameter set with a scope note clarifying that deployment
+   pipelines are enabled by installing the Power Platform Pipelines app and
+   configuring a host environment, not by `set-governance-config`.
+5. **`README.md`** optional `PipelineCleanupLog` table listed `scheduledremovaldate`
+   while the notification templates and automation guide use `enforcementdate`.
+   Reconciled to `enforcementdate`.
+
+### Dependencies / prerequisites
+
+- No dependency changes required. Prerequisites (Power Platform Admin, Deployment
+  Pipeline Administrator role, PAC CLI, Microsoft Graph `Mail.Send` /
+  `User.Read.All`, Power Platform Pipelines app on a custom host) are documented
+  and accurate. `Send-OwnerNotifications.ps1` declares its Graph module
+  dependencies via `#Requires -Modules`.
+
+## Runtime-only caveats (cannot be verified statically)
+
+- Actual `pac admin set-governance-config` execution requires a Power Platform
+  Admin profile and a live tenant; only command shape was validated here.
+- Pipeline detection via `pac pipeline list` text parsing is directional; manual
+  validation in the Deployment Pipeline Configuration app remains required before
+  enforcement, as documented.
+- Microsoft Graph mail send (delegated or application) requires tenant consent and
+  a mailbox; only code paths and parameters were validated.
+- The Feb 2026 Managed Environment auto-enablement behavior for pipeline targets is
+  a platform rollout; verify current state in-tenant before force-linking.
+
+## Lab-readiness assessment
+
+**Lab-ready.** The one blocking correctness defect (`Set-GovernanceConfig.ps1`
+invalid/missing `pac` parameters) is fixed and the documentation now matches the
+supported CLI surface. All three scripts parse cleanly, all documented `pac`
+commands/parameters and the Dataverse schema are confirmed against authoritative
+Microsoft Learn references, and FSI language rules pass. Remaining items are
+inherently runtime/tenant-dependent and are clearly documented as manual steps.

--- a/pipeline-governance-cleanup/README.md
+++ b/pipeline-governance-cleanup/README.md
@@ -230,7 +230,7 @@ For tracking cleanup progress, create a custom table:
 | owneremail | Text | Owner email |
 | discovereddate | DateTime | When discovered |
 | notificationsentdate | DateTime | When owner was notified |
-| scheduledremovaldate | DateTime | Target enforcement date |
+| enforcementdate | DateTime | Target enforcement date |
 | status | Choice | Pending, Notified, ForceLinked, Exempted |
 | notes | Multiline Text | Admin notes |
 

--- a/pipeline-governance-cleanup/docs/automation-guide.md
+++ b/pipeline-governance-cleanup/docs/automation-guide.md
@@ -138,25 +138,26 @@ Sends governance notification emails to environment/pipeline owners.
 
 ## Managed Environment Governance Configuration
 
-Use `pac admin set-governance-config` to enforce governance policies on production Managed Environments. This is recommended before enabling deployment pipelines to prevent unvetted solutions from being imported.
+Use `pac admin set-governance-config` to enforce governance policies on production Managed Environments. This is recommended before deploying solutions through pipelines, to help prevent unvetted solutions from being imported.
 
 **Required role:** Power Platform Admin (or Dynamics 365 admin with environment-level permissions).
+
+> **Scope note:** `pac admin set-governance-config` configures the Managed Environment protection level and solution checker mode only. It does not expose flags to disable unmanaged customizations or to enable deployment pipelines. Deployment pipelines are enabled by installing the Power Platform Pipelines app and configuring a host environment (see the [README Prerequisites](../README.md#prerequisites) and [portal walkthrough](portal-walkthrough.md)).
 
 ### Recommended configuration
 
 ```powershell
-# Apply FSI-recommended governance settings
+# Apply FSI-recommended governance settings (Managed Environment + solution checker warn)
 .\scripts\Set-GovernanceConfig.ps1 `
     -EnvironmentId "00000000-0000-0000-0000-000000000000" `
-    -SolutionCheckerMode "warn" `
-    -EnablePipelines
+    -ProtectionLevel "Standard" `
+    -SolutionCheckerMode "warn"
 
 # For stricter enforcement (blocks imports with critical solution checker findings)
 .\scripts\Set-GovernanceConfig.ps1 `
     -EnvironmentId "00000000-0000-0000-0000-000000000000" `
-    -SolutionCheckerMode "block" `
-    -DisableUnmanagedCustomizations `
-    -EnablePipelines
+    -ProtectionLevel "Standard" `
+    -SolutionCheckerMode "block"
 ```
 
 **Script location:** [`scripts/Set-GovernanceConfig.ps1`](../scripts/Set-GovernanceConfig.ps1)
@@ -165,20 +166,15 @@ Use `pac admin set-governance-config` to enforce governance policies on producti
 
 | Flag | Effect |
 |------|--------|
+| `--protection-level Standard` | Enables Managed Environments for the environment (required parameter) |
+| `--protection-level Basic` | Disables Managed Environments for the environment |
 | `--solution-checker-mode warn` | Logs solution checker findings without blocking import |
 | `--solution-checker-mode block` | Prevents import of solutions with critical findings |
-| `--disable-unmanaged-customizations` | Blocks unmanaged customizations in the environment |
-| `--enable-pipelines` | Enables deployment pipelines for ALM governance |
+| `--solution-checker-mode none` | Disables solution checker validation |
 
 ### Verification
 
-After applying configuration, verify with:
-
-```powershell
-pac admin governance-config get --environment "00000000-0000-0000-0000-000000000000"
-```
-
-If the CLI verification command is unavailable, verify in PPAC: **Environments** → select environment → **Settings** → **Governance**.
+The `pac` CLI does not currently expose a governance-config read command. Verify the applied settings in the Power Platform Admin Center (PPAC): **Environments** → select environment → **Settings** → **Governance**.
 
 > **Note:** Start with `warn` mode in non-production environments to assess solution checker impact before enforcing `block` in production.
 

--- a/pipeline-governance-cleanup/scripts/Get-PipelineInventory.ps1
+++ b/pipeline-governance-cleanup/scripts/Get-PipelineInventory.ps1
@@ -194,7 +194,7 @@ function Test-EnvironmentPipelines {
 function Main {
     Write-Host "================================================" -ForegroundColor Cyan
     Write-Host "  Power Platform Environment Inventory Script" -ForegroundColor Cyan
-    Write-Host "  Version: 1.2.0 - April 2026" -ForegroundColor Cyan
+    Write-Host "  Version: 1.2.1 - June 2026" -ForegroundColor Cyan
     Write-Host "================================================" -ForegroundColor Cyan
     Write-Host ""
 

--- a/pipeline-governance-cleanup/scripts/Send-OwnerNotifications.ps1
+++ b/pipeline-governance-cleanup/scripts/Send-OwnerNotifications.ps1
@@ -309,7 +309,7 @@ function Main {
 
     Write-Host "================================================" -ForegroundColor Cyan
     Write-Host "  Pipeline Governance Notification Script" -ForegroundColor Cyan
-    Write-Host "  Version: 1.1.0 - April 2026" -ForegroundColor Cyan
+    Write-Host "  Version: 1.2.1 - June 2026" -ForegroundColor Cyan
     Write-Host "================================================" -ForegroundColor Cyan
     Write-Host ""
 

--- a/pipeline-governance-cleanup/scripts/Set-GovernanceConfig.ps1
+++ b/pipeline-governance-cleanup/scripts/Set-GovernanceConfig.ps1
@@ -7,30 +7,36 @@
 
 .DESCRIPTION
     Configures Managed Environment governance settings for production environments.
-    This script wraps pac admin set-governance-config with FSI-recommended defaults:
-    - Solution checker enforcement mode (warn or block)
-    - Disable unmanaged solution customizations
-    - Enable deployment pipelines
+    This script wraps `pac admin set-governance-config` with FSI-recommended defaults:
+    - Managed Environment protection level (Standard enables Managed Environments)
+    - Solution checker enforcement mode (none, warn, or block)
 
     IMPORTANT: This script requires the Power Platform Admin role and PAC CLI
     authenticated to the target tenant.
 
-    After applying configuration, the script verifies the settings using
-    pac admin governance-config get (when available) and outputs the result.
+    Scope note: `pac admin set-governance-config` does not expose flags to disable
+    unmanaged customizations or to enable deployment pipelines. Deployment pipelines
+    are enabled by installing the Power Platform Pipelines app and configuring a host
+    environment (see ../README.md Prerequisites and docs/portal-walkthrough.md). This
+    script intentionally configures only the supported managed-environment and
+    solution-checker settings.
+
+    The `pac` CLI does not currently expose a governance-config read command, so the
+    script directs the operator to verify the applied settings in the Power Platform
+    Admin Center.
 
 .PARAMETER EnvironmentId
     Target Power Platform environment ID (GUID).
 
+.PARAMETER ProtectionLevel
+    Managed Environment protection level. 'Standard' enables Managed Environments;
+    'Basic' disables them. This maps to the required `--protection-level` parameter
+    of `pac admin set-governance-config`. Default: Standard
+
 .PARAMETER SolutionCheckerMode
-    Solution checker enforcement mode. 'warn' logs findings without blocking;
-    'block' prevents import of solutions with critical findings.
-    Default: warn
-
-.PARAMETER DisableUnmanagedCustomizations
-    If specified, disables unmanaged solution customizations in the environment.
-
-.PARAMETER EnablePipelines
-    If specified, enables deployment pipelines for the environment.
+    Solution checker enforcement mode. 'none' disables the checker; 'warn' logs
+    findings without blocking; 'block' prevents import of solutions with critical
+    findings. Default: warn
 
 .PARAMETER DryRun
     If specified, prints the commands that would be executed without running them.
@@ -40,7 +46,7 @@
 
 .EXAMPLE
     .\Set-GovernanceConfig.ps1 -EnvironmentId "00000000-0000-0000-0000-000000000000" `
-        -SolutionCheckerMode "block" -DisableUnmanagedCustomizations -EnablePipelines
+        -ProtectionLevel "Standard" -SolutionCheckerMode "block"
 
 .NOTES
     Prerequisites:
@@ -48,6 +54,7 @@
     - Power Platform Admin role
 
     Reference:
+    - https://learn.microsoft.com/power-platform/developer/cli/reference/admin#pac-admin-set-governance-config
     - https://learn.microsoft.com/power-apps/maker/data-platform/use-powerapps-checker
     - https://learn.microsoft.com/power-platform/admin/managed-environment-overview
 #>
@@ -59,14 +66,12 @@ param(
     [string]$EnvironmentId,
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("warn", "block")]
+    [ValidateSet("Standard", "Basic")]
+    [string]$ProtectionLevel = "Standard",
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("none", "warn", "block")]
     [string]$SolutionCheckerMode = "warn",
-
-    [Parameter(Mandatory = $false)]
-    [switch]$DisableUnmanagedCustomizations,
-
-    [Parameter(Mandatory = $false)]
-    [switch]$EnablePipelines,
 
     [Parameter(Mandatory = $false)]
     [switch]$DryRun
@@ -95,16 +100,9 @@ catch {
 $setArgs = @(
     "admin", "set-governance-config",
     "--environment", $EnvironmentId,
+    "--protection-level", $ProtectionLevel,
     "--solution-checker-mode", $SolutionCheckerMode
 )
-
-if ($DisableUnmanagedCustomizations) {
-    $setArgs += "--disable-unmanaged-customizations"
-}
-
-if ($EnablePipelines) {
-    $setArgs += "--enable-pipelines"
-}
 
 $cmdDisplay = "pac $($setArgs -join ' ')"
 
@@ -114,8 +112,8 @@ if ($DryRun) {
     Write-Info "[DRY RUN] Would execute:"
     Write-Host "  $cmdDisplay"
     Write-Host ""
-    Write-Info "[DRY RUN] Would then verify with:"
-    Write-Host "  pac admin governance-config get --environment $EnvironmentId"
+    Write-Info "[DRY RUN] Then verify in the Power Platform Admin Center:"
+    Write-Host "  Environments > $EnvironmentId > Settings > Governance"
     return
 }
 
@@ -135,24 +133,14 @@ Write-Host ($output -join "`n")
 Write-Host ""
 
 # ── Verify ───────────────────────────────────────────────────────────────────
+# The pac CLI does not currently expose a governance-config read command, so
+# verification is a manual step in the Power Platform Admin Center.
 
-Write-Info "Verifying applied configuration..."
-
-$verifyArgs = @("admin", "governance-config", "get", "--environment", $EnvironmentId)
-$verifyOutput = & pac @verifyArgs 2>&1
-$verifyExit = $LASTEXITCODE
-
-if ($verifyExit -ne 0) {
-    Write-Host "[WARN] Verification command not available or failed (exit $verifyExit)." -ForegroundColor Yellow
-    Write-Host "  Manually verify in Power Platform Admin Center:" -ForegroundColor Yellow
-    Write-Host "  Environments > $EnvironmentId > Settings > Governance" -ForegroundColor Yellow
-}
-else {
-    Write-Host ($verifyOutput -join "`n")
-}
+Write-Host ""
+Write-Info "Verify the applied configuration in the Power Platform Admin Center:"
+Write-Host "  Environments > $EnvironmentId > Settings > Governance" -ForegroundColor Yellow
 
 Write-Host ""
 Write-Info "Governance configuration applied to environment $EnvironmentId"
+Write-Info "  Protection level: $ProtectionLevel"
 Write-Info "  Solution checker mode: $SolutionCheckerMode"
-if ($DisableUnmanagedCustomizations) { Write-Info "  Unmanaged customizations: disabled" }
-if ($EnablePipelines) { Write-Info "  Deployment pipelines: enabled" }


### PR DESCRIPTION
## Summary
Lab-readiness validation of the **pipeline-governance-cleanup** solution (v1.2.1, controls 2.3 / 2.1). Static validation only (no live tenant): parse-validity + authoritative Microsoft Learn verification + doc completeness.

## Key fix (correctness blocker)
`Set-GovernanceConfig.ps1` built an invalid `pac admin set-governance-config` call — it **omitted the required `--protection-level`** and passed two parameters that do not exist in the current pac CLI (`--disable-unmanaged-customizations`, `--enable-pipelines`). Every invocation would have failed. The verify step also called a non-existent `pac admin governance-config get` command.

**Fixed:** added `-ProtectionLevel` (Standard/Basic, default Standard), added `none` to solution-checker set, removed the invalid switches, and replaced the verify step with PPAC guidance.

## Other fixes
- `docs/automation-guide.md`: examples, flags table, and verification updated to the supported pac surface; added scope note that pipeline enablement is separate from `set-governance-config`.
- `README.md`: reconciled optional `PipelineCleanupLog` column `scheduledremovaldate` → `enforcementdate` (matches notification templates / automation guide).
- Script version banners aligned to manifest 1.2.1 (were 1.2.0 / 1.1.0).
- Added `LAB-VALIDATION.md` evidence report; refreshed `.ralph-config.json` domain facts.

## Verified correct (no change)
Dataverse pipeline schema in README (table names, logical columns incl. `previousdeploymentstageid`, option sets `EnvironmentType` 200000000/200000001, `ValidationStatus` 200000000/200000001/200000002, `statuscode` 1/2); `pac admin list`, `pac pipeline list --environment`, `pac auth who`, `pac auth create --managedIdentity`.

## Sources (Microsoft Learn)
- pipeline table reference, pac admin, pac pipeline, pac auth references; pipelines overview; Managed Environments overview (URLs in LAB-VALIDATION.md).

## Caveats
Runtime/tenant-dependent items (live pac execution, Graph mail send, Feb 2026 Managed Environment auto-enablement, pipeline-host linkage) remain manual, as documented. manifest.yaml not modified.