### PR TITLE
docs(rag-source-validator): lab-readiness validation and prerequisite corrections

### DIFF
--- a/rag-source-validator/CHANGELOG.md
+++ b/rag-source-validator/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to the RAG Source Validator.
 
 - **Operator ergonomics (Wave 6 P4a):** State-changing scripts now support `-WhatIf` and `-Confirm` switches via `SupportsShouldProcess`. Existing callers see no behavior change unless they explicitly pass `-WhatIf`.
 
+### Fixed
+
+- **Docs (lab-readiness):** Corrected the README **Prerequisites** section. The Licensing table previously listed "Power Platform Premium -- Validation flows," but this solution is script-based and ships no Power Automate flows; replaced with the actual Dataverse-capacity and Azure-compute (Automation / Functions / VM) requirements. Rewrote the **Permissions** table around the managed-identity-first model with concrete, citation-backed grants: Microsoft Graph application permission `Sites.Read.All`/`Files.Read.All` for `driveItem` content retrieval, a Dataverse application user with a security role on the three RSV tables, and `Storage Blob Data Reader` for the optional/planned blob path. Aligned the Deployment step and the Troubleshooting authentication row with the same permission names. `README.md`. (lab-readiness validation)
+
 ## [1.3.1] - 2026-05-23
 
 ### Council Review -- Production-Readiness Fixes

--- a/rag-source-validator/LAB-VALIDATION.md
+++ b/rag-source-validator/LAB-VALIDATION.md
@@ -1,0 +1,53 @@
+# Lab Validation Report — RAG Source Validator
+
+> **Solution:** rag-source-validator · **Version:** v1.3.1 (Unreleased doc fixes)
+> **Controls:** 2.16 (RAG Source Integrity Validation), 1.7 (Comprehensive Audit Logging), 2.13 (Documentation and Record-Keeping)
+> **Validation date:** 2026-06-04 · **Mode:** Static (no live tenant) — parse-validity, authoritative-source verification, doc completeness.
+
+## Purpose
+
+Integrity validation for Retrieval-Augmented Generation (RAG) knowledge sources used by Copilot Studio / Agent Builder agents. The solution computes SHA-256 content hashes for registered knowledge sources, compares against a stored baseline to detect unauthorized changes, records validation history and change audit trails in Dataverse, and exports tamper-evident evidence packages. Supports compliance with SEC Rule 17a-4 (record integrity), FINRA Rule 4511(a) (books and records accuracy), and SOX Section 404 (internal controls over data integrity).
+
+## Scope checked
+
+| Area | What was verified |
+|------|-------------------|
+| Python scripts | `create_rsv_dataverse_schema.py`, `create_rsv_connection_references.py`, `create_rsv_environment_variables.py` — `py_compile` clean; argparse auth-mode surface (`managed-identity`, `workload-identity`, `certificate`, `access-token`, `interactive`, `client-secret`) matches the shared `dataverse_client.py` contract |
+| PowerShell scripts | `Invoke-SourceValidation.ps1`, `governance/Export-ValidationEvidence.ps1`, `governance/Get-SourceValidationSummary.ps1`, `governance/Test-EvidenceIntegrity.ps1` — `Parser::ParseFile` zero errors |
+| Dataverse column names | All OData `$select`/`$filter` references in scripts cross-checked against `create_rsv_dataverse_schema.py` (source of truth) and `docs/dataverse-schema.md` — logical names lowercase, no inter-word underscores, consistent |
+| Option-set values | Compact 1–N values (e.g. `fsi_RSV_sourcetype` 1–13, `fsi_RSV_validationresult` 1–8) are intentional and consistent across schema script, PowerShell integer literals, and docs — confirmed by `.ralph-config.json` domain facts |
+| Authentication | Managed-identity-first; IMDS / App Service MSI endpoints and API versions verified; client-secret path marked `# legacy: dev-only` |
+| Sovereign-cloud parity | Graph/Auth/Dataverse endpoint triples cross-validated in-script; China endpoints aligned on `login.chinacloudapi.cn` (prior council fix M1) |
+| Language rules | grep for the four banned compliance-overclaim phrases across `*.md`/`*.ps1`/`*.py` (excluding CHANGELOG history) — zero hits |
+
+## Authoritative sources cited
+
+1. **Copilot Studio supported knowledge sources** — Public website, Documents (uploaded to Dataverse), SharePoint, Dataverse, Enterprise data via Microsoft Copilot connectors (Microsoft Search). Confirms the README source-type taxonomy. <https://learn.microsoft.com/microsoft-copilot-studio/knowledge-copilot-studio#supported-knowledge-sources>
+2. **Unstructured data as a knowledge source** — SharePoint/OneDrive files and folders; Dataverse stores uploaded files and semantic/vector indexes. <https://learn.microsoft.com/microsoft-copilot-studio/knowledge-unstructured-data>
+3. **Get driveItem content (Microsoft Graph)** — Downloading `driveItem` primary stream requires a Graph permission such as `Files.Read.All` or `Sites.Read.All`. Basis for the corrected Permissions table. <https://learn.microsoft.com/graph/api/driveitem-get-content>
+4. **Use delta query to track changes (Microsoft Graph)** — Validates the README change-detection guidance (delta links, eTag/cTag, `lastModifiedDateTime`). <https://learn.microsoft.com/graph/delta-query-overview>
+5. **Azure Instance Metadata Service / managed identity token acquisition** — Confirms IMDS endpoint `http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=...` and App Service `IDENTITY_ENDPOINT` + `X-IDENTITY-HEADER` with `api-version=2019-08-01`, both used by the scripts. <https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service>
+6. **Dataverse application user + security role (server-to-server)** — The managed identity must be a Dataverse application user mapped to a security role to read/write tables. <https://learn.microsoft.com/power-apps/developer/data-platform/use-multi-tenant-server-server-authentication#create-an-application-user-associated-with-the-registered-application-in-dataverse>
+
+## Gaps found and fixed
+
+| # | Severity | Gap | Fix |
+|---|----------|-----|-----|
+| 1 | Minor (docs) | README Licensing table listed **"Power Platform Premium — Validation flows"**; the solution ships no Power Automate flows (it is script-based, run on Azure compute). Misleading prerequisite. | Replaced the row with the actual requirements: Dataverse capacity (registry + uploaded-document storage) and Azure compute (Automation / Functions / VM) hosting the script via managed identity. Added an explicit "no flows / no canvas apps" statement. `README.md` |
+| 2 | Minor (docs) | Permissions table named only vague roles (`SharePoint Reader`, `Dataverse Reader`, `Storage Blob Reader`) and omitted the concrete Microsoft Graph application permission the managed identity needs to read `driveItem` content — a real prerequisite given the managed-identity-first design. | Rewrote the Permissions table around managed identity with citation-backed grants: Graph `Sites.Read.All`/`Files.Read.All`, a Dataverse application user with a security role on the three RSV tables, and `Storage Blob Data Reader` for the optional blob path. `README.md` |
+| 3 | Trivial (consistency) | Deployment step 2 and the Troubleshooting authentication row referenced generic "Graph permissions" / "SharePoint Reader and Dataverse Reader roles," inconsistent with the corrected Permissions section. | Aligned both to the concrete permission names. `README.md` |
+
+No script logic, schema, option-set, or column changes were required — the code paths and Dataverse references were already correct and internally consistent (the solution has been through three prior council reviews; see CHANGELOG v1.2.0/v1.3.0/v1.3.1).
+
+## Runtime-only caveats (cannot be verified statically)
+
+- **No live tenant:** Token acquisition (IMDS/App Service MSI, client-secret), actual Graph `driveItem` downloads, and Dataverse Web API reads/writes were not executed. Endpoint shapes and permission names are verified against Microsoft Learn but not exercised end-to-end.
+- **Planned source types:** Only SharePoint Document Library (type 1) content validation is implemented; types 2–13 are registered in schema and correctly return `Skipped - Not Implemented` (result 7) or `Unsupported Type` (8). README labels these "Planned" accurately.
+- **Trust-on-first-use baseline:** First-run baseline capture trusts current content; documented as a limitation. Operators must verify source integrity out-of-band.
+- **WORM/immutability:** Validation results are stored in mutable Dataverse records; full SEC Rule 17a-4 WORM compliance requires an external immutable store. Documented in README.
+- **No automated tests:** `Invoke-SourceValidation.ps1` has no unit-test coverage (documented limitation).
+- **Schema package:** No managed/unmanaged solution `.zip` ships; schema is deployed via `create_rsv_dataverse_schema.py` or manual table creation (documented).
+
+## Lab-readiness assessment
+
+**Lab-ready.** The solution parses cleanly (Python + PowerShell), uses managed-identity-first authentication with correct IMDS/Graph/Dataverse endpoints and token audiences, references Dataverse columns and option-set values consistently with its schema source of truth, and honors the FSI language rules. The two documentation gaps that could block a first-time lab deployment — an inaccurate licensing prerequisite and missing concrete identity permissions — are now corrected and citation-backed. Remaining caveats are runtime-only or already-documented design limitations, none of which prevent a lab installation.

--- a/rag-source-validator/README.md
+++ b/rag-source-validator/README.md
@@ -80,22 +80,30 @@ The RAG Source Validator helps verify AI agents use trusted, verified knowledge 
 
 ## Prerequisites
 
-### Licensing
+### Licensing and hosting
+
+This solution is script-based and ships no Power Automate flows or canvas apps. The validator (`Invoke-SourceValidation.ps1`) and governance scripts run as PowerShell 7 on an Azure-hosted compute host (Azure Automation, Azure Functions, or a VM-hosted scheduled job) using its managed identity.
 
 | Requirement | Purpose |
 |-------------|---------|
-| **Power Platform Premium** | Validation flows |
-| **Dataverse capacity** | Source registry |
-| **SharePoint Online** | SharePoint source access |
-| **Azure Storage** | Blob source access (optional) |
+| **Dataverse capacity** | Source registry tables (`fsi_knowledgesource`, `fsi_validationresult`, `fsi_sourcechange`) and Copilot Studio uploaded-document storage |
+| **Azure compute (Automation / Functions / VM)** | Hosts the scheduled validation script with a managed identity |
+| **SharePoint Online** | SharePoint / OneDrive source content access via Microsoft Graph |
+| **Azure Storage** | Azure Blob source access (optional; blob validation is planned, not yet implemented) |
 
 ### Permissions
 
-| Role | Required For |
-|------|--------------|
-| **SharePoint Reader** | Document content access |
-| **Dataverse Reader** | Table data access |
-| **Storage Blob Reader** | Azure Blob access |
+The recommended production path is a system- or user-assigned managed identity. Grant it the following (least-privilege, read-only where possible):
+
+| Identity grant | Scope | Required for |
+|----------------|-------|--------------|
+| **Microsoft Graph application permission `Sites.Read.All`** (or `Files.Read.All`) | Tenant, admin-consented | Reading SharePoint / OneDrive `driveItem` content for hash validation |
+| **Dataverse application user with a security role** granting create/read/write on `fsi_knowledgesource`, `fsi_validationresult`, and `fsi_sourcechange` | Target environment | Reading the source registry and writing validation results, source changes, and status updates |
+| **Storage Blob Data Reader** | Target storage account | Azure Blob source access (optional; planned source type) |
+
+> **Permission references:** Downloading `driveItem` content requires a Graph permission such as `Sites.Read.All` or `Files.Read.All` ([Get driveItem content](https://learn.microsoft.com/graph/api/driveitem-get-content)). The managed identity must be registered as a Dataverse [application user associated with a security role](https://learn.microsoft.com/power-apps/developer/data-platform/use-multi-tenant-server-server-authentication#create-an-application-user-associated-with-the-registered-application-in-dataverse) before it can read or write the registry tables.
+>
+> The legacy client-secret development fallback uses the same Entra app registration and Dataverse application-user role; it is for local development only (see [Deployment](#deployment)).
 
 ## Quick Start
 
@@ -144,7 +152,7 @@ The script automatically captures baselines on first run for sources without an 
 ## Deployment
 
 1. Create the Dataverse schema manually in your Power Platform environment (see [Quick Start](#1-deploy-dataverse-schema-manual) for current status)
-2. Grant the Azure-hosted job's managed identity Dataverse access to `fsi_knowledgesource`, `fsi_validationresult`, and `fsi_sourcechange`, plus Microsoft Graph permissions for SharePoint or OneDrive content retrieval
+2. Grant the Azure-hosted job's managed identity Dataverse access to `fsi_knowledgesource`, `fsi_validationresult`, and `fsi_sourcechange` (via a Dataverse application user and security role), plus the Microsoft Graph application permission `Sites.Read.All` (or `Files.Read.All`) for SharePoint or OneDrive content retrieval
 3. Register knowledge sources via the model-driven app or Dataverse API
 4. Run `Invoke-SourceValidation.ps1 -UseManagedIdentity` to capture baselines and validate
 5. Configure scheduled execution via Azure Automation, Azure Functions, or a VM-hosted scheduled job with managed identity enabled
@@ -304,7 +312,7 @@ For documents with references, validates all links are accessible.
 
 | Issue | Cause | Resolution |
 |-------|-------|------------|
-| Authentication failure | Expired token or insufficient SharePoint/Dataverse permissions | Re-authenticate; verify SharePoint Reader and Dataverse Reader roles |
+| Authentication failure | Expired token or insufficient SharePoint/Dataverse permissions | Re-authenticate; verify the managed identity has Graph `Sites.Read.All`/`Files.Read.All` and a Dataverse application-user security role (see [Permissions](#permissions)) |
 | Hash mismatch on first run | No baseline captured for the source | Run `Invoke-SourceValidation.ps1` — baselines are captured automatically on first run |
 | Source not found | Incorrect URI or source moved/renamed | Verify source URI; re-register via the model-driven app or Dataverse API |
 | Stale content alerts | Source not updated within freshness threshold | Review source update schedule; adjust threshold if appropriate |


### PR DESCRIPTION
## Summary

Lab-readiness validation for **rag-source-validator** (v1.3.1). Static validation only (no live tenant): parse-validity, authoritative-source verification, and documentation completeness. Controls: 2.16, 1.7, 2.13.

The solution code (PowerShell validator + governance scripts, Python schema/env/connection scripts) was already correct and internally consistent after three prior council reviews — no logic, schema, option-set, or column changes were needed. This PR fixes two documentation prerequisite gaps that could block a first-time lab deployment, plus a committed evidence report.

## What / why

- **Licensing prerequisite was wrong.** README listed `Power Platform Premium — Validation flows`, but this solution ships **no** Power Automate flows (it is script-based, run on Azure compute). Replaced with the real requirements: Dataverse capacity + Azure compute (Automation / Functions / VM) hosting the script via managed identity.
- **Permissions prerequisite was incomplete.** The Permissions table named only vague roles and omitted the concrete Microsoft Graph application permission the managed identity needs to read `driveItem` content. Rewrote around the managed-identity-first model with citation-backed grants: Graph `Sites.Read.All`/`Files.Read.All`, a Dataverse application user + security role on the three RSV tables, and `Storage Blob Data Reader` for the optional/planned blob path. Aligned the Deployment step and Troubleshooting row.
- **Added `LAB-VALIDATION.md`** evidence report (purpose, scope checked, sources, gaps/fixes, runtime-only caveats, lab-readiness verdict).

## Authoritative sources (6)

- Copilot Studio supported knowledge sources & unstructured data
- Microsoft Graph: Get driveItem content (permissions), delta query change tracking
- Azure IMDS / App Service managed-identity token endpoints
- Dataverse application user + security role (server-to-server auth)

## Verification

- `py_compile` clean on all three Python scripts
- `Parser::ParseFile` zero errors on all four PowerShell scripts
- Language-rule grep (banned compliance-overclaim phrases) — zero hits
- `manifest.yaml` not touched

## Caveats

Runtime paths (token acquisition, Graph downloads, Dataverse reads/writes) not exercised — no live tenant. Endpoint shapes and permission names verified against Microsoft Learn but not run end-to-end. Planned source types (2–13), trust-on-first-use baseline, WORM/immutability, and no-automated-tests remain documented design limitations.

Lab-ready verdict: **lab-ready.**