### PR TITLE
fix(segregation-detector): correct Power Platform BAP token audience + lab-readiness validation

### DIFF
--- a/segregation-detector/CHANGELOG.md
+++ b/segregation-detector/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the Segregation of Duties Detector.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Invoke-SoDScan.ps1` / `SoDShared.ps1` — Power Platform BAP token audience (supersedes v1.2.1 M2 "false positive"):** the scanner requested the BAP admin REST API token with audience `https://api.bap.microsoft.com/.default`, which is not a documented Microsoft Entra resource identifier URI and can fail token acquisition with `AADSTS500011` (resource principal not found). Per Microsoft's [Power Platform programmability authentication](https://learn.microsoft.com/en-us/power-platform/admin/programmability-authentication) docs, the documented audience for the BAP / Power Platform admin REST surface is the first-party **Power Apps Service** resource `https://service.powerapps.com/` (App ID `475226c6-020e-4fb2-8a90-7a972cbfc1d4`) — the same resource targeted by `New-PowerAppManagementApp` and `Microsoft.PowerApps.Administration.PowerShell`. Added `Get-BapResource` to derive the documented audience (commercial defaults to `https://service.powerapps.com/`; the BAP *request host* is unchanged and remains derived by `Get-BapApiBaseUrl`). Sovereign clouds retain the prior base-URL audience pending in-tenant verification. Added a `-BapResource` parameter / `FSI_BAP_RESOURCE` environment variable to override the audience. The earlier M2 conclusion that `$bapBaseUrl/.default` was "the documented Microsoft pattern" is not supported by authoritative documentation and is hereby corrected.
+
 ### Changed
 
 - **Operator ergonomics (Wave 6 P4a):** State-changing scripts now support `-WhatIf` and `-Confirm` switches via `SupportsShouldProcess`. Existing callers see no behavior change unless they explicitly pass `-WhatIf`.

--- a/segregation-detector/LAB-VALIDATION.md
+++ b/segregation-detector/LAB-VALIDATION.md
@@ -1,0 +1,138 @@
+# Lab Validation Report — Segregation of Duties Detector
+
+> **Solution version:** v1.2.1 (with `[Unreleased]` BAP audience fix)
+> **Validation date:** 2026-06-04
+> **Validation type:** Static (no live tenant) — parse-validity + authoritative-source verification + documentation completeness
+> **Validator:** Autonomous engineering pass (owl-mode)
+
+---
+
+## 1. Purpose and controls
+
+The Segregation of Duties (SoD) Detector identifies users who hold incompatible role
+combinations across three sources — Microsoft Entra ID directory roles, Power Platform
+environment roles, and Dataverse security roles — and records Maker/Checker conflicts as
+`fsi_sodviolation` rows. It supports compliance with:
+
+- **Control 2.8** — Access Control and Segregation of Duties (primary)
+- **Control 2.1** — Managed Environments (environment role context)
+- **Control 2.3** — Change Management and Release Planning (pipeline gate)
+
+Regulatory alignment documented by the solution: SOX Section 404 (IT General Controls),
+COSO control activities, and OCC heightened standards. The shipped capability is
+**detection + CI-gate exit code**; runtime pipeline blocking and real-time alerts are
+documented roadmap items.
+
+## 2. What was checked
+
+| Area | Method | Result |
+|------|--------|--------|
+| PowerShell parse validity (`Invoke-SoDScan.ps1`, `Import-ConflictRules.ps1`, `SoDShared.ps1`) | `[Parser]::ParseFile` | 0 errors |
+| Python compile (`create_sd_dataverse_schema.py`) | `python -m py_compile` | Pass |
+| Dataverse column / entity-set names | Cross-checked scripts against `create_sd_dataverse_schema.py` and Microsoft Learn | Consistent |
+| Microsoft Graph role-assignment query + permissions | Authoritative Graph v1.0 reference | Verified |
+| Power Platform BAP role-assignment API host + token audience | Authoritative Power Platform admin docs | Host verified; **audience corrected** |
+| Dataverse `systemuser` query columns | Authoritative SystemUser entity reference | Verified |
+| Choice/option-set values (100000000+) | `SoDShared.ps1` vs `docs/conflict-rules.md` vs schema | Consistent (no 0/1/2 drift) |
+| Regulatory language rules | grep `ensures|guarantees|will prevent|eliminates risk` (excl. CHANGELOG) | 0 hits |
+| Managed-identity-first auth | Reviewed `Get-AccessToken` flow ordering | Compliant |
+
+## 3. Authoritative sources cited
+
+1. **List roleAssignmentScheduleInstances** — Microsoft Graph v1.0 —
+   <https://learn.microsoft.com/en-us/graph/api/rbacapplication-list-roleassignmentscheduleinstances?view=graph-rest-1.0>
+   Confirms: endpoint path; `principalId` / `roleDefinitionId` response properties;
+   `$expand` / `$filter` / `$select` support; least-privileged application permission
+   `RoleAssignmentSchedule.Read.Directory`; availability in Global, GCC High, DoD, and
+   21Vianet clouds; that active assignments include both PIM-activation and direct
+   assignments.
+2. **Power Platform programmability authentication (legacy)** —
+   <https://learn.microsoft.com/en-us/power-platform/admin/programmability-authentication>
+   Confirms: the BAP / Power Platform admin REST token audience is the **Power Apps Service**
+   resource `https://service.powerapps.com/` (App ID `475226c6-020e-4fb2-8a90-7a972cbfc1d4`);
+   documented scope string `https://service.powerapps.com//.default` (double slash is correct).
+3. **Power Platform programmability authentication v2** —
+   <https://learn.microsoft.com/en-us/power-platform/admin/programmability-authentication-v2>
+   Confirms: the BAP admin host `https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/...`
+   is the real request host; the newer Power Platform API uses audience `https://api.powerplatform.com/`.
+4. **User (SystemUser) table/entity reference (Dataverse)** — Microsoft Learn
+   Confirms columns `azureactivedirectoryobjectid`, `applicationid`, `isdisabled`,
+   `domainname`, and the `systemuserroles_association` N:N relationship to `role`.
+
+## 4. Gaps found and fixes applied
+
+### 4.1 (Substantive) Power Platform BAP token audience — corrected
+
+- **Gap:** `Invoke-SoDScan.ps1` acquired the BAP token with audience
+  `https://api.bap.microsoft.com/.default`. `api.bap.microsoft.com` is the request **host**,
+  not a documented Microsoft Entra resource identifier URI, so token acquisition can fail with
+  `AADSTS500011` (resource principal not found). The v1.2.1 CHANGELOG marked this an "M2 false
+  positive," asserting "the BAP API resource ID equals the API base URL" — that claim is **not
+  supported** by authoritative documentation.
+- **Authoritative basis:** Source 2 above shows the documented audience for the BAP admin REST
+  surface is `https://service.powerapps.com/`, the same resource targeted by
+  `New-PowerAppManagementApp` (already required in `docs/prerequisites.md`) and the
+  `Microsoft.PowerApps.Administration.PowerShell` module.
+- **Fix (surgical, low-regression):**
+  - Added `Get-BapResource` to `SoDShared.ps1`. Commercial cloud now resolves the documented
+    audience `https://service.powerapps.com/` (yielding the documented `…//.default` scope).
+    The BAP **request host** is unchanged (`Get-BapApiBaseUrl`).
+  - Sovereign clouds (GCC High, DoD, 21Vianet) retain the prior base-URL audience because their
+    Power Apps Service resource identifier URIs are **not publicly documented** — flagged for
+    in-tenant verification rather than guessed.
+  - Added a `-BapResource` parameter and `FSI_BAP_RESOURCE` environment variable to override the
+    audience for any cloud.
+  - Documented in `docs/prerequisites.md`, `docs/troubleshooting.md` (new `AADSTS500011` row),
+    README helper list, and CHANGELOG `[Unreleased]` (explicitly superseding the prior M2 note).
+
+### 4.2 (Verified, no change) Items previously flagged or assumed
+
+- **Graph PIM schedule-instance query** — verified correct against Source 1; permissions in
+  `docs/prerequisites.md` (`RoleAssignmentSchedule.Read.Directory`, `RoleManagement.Read.Directory`,
+  `Directory.Read.All`, `User.Read.All`) match the documented least-privileged + higher-privileged set.
+- **Dataverse `systemusers` query** — `azureactivedirectoryobjectid`, `domainname`, `fullname`,
+  `isdisabled`, `applicationid`, and `systemuserroles_association($select=name,roleid)` all verified.
+- **Choice values** — `Category`, `RoleContext`, `Severity`, `ViolationStatus` etc. use
+  `100000000+` consistently across `SoDShared.ps1`, `docs/conflict-rules.md`, and the schema
+  generator. No 0/1/2-vs-100000000 drift. The README conflict-matrix "Context: 1/3/4" labels are
+  human-readable context **codes** (explicitly defined in a README note), not Dataverse option-set
+  values, so they are not a drift defect.
+- **Disabled aspirational rules** — `DLP Policy Author/Approver` and `Environment Approver` remain
+  `fsi_enabled = $false` because those names are not produced by the BAP role-assignment API; this
+  is correct and documented.
+
+## 5. Runtime-only caveats (cannot be verified statically without a tenant)
+
+1. **BAP environment role-assignments endpoint** — `…/scopes/admin/environments/{id}/roleAssignments?api-version=2023-06-01`
+   is the host/path the PowerApps Administration module uses, but the per-environment
+   `roleAssignments` contract is not part of the publicly documented REST reference (which is the
+   newer RBAC REST API). Response shape (`properties.principal.type`,
+   `properties.roleDefinition.displayName`) is assumed from that module's behavior and must be
+   confirmed against a live tenant.
+2. **Corrected BAP audience** — the commercial fix to `https://service.powerapps.com/` is grounded
+   in authoritative docs but must still be exercised end-to-end in a tenant. Sovereign-cloud
+   audiences are explicitly unverified (use `-BapResource`).
+3. **`New-PowerAppManagementApp` registration** — required for BAP queries to return data; cannot be
+   exercised here.
+4. **Token lifetime** — long scans in large tenants may exceed ~60 min; no in-script refresh
+   (documented in README Known Limitations).
+5. **Group-based / PIM-eligible / App-role assignments** — not evaluated (documented limitations).
+
+## 6. Lab-readiness assessment
+
+**Verdict: Lab-ready, with the BAP audience correction.**
+
+The scripts parse cleanly, use authoritatively-verified Graph and Dataverse APIs with correct
+property and column names, follow managed-identity-first auth, and carry accurate, language-rule-
+compliant documentation. The one substantive defect found — an undocumented BAP token audience that
+would likely fail token acquisition for the Power Platform role-enumeration branch — has been
+corrected for commercial cloud and made overridable for all clouds, with zero change to the verified
+Graph/Dataverse paths.
+
+Before production (vs. lab) use, an operator should run an authenticated `-DryRun -Verbose` scan in a
+real tenant to confirm: (a) the BAP audience succeeds and environment role data is returned, (b)
+`New-PowerAppManagementApp` registration is in place, and (c) sovereign-cloud audiences if applicable.
+
+---
+
+*Segregation of Duties Detector — Lab Validation Report*

--- a/segregation-detector/LAB-VALIDATION.md
+++ b/segregation-detector/LAB-VALIDATION.md
@@ -34,7 +34,7 @@ documented roadmap items.
 | Power Platform BAP role-assignment API host + token audience | Authoritative Power Platform admin docs | Host verified; **audience corrected** |
 | Dataverse `systemuser` query columns | Authoritative SystemUser entity reference | Verified |
 | Choice/option-set values (100000000+) | `SoDShared.ps1` vs `docs/conflict-rules.md` vs schema | Consistent (no 0/1/2 drift) |
-| Regulatory language rules | grep `ensures|guarantees|will prevent|eliminates risk` (excl. CHANGELOG) | 0 hits |
+| Regulatory language rules | grep for the FSI-prohibited compliance-absolute phrases (per `fsi-language-rules.instructions.md`, excl. CHANGELOG) | 0 hits |
 | Managed-identity-first auth | Reviewed `Get-AccessToken` flow ordering | Compliant |
 
 ## 3. Authoritative sources cited

--- a/segregation-detector/README.md
+++ b/segregation-detector/README.md
@@ -158,7 +158,7 @@ Review scan output for detected conflicts. A Power Apps dashboard for visual rev
 | `scripts/Invoke-SoDScan.ps1` | Scans for SoD violations across Entra ID, Power Platform, and Dataverse |
 | `scripts/Import-ConflictRules.ps1` | Imports conflict rule sets into Dataverse |
 | `scripts/create_sd_dataverse_schema.py` | Generates the Dataverse schema reference used as the table and choice-value source of truth |
-| `scripts/SoDShared.ps1` | Shared helper module (`Invoke-WithRetry`, `Get-AccessToken`, `Get-LoginEndpoint`, `Get-GraphEndpoint`, `Get-BapApiBaseUrl`) dot-sourced by both scripts |
+| `scripts/SoDShared.ps1` | Shared helper module (`Invoke-WithRetry`, `Get-AccessToken`, `Get-LoginEndpoint`, `Get-GraphEndpoint`, `Get-BapApiBaseUrl`, `Get-BapResource`) dot-sourced by both scripts |
 
 ## Detection Process
 

--- a/segregation-detector/docs/prerequisites.md
+++ b/segregation-detector/docs/prerequisites.md
@@ -98,6 +98,17 @@ $env:FSI_CLIENT_SECRET = "<client-secret>"
 
 Reference: [Use service principal accounts to connect to Power Platform](https://learn.microsoft.com/en-us/power-platform/admin/powershell-create-service-principal).
 
+### Power Platform BAP token audience
+
+The scanner queries Power Platform environment role assignments through the BAP admin REST API
+(`api.bap.microsoft.com` and sovereign equivalents). The OAuth **resource (audience)** for these
+calls is the first-party **Power Apps Service** resource `https://service.powerapps.com/`
+(Application ID `475226c6-020e-4fb2-8a90-7a972cbfc1d4`) — the request host is *not* the audience.
+`Invoke-SoDScan.ps1` derives this automatically for commercial cloud. For sovereign clouds, or if
+token acquisition fails with `AADSTS500011`, override the audience with `-BapResource` or the
+`FSI_BAP_RESOURCE` environment variable. Reference:
+[Power Platform programmability authentication](https://learn.microsoft.com/en-us/power-platform/admin/programmability-authentication).
+
 ---
 
 ## Environment Requirements

--- a/segregation-detector/docs/troubleshooting.md
+++ b/segregation-detector/docs/troubleshooting.md
@@ -142,6 +142,7 @@ Common issues and solutions for the Segregation of Duties Detector.
 | Error | Cause | Solution |
 |-------|-------|----------|
 | "AADSTS700016" | App not found in tenant | Verify client ID |
+| "AADSTS500011" | BAP token resource/audience not found | The Power Platform BAP admin REST API token audience is `https://service.powerapps.com/` (Power Apps Service, App ID `475226c6-020e-4fb2-8a90-7a972cbfc1d4`), not the request host. The scanner derives this automatically; if it still fails (e.g., sovereign cloud), pass `-BapResource` or set `FSI_BAP_RESOURCE`. |
 | "AADSTS7000215" | Invalid client secret in legacy dev-only mode | Prefer ManagedIdentity or WorkloadIdentity; rotate local dev secret if ClientSecret mode is unavoidable |
 | "403 Forbidden" | Insufficient permissions | Grant required permissions |
 | "Resource not found" | Wrong environment URL | Verify Dataverse URL |

--- a/segregation-detector/scripts/Invoke-SoDScan.ps1
+++ b/segregation-detector/scripts/Invoke-SoDScan.ps1
@@ -29,6 +29,12 @@
 .PARAMETER ClientSecret
     Legacy dev-only client secret. If not specified, uses FSI_CLIENT_SECRET or AZURE_CLIENT_SECRET when AuthMode is ClientSecret.
 
+.PARAMETER BapResource
+    Optional override for the OAuth resource (audience) used to acquire the Power Platform BAP admin
+    REST API token. When omitted, the documented audience is derived (https://service.powerapps.com/
+    for commercial). Set this (or FSI_BAP_RESOURCE) if BAP token acquisition fails with AADSTS500011,
+    or for sovereign clouds where the resource identifier URI differs.
+
 .PARAMETER DryRun
     Run scan without creating violation records.
 
@@ -75,6 +81,12 @@ param(
 
     [Parameter(Mandatory = $false)]
     [switch]$DryRun,
+
+    [Parameter(Mandatory = $false)]
+    # Override the OAuth resource (audience) used for the Power Platform BAP admin REST API token.
+    # When empty, Get-BapResource derives the documented audience (https://service.powerapps.com/
+    # for commercial). Set this if BAP token acquisition fails with AADSTS500011 in your cloud.
+    [string]$BapResource = $env:FSI_BAP_RESOURCE,
 
     [Parameter(Mandatory = $false)]
     # When set, allow the scan to continue even if Power Platform BAP role enumeration fails for
@@ -520,7 +532,11 @@ foreach ($dr in $directoryRoles) { $directoryRoleLookup[$dr.id] = $dr }
 Write-Host ""
 Write-Host "Querying Power Platform role assignments..." -ForegroundColor Gray
 $bapBaseUrl = Get-BapApiBaseUrl -EnvironmentUrl $Environment
-$ppToken = Get-AccessToken @tokenParams -Scope "$bapBaseUrl/.default"
+# The BAP request host is not the token audience. Resolve the documented OAuth resource
+# (https://service.powerapps.com/ for commercial) unless explicitly overridden via -BapResource.
+$bapResource = if ($BapResource) { $BapResource } else { Get-BapResource -EnvironmentUrl $Environment -BapApiBaseUrl $bapBaseUrl }
+Write-Verbose "Power Platform BAP token audience: $bapResource (request host: $bapBaseUrl)"
+$ppToken = Get-AccessToken @tokenParams -Scope "$bapResource/.default"
 $ppRoleAssignments = Get-PowerPlatformRoleAssignments -Token $ppToken -EnvironmentUrl $Environment
 Write-Host "  Found $($ppRoleAssignments.Count) Power Platform role assignments" -ForegroundColor Green
 

--- a/segregation-detector/scripts/SoDShared.ps1
+++ b/segregation-detector/scripts/SoDShared.ps1
@@ -285,3 +285,37 @@ function Get-BapApiBaseUrl {
         return "https://api.bap.microsoft.com"
     }
 }
+
+function Get-BapResource {
+    <#
+    .SYNOPSIS
+        Returns the OAuth resource (audience) used to acquire a token for the Power Platform
+        Business Application Platform (BAP) admin REST API.
+
+    .DESCRIPTION
+        The BAP admin REST API is hosted at api.bap.microsoft.com (and sovereign equivalents),
+        but the request HOST is not the token AUDIENCE. Microsoft's documented audience for the
+        BAP / Power Platform admin REST surface is the first-party "Power Apps Service" resource
+        https://service.powerapps.com/ (Application ID 475226c6-020e-4fb2-8a90-7a972cbfc1d4) --
+        the same resource the Microsoft.PowerApps.Administration.PowerShell module and
+        New-PowerAppManagementApp registration target.
+        Ref: https://learn.microsoft.com/power-platform/admin/programmability-authentication
+
+        Requesting "https://api.bap.microsoft.com/.default" can fail token acquisition
+        (AADSTS500011: resource principal not found) because that host is not a registered
+        Microsoft Entra resource identifier URI.
+
+        Sovereign-cloud resource identifier URIs for Power Apps Service are not publicly
+        documented. For those clouds this helper falls back to the BAP base URL as the audience;
+        operators should verify in-tenant and use -BapResource / FSI_BAP_RESOURCE to override.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$EnvironmentUrl,
+        [Parameter(Mandatory = $true)][string]$BapApiBaseUrl
+    )
+    if ($EnvironmentUrl -match '\.(microsoftdynamics\.us|appsplatform\.us|dynamics\.cn)') {
+        # Sovereign clouds: resource identifier URI not authoritatively documented -- verify in-tenant.
+        return $BapApiBaseUrl
+    }
+    return "https://service.powerapps.com/"
+}


### PR DESCRIPTION
## Summary

Lab-readiness validation of **segregation-detector** (v1.2.1) via static checks: PowerShell/Python parse validity, authoritative Microsoft-source verification, and documentation completeness. No live tenant was used.

## Substantive fix — BAP token audience

`Invoke-SoDScan.ps1` requested the Power Platform BAP admin REST API token with audience `https://api.bap.microsoft.com/.default`. That value is the request **host**, not a documented Microsoft Entra resource identifier URI, and can fail token acquisition with **AADSTS500011** — which would break the entire Power Platform environment-role branch (now fail-closed).

Per Microsoft's [Power Platform programmability authentication](https://learn.microsoft.com/en-us/power-platform/admin/programmability-authentication) docs, the documented audience for the BAP / admin REST surface is the **Power Apps Service** resource `https://service.powerapps.com/` (App ID `475226c6-020e-4fb2-8a90-7a972cbfc1d4`) — the same resource targeted by `New-PowerAppManagementApp` (already a documented prerequisite) and `Microsoft.PowerApps.Administration.PowerShell`.

This **supersedes** the v1.2.1 CHANGELOG "M2 false positive" note, whose claim that "the BAP API resource ID equals the API base URL" is not supported by authoritative documentation.

### Change (surgical, low-regression)
- New `Get-BapResource` helper in `SoDShared.ps1`: commercial → `https://service.powerapps.com/` (documented `//.default` scope); the BAP request host is unchanged (`Get-BapApiBaseUrl`).
- Sovereign clouds (GCC High / DoD / 21Vianet) keep the prior base-URL audience — their Power Apps Service resource URIs are not publicly documented, so they are flagged for in-tenant verification rather than guessed.
- New `-BapResource` parameter / `FSI_BAP_RESOURCE` env var to override the audience for any cloud.

## Verified, no change
- Graph `roleAssignmentScheduleInstances` query, `principalId`/`roleDefinitionId` properties, and `RoleAssignmentSchedule.Read.Directory` least-privilege permission ([Graph v1.0 ref](https://learn.microsoft.com/en-us/graph/api/rbacapplication-list-roleassignmentscheduleinstances?view=graph-rest-1.0)).
- Dataverse `systemuser` columns (`azureactivedirectoryobjectid`, `applicationid`, `isdisabled`, `domainname`) and `systemuserroles_association` N:N.
- Choice values use `100000000+` consistently (no 0/1/2 drift).

## Docs
- `LAB-VALIDATION.md` evidence report (sources, gaps, caveats, verdict).
- Updated `docs/prerequisites.md`, `docs/troubleshooting.md` (AADSTS500011), `README.md`, `CHANGELOG.md [Unreleased]`.

## Runtime-only caveats
BAP per-environment `roleAssignments` response shape, the corrected audience end-to-end, `New-PowerAppManagementApp` registration, and sovereign-cloud audiences require a live tenant to confirm.

## Verification
- `[Parser]::ParseFile` → 0 errors on all 3 `.ps1`; `py_compile` clean.
- `Get-BapResource` mapping unit-checked across commercial/sovereign hosts.
- Language-rule grep clean (no `ensures|guarantees|will prevent|eliminates risk`).
- `manifest.yaml` not modified.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>