### PR TITLE
fix(session-security-configurator): lab-readiness validation and corrections

### DIFF
--- a/session-security-configurator/CHANGELOG.md
+++ b/session-security-configurator/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to the Session Security Configurator solution are documented
 ### Fixed
 
 - **Wave 6 P4b:** Empty catch blocks now log via `Write-Verbose` instead of silently swallowing errors. Output is unchanged unless caller passes `-Verbose`.
+- **CAE detection read from beta endpoint** (`scripts/Get-CAEConfiguration.ps1`): Switched policy retrieval from `Get-MgIdentityConditionalAccessPolicy` (v1.0) to `Get-MgBetaIdentityConditionalAccessPolicy` (beta). The `continuousAccessEvaluation` session control is not part of the v1.0 `conditionalAccessSessionControls` resource type, so the v1.0 cmdlet never populated `SessionControls.ContinuousAccessEvaluation`; every policy was reported as CAE "default enabled" and `CAEExplicitlyDisabled` was always `$false`, defeating the script's purpose of identifying policies with CAE explicitly disabled. Updated `#Requires` to `Microsoft.Graph.Beta.Identity.SignIns` (already a solution dependency for the Zone 3 risky-user policy). Verified against the [continuousAccessEvaluationSessionControl (beta)](https://learn.microsoft.com/graph/api/resources/continuousaccessevaluationsessioncontrol?view=graph-rest-beta) and [conditionalAccessSessionControls (v1.0)](https://learn.microsoft.com/graph/api/resources/conditionalaccesssessioncontrols?view=graph-rest-1.0) resource types.
+
+### Documentation
+
+- **persistentBrowser mode values corrected** (`scripts/private/Compare-SessionBaseline.ps1`): The `.PARAMETER Baseline` help listed `persistentBrowser` modes as `("never", "always", "persistent")`. Per the [persistentBrowserSessionControl](https://learn.microsoft.com/graph/api/resources/persistentbrowsersessioncontrol?view=graph-rest-1.0) resource type, only `always` and `never` are valid; removed the non-existent `"persistent"` value.
+- **`Get-AzAccessToken` SecureString caveat added** (`docs/prerequisites.md`): Documented that `Az.Accounts` 5.0.0+ returns the token as a `SecureString` by default, so a manual conversion is required before passing it to the SSC scripts' plain-text token parameters. Verified against [Protect secrets in Azure PowerShell](https://learn.microsoft.com/powershell/azure/security-features#transition-from-strings-to-securestrings).
+- **Accuracy/language fix** (`docs/prerequisites.md`): Changed "SSC enforces zone-specific session security controls" to "SSC validates …" — SSC validates configuration and detects drift; Conditional Access policies perform enforcement.
 
 ## [1.3.0] - 2026-05-22
 

--- a/session-security-configurator/LAB-VALIDATION.md
+++ b/session-security-configurator/LAB-VALIDATION.md
@@ -1,0 +1,120 @@
+# Lab Validation Report — Session Security Configurator
+
+**Solution:** session-security-configurator
+**Version:** v1.3.0 (manifest unchanged; fixes recorded under CHANGELOG `[Unreleased]`)
+**Primary controls:** 1.23 (Session Security and Step-Up Authentication), 1.11 (Conditional Access and MFA)
+**Validation type:** Static — parse-validity, authoritative-source verification, and documentation completeness. No live tenant was used.
+**Date:** 2026-06-04
+
+## Purpose
+
+The Session Security Configurator (SSC) validates Microsoft 365 / Entra ID session security configuration
+against per-zone governance baselines (Zone 1 = 8 h, Zone 2 = 4 h, Zone 3 = 1 h sign-in frequency), deploys
+zone step-up Conditional Access (CA) policies and authentication contexts in report-only mode, captures
+baselines for drift detection, tracks Continuous Access Evaluation (CAE) posture, and exports SHA-256-hashed
+compliance evidence to Dataverse. It supports compliance with FINRA 4511/3110, SEC 17a-3/4, GLBA 501(b),
+and SOX 302/404 — it does not by itself satisfy any regulation.
+
+## What was checked
+
+- PowerShell parse-validity for all 14 `.ps1` scripts (`Parser::ParseFile`, zero errors).
+- `py_compile` for all 5 Python scripts (all OK).
+- Microsoft Graph Conditional Access **session control** schema: `signInFrequency`, `persistentBrowser`,
+  `continuousAccessEvaluation`, and `grantControls.authenticationStrength` / `builtInControls`.
+- Graph PowerShell cmdlet currency (`Get-/New-/Update-MgIdentityConditionalAccessPolicy`,
+  `Get-MgIdentityConditionalAccessAuthenticationStrengthPolicy`,
+  `*-MgIdentityConditionalAccessAuthenticationContextClassReference`, beta `*-MgBetaIdentityConditionalAccessPolicy`).
+- Required Graph permission scopes and the v1.0-vs-beta endpoint boundary for each property read.
+- `Az.Accounts` `Get-AzAccessToken` output-type change and `MSAL.PS` deprecation status.
+- Dataverse logical column names and option-set values against `scripts/create_dataverse_schema.py`.
+- Zone→setting mapping and drift-detection comparison logic (`Compare-SessionBaseline.ps1`).
+- FSI language rules across all Markdown (excluding CHANGELOG history).
+
+## Authoritative sources cited
+
+| Topic | Source URL |
+|-------|-----------|
+| `signInFrequencySessionControl` (`type` = days/hours; `frequencyInterval` = timeBased/everyTime) | https://learn.microsoft.com/graph/api/resources/signinfrequencysessioncontrol?view=graph-rest-1.0 |
+| `persistentBrowserSessionControl` (`mode` = always/never) | https://learn.microsoft.com/graph/api/resources/persistentbrowsersessioncontrol?view=graph-rest-1.0 |
+| `conditionalAccessSessionControls` (v1.0 — no `continuousAccessEvaluation`) | https://learn.microsoft.com/graph/api/resources/conditionalaccesssessioncontrols?view=graph-rest-1.0 |
+| `continuousAccessEvaluationSessionControl` (beta-only; `mode` = strictEnforcement/disabled/…) | https://learn.microsoft.com/graph/api/resources/continuousaccessevaluationsessioncontrol?view=graph-rest-beta |
+| Require reauthentication every time (sign-in frequency `everyTime`) | https://learn.microsoft.com/entra/identity/conditional-access/concept-session-lifetime#require-reauthentication-every-time |
+| `Get-AzAccessToken` SecureString change (Az.Accounts 5.0.0 / Az 14.0.0) | https://learn.microsoft.com/powershell/azure/security-features#transition-from-strings-to-securestrings |
+
+## Gaps found and fixes applied
+
+### 1. (Bug) CAE detection read from the wrong Graph endpoint — fixed
+
+`scripts/Get-CAEConfiguration.ps1` retrieved policies with `Get-MgIdentityConditionalAccessPolicy`
+(**v1.0**) and then read `$sessionControls.ContinuousAccessEvaluation.Mode`. The `continuousAccessEvaluation`
+session control is **not part of the v1.0 `conditionalAccessSessionControls` resource type** — it is exposed
+only on the **beta** endpoint. As a result the property was always `$null`, so the script reported every
+policy as CAE "default enabled" and `CAEExplicitlyDisabled` could never become `$true` — defeating the
+script's stated purpose (identify policies with CAE explicitly disabled).
+
+**Fix:** switched retrieval to `Get-MgBetaIdentityConditionalAccessPolicy -All` and updated `#Requires` to
+`Microsoft.Graph.Beta.Identity.SignIns` (already a solution dependency, used by the Zone 3 risky-user policy
+in `Deploy-StepUpPolicies.ps1`). Added inline + `.DESCRIPTION` notes explaining the v1.0/beta boundary, and
+bumped the script-level version note to 1.2.1.
+
+### 2. (Docs) Invalid `persistentBrowser` mode in help text — fixed
+
+`scripts/private/Compare-SessionBaseline.ps1` `.PARAMETER Baseline` listed modes as
+`("never", "always", "persistent")`. The Graph `persistentBrowserSessionControl.mode` enum is only
+`always` / `never`; `"persistent"` does not exist. Removed it. (Runtime comparison is plain string equality,
+so this was a documentation-only defect.)
+
+### 3. (Docs) `Get-AzAccessToken` SecureString caveat added — fixed
+
+`docs/prerequisites.md` recommended `Get-AzAccessToken -ResourceUrl` as a modern alternative to the
+deprecated `MSAL.PS`, but did not mention that **Az.Accounts 5.0.0+** returns a `SecureString` by default.
+The SSC scripts accept a plain-text bearer token (`-DataverseToken` / `-AccessToken`), so a manual
+`SecureString` → plain-text conversion is now documented (per Microsoft's "Protect secrets in Azure
+PowerShell" guidance, which states the token must be converted manually; there is no plain-text switch in 5.x).
+
+### 4. (Accuracy/language) "enforces" → "validates" — fixed
+
+`docs/prerequisites.md` stated "SSC enforces zone-specific session security controls." SSC validates
+configuration and detects drift; the deployed Conditional Access policies perform enforcement. Changed to
+"SSC validates …".
+
+## Verified as correct (no change needed)
+
+- **Session-control comparison** (`Compare-SessionBaseline.ps1`) normalizes `signInFrequency` of type
+  `hours`/`minutes`/`days` to minutes. Graph only emits `days`/`hours`, so the `minutes` branch is harmless
+  defensive code; all three zone baselines (8 h / 4 h / 1 h) are expressible in hours.
+- **Zone 3 risky-user beta policy** (`Deploy-StepUpPolicies.ps1`) sets `signInFrequency` with
+  `frequencyInterval = "everyTime"` and omits `value`/`type` — consistent with the beta schema (per the
+  resource doc, `everyTime` is for risky users / risky sign-ins / Intune enrollment).
+- **Graph cmdlets and scopes** are current: `Policy.ReadWrite.ConditionalAccess`, `Policy.Read.All`,
+  `GroupMember.Read.All`, `RoleManagement.Read.Directory`.
+- **Dataverse column logical names** in OData queries match `create_dataverse_schema.py`
+  (e.g., `fsi_signinfrequencyminutes`, `fsi_requirecompliantdevice`, `fsi_capturedon`).
+- **Option-set values** are internally consistent: `fsi_acv_zone` = 100000001-3,
+  `fsi_ssc_validationtype` = 100000001-6, and `fsi_acv_severity` = 1-5 (a shared cross-solution set
+  intentionally kept 1-based; documented in CHANGELOG 1.3.0). Read-side maps in
+  `Export-SessionSecurityEvidence.ps1` match the schema.
+- **No FSI language-rule violations** remain in Markdown.
+
+## Runtime-only caveats (cannot be verified without a tenant)
+
+- The CAE fix was verified against the published Graph schema and parse-checked. End-to-end behavior
+  (beta cmdlet returning populated `ContinuousAccessEvaluation` for a policy that has it explicitly set)
+  requires a live tenant with `Microsoft.Graph.Beta.Identity.SignIns` installed.
+- Graph beta APIs are subject to change and are not formally supported for production by Microsoft; the
+  CAE read and the Zone 3 risky-user policy both depend on beta surfaces. This is an inherent platform
+  constraint, not a defect.
+- `signInFrequency` `everyTime` only takes effect for the scenarios Microsoft documents (risky users,
+  risky sign-ins, Intune enrollment); deploying it via a group-targeted policy does not make every sign-in
+  reauthenticate outside those conditions. Validate the intended behavior in a tenant before enforcing.
+- `continuousAccessEvaluationMode` also defines `strictLocation` (evolvable enum); the script labels any
+  non-`disabled`/non-`strictEnforcement` value as "DefaultEnabled". This is a display nuance only.
+- All deployment paths create CA policies in `enabledForReportingButNotEnforced` (report-only) mode; an
+  operator must promote them to enforced after review. No live MFA/session impact occurs from deployment alone.
+
+## Lab-readiness assessment
+
+**Ready for lab use** with the fixes above. Scripts parse cleanly, Python compiles, API/permission/option-set
+references are verified against authoritative Microsoft sources, and the one functional defect (CAE endpoint)
+is corrected. Remaining items are runtime-only behaviors that require a tenant to exercise and are documented
+as caveats rather than blockers.

--- a/session-security-configurator/docs/prerequisites.md
+++ b/session-security-configurator/docs/prerequisites.md
@@ -32,6 +32,8 @@ The following PowerShell modules are required for SSC scripts:
 - `MSAL.PS` (for evidence export with service principal)
 
 > ⚠️ **MSAL.PS deprecation notice:** The [`MSAL.PS`](https://github.com/AzureAD/MSAL.PS) repository was archived in September 2023 and receives no further updates or security patches. It remains functional but is not officially supported by Microsoft. For new deployments, consider acquiring Dataverse tokens via `Az.Accounts` (`Get-AzAccessToken -ResourceUrl`) or the Microsoft Graph PowerShell SDK instead. A future release of this solution will migrate off MSAL.PS; in the interim, the existing scripts continue to work with the archived module.
+>
+> **`Get-AzAccessToken` output change:** Starting with **Az.Accounts 5.0.0** (and the `Az` 14.0.0 rollup), `Get-AzAccessToken` returns the token as a `SecureString` by default instead of a plain `String`. The SSC scripts expect a plain-text bearer token via `-DataverseToken` / `-AccessToken`, so when sourcing a token from `Az.Accounts` 5.x you must convert the returned `SecureString` to plain text before passing it (for example with `ConvertFrom-SecureString -AsPlainText`). See [Protect secrets in Azure PowerShell](https://learn.microsoft.com/powershell/azure/security-features#transition-from-strings-to-securestrings).
 
 Install all required modules:
 
@@ -102,7 +104,7 @@ For scheduled validation via Azure Automation:
 
 ## Governance Zone Alignment
 
-SSC enforces zone-specific session security controls as defined in the FSI-AgentGov framework:
+SSC validates zone-specific session security controls as defined in the FSI-AgentGov framework:
 
 | Zone | Sign-In Frequency | Auth Strength | Compliant Device |
 |------|------------------|---------------|------------------|

--- a/session-security-configurator/scripts/Get-CAEConfiguration.ps1
+++ b/session-security-configurator/scripts/Get-CAEConfiguration.ps1
@@ -19,6 +19,14 @@
     4. Correlates with SSC session baselines to determine CAE coverage per zone
     5. Generates a CAE rollout posture report
 
+    Note: The continuousAccessEvaluation session control is only exposed on the
+    Microsoft Graph beta endpoint (the v1.0 conditionalAccessSessionControls
+    resource type does not include it). This script therefore reads policies via
+    Get-MgBetaIdentityConditionalAccessPolicy so the CAE mode is populated; using
+    the v1.0 cmdlet would report every policy as CAE "default enabled" regardless
+    of an explicit disabled setting.
+    See: https://learn.microsoft.com/graph/api/resources/continuousaccessevaluationsessioncontrol?view=graph-rest-beta
+
     Reference: https://learn.microsoft.com/entra/identity/conditional-access/concept-continuous-access-evaluation
 
 .PARAMETER OutputFormat
@@ -32,16 +40,17 @@
 
 .NOTES
     File: Get-CAEConfiguration.ps1
-    Version: 1.2.0
+    Version: 1.2.1
     Solution: Session Security Configurator (SSC)
     Controls: 1.23, 1.11
-    Requires: Microsoft.Graph.Identity.SignIns module
+    Requires: Microsoft.Graph.Beta.Identity.SignIns module (continuousAccessEvaluation
+              session control is beta-only)
 
     Part of FSI Agent Governance Framework
 #>
 
 #Requires -Version 7.0
-#Requires -Modules Microsoft.Graph.Authentication, Microsoft.Graph.Identity.SignIns
+#Requires -Modules Microsoft.Graph.Authentication, Microsoft.Graph.Beta.Identity.SignIns
 
 function Get-CAEConfiguration {
     [CmdletBinding()]
@@ -65,7 +74,12 @@ function Get-CAEConfiguration {
         # ---------------------------------------------------------------
         # Step 1: Retrieve all Conditional Access policies
         # ---------------------------------------------------------------
-        $policies = Get-MgIdentityConditionalAccessPolicy -All -ErrorAction Stop
+        # Use the beta endpoint: the continuousAccessEvaluation session control
+        # is not present on the v1.0 conditionalAccessSessionControls resource,
+        # so the v1.0 cmdlet (Get-MgIdentityConditionalAccessPolicy) never
+        # populates SessionControls.ContinuousAccessEvaluation and CAE-disabled
+        # policies would be silently misreported as default-enabled.
+        $policies = Get-MgBetaIdentityConditionalAccessPolicy -All -ErrorAction Stop
         Write-Verbose "Retrieved $($policies.Count) Conditional Access policies."
 
         # ---------------------------------------------------------------

--- a/session-security-configurator/scripts/private/Compare-SessionBaseline.ps1
+++ b/session-security-configurator/scripts/private/Compare-SessionBaseline.ps1
@@ -25,7 +25,7 @@
     Baseline configuration object loaded from zone baseline JSON file.
     Expected properties:
     - signInFrequencyMinutes: Numeric value in minutes
-    - persistentBrowser: Mode string ("never", "always", "persistent")
+    - persistentBrowser: Mode string ("never", "always")
     - authenticationStrength: Auth strength policy ID (or $null)
     - requireCompliantDevice: Boolean
 


### PR DESCRIPTION
## Summary
Static lab-readiness validation of **session-security-configurator** (v1.3.0; controls 1.23, 1.11) against authoritative Microsoft sources. No live tenant. Fixes one functional defect and three documentation gaps. Version/manifest unchanged — fixes recorded under CHANGELOG `[Unreleased]`.

## Functional fix
- **CAE detection used the wrong Graph endpoint.** `Get-CAEConfiguration.ps1` read `SessionControls.ContinuousAccessEvaluation` from `Get-MgIdentityConditionalAccessPolicy` (**v1.0**), but `continuousAccessEvaluation` is **beta-only** — it is not part of the v1.0 `conditionalAccessSessionControls` resource type. The property was always `\`, so every policy was reported CAE "default enabled" and `CAEExplicitlyDisabled` could never be `\True`, defeating the script's purpose. Switched to `Get-MgBetaIdentityConditionalAccessPolicy -All` and updated `#Requires` to `Microsoft.Graph.Beta.Identity.SignIns` (already a solution dependency).

## Documentation fixes
- `Compare-SessionBaseline.ps1` help: removed invalid `persistentBrowser` mode `"persistent"` (Graph enum is only `always`/`never`).
- `prerequisites.md`: documented that `Get-AzAccessToken` returns a `SecureString` by default in **Az.Accounts 5.0.0+**, requiring manual conversion for the plain-text token the SSC scripts expect.
- `prerequisites.md`: "SSC enforces…" → "SSC validates…" (SSC validates + detects drift; CA policies enforce).

## Evidence
Added `LAB-VALIDATION.md` (purpose, checks, sources, gaps/fixes, runtime caveats, lab-readiness verdict).

## Sources (authoritative)
- signInFrequencySessionControl, persistentBrowserSessionControl, conditionalAccessSessionControls (v1.0), continuousAccessEvaluationSessionControl (beta) — Microsoft Graph reference
- `Get-AzAccessToken` SecureString change — Protect secrets in Azure PowerShell

## Caveats (runtime-only)
- CAE fix verified against published schema + parse-checked; end-to-end behavior needs a tenant with the beta module.
- Graph beta surfaces (CAE read, Zone 3 risky-user policy) are subject to change.
- `signInFrequency=everyTime` applies only in Microsoft-documented scenarios (risky users/sign-ins, Intune enrollment).
- All deployments create CA policies in report-only mode.

## Verification
- All 14 `.ps1` parse clean (`Parser::ParseFile`); all 5 `.py` `py_compile` OK.
- No FSI language-rule violations in Markdown. `manifest.yaml` not touched.