### PR TITLE
fix(unrestricted-agent-sharing-detector): lab-readiness validation and corrections

### DIFF
--- a/unrestricted-agent-sharing-detector/CHANGELOG.md
+++ b/unrestricted-agent-sharing-detector/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to the Unrestricted Agent Sharing Detector are documented he
 ### Fixed
 
 - `Restore-AgentSharingFromEvidence.ps1` nested `Restore-AgentSharing` helper now declares `SupportsShouldProcess`, preserving `-WhatIf` handling for live sharing restore calls.
+- `Restore-AgentSharingFromEvidence.ps1` token acquisition now requests `Get-AzAccessToken -AsSecureString` and converts to plain text before building the `Bearer` header. The ManagedIdentity and Interactive paths previously returned `$tokenResponse.Token` directly, which is a `SecureString` on Az.Accounts 5.0.0+/Az 14.0.0+, producing a `Bearer System.Security.SecureString` header and 401s. Aligns with the SecureString handling already used in the detector, export, and import scripts. ([Protect secrets in Azure PowerShell](https://learn.microsoft.com/powershell/azure/protect-secrets))
+- `Restore-AgentSharingFromEvidence.ps1` now restores the canonical UASD evidence shape — the prior bot-table sharing columns (`accesscontrolpolicy`, `authorizedsecuritygroupids`, `authenticationmode`, `authenticationtrigger`) captured in `fsi_evidencejson` by `Test-AgentSharingCompliance.ps1` and the detection flow — by PATCHing the `bot` record (with `If-Match: *`), reversing the documented remediation. The legacy per-principal `GrantAccess` evidence format is retained as a backward-compatible fallback. Previously the runbook only understood the principal-array format and could not consume real UASD evidence.
+
+### Changed
+
+- Added `#Requires -Modules Az.Accounts` to `Restore-AgentSharingFromEvidence.ps1` so the `Get-AzAccessToken` dependency is declared, matching the other governance scripts.
 
 ## [2.0.1] — 2026-05-04
 

--- a/unrestricted-agent-sharing-detector/LAB-VALIDATION.md
+++ b/unrestricted-agent-sharing-detector/LAB-VALIDATION.md
@@ -1,0 +1,115 @@
+# Lab Validation — Unrestricted Agent Sharing Detector (UASD)
+
+> Static validation report. No live tenant was used. Validation = parse-validity +
+> authoritative-source verification (Microsoft Learn) + script/doc coherence.
+> Date: 2026-06-04 · Solution version: v2.0.1 (+ Unreleased fixes)
+
+## Purpose & controls
+
+UASD provides **detective and corrective** controls for overly permissive Copilot
+Studio agent sharing. It reads each agent's sharing posture from the Dataverse
+`bot` table, classifies violations against zone policy, optionally remediates by
+restricting to approved security groups, and retains rollback evidence.
+
+- **Control 1.1** — Restrict Agent Publishing by Authorization (primary)
+- **Control 3.8** — Copilot Hub & Governance Dashboard (sharing visibility)
+- Regulatory context referenced: FINRA Rule 4511(a), SEC Rule 17a-4, SOX
+  Section 302/404, GLBA Section 501(b). Per repo language rules, the solution
+  *supports compliance with* / *helps meet* these obligations; it does not
+  guarantee them.
+
+## What was checked
+
+- All PowerShell scripts parse with zero errors
+  (`[Parser]::ParseFile`), and `Invoke-ScriptAnalyzer` shows only pre-existing
+  `PSAvoidUsingWriteHost` style warnings (consistent with the rest of the repo).
+- All Python setup scripts compile (`python -m py_compile`, exit 0).
+- The sharing-read path (`bot` table columns and option-set integers) was
+  verified column-by-column against the Microsoft Learn `bot` entity reference.
+- Auto-remediation and rollback (`Restore-AgentSharingFromEvidence.ps1`) were
+  checked against the documented evidence contract in `docs/flow-configuration.md`.
+- Token audiences and Az.Accounts behavior verified against Microsoft Learn.
+- Dataverse logical column names and option-set values cross-checked against
+  `create_uasd_dataverse_schema.py` / `docs/dataverse-schema.md`.
+- Markdown scanned for prohibited compliance-language (zero hits outside
+  CHANGELOG history).
+
+## Authoritative sources cited
+
+1. **Copilot (bot) table/entity reference (Microsoft Dataverse)** —
+   <https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/bot>
+   - `accesscontrolpolicy` (GlobalChoiceName `bot_accesscontrolpolicy`):
+     `0 = Any`, `1 = Copilot readers`, `2 = Group membership`,
+     `3 = Any (multi-tenant)`. **Matches** the detector's map and policy logic.
+   - `authenticationmode` (`bot_authenticationmode`): `0 = Unspecified`,
+     `1 = None`, `2 = Integrated`, `3 = Custom Azure Active Directory`,
+     `4 = Generic OAuth2`. Detector treats `1 = None` as unauthenticated/public —
+     **correct**.
+   - `authenticationtrigger`: `0 = As Needed`, `1 = Always`. **Matches.**
+   - `authorizedsecuritygroupids`: String, "comma-delimited list of **up to 20**
+     Azure AD Group IDs … ignored if Access Control Policy is not Group
+     membership", `MaxLength 739`. Remediation caps to the first 20 groups —
+     **correct**.
+2. **Protect secrets in Azure PowerShell** —
+   <https://learn.microsoft.com/powershell/azure/protect-secrets>
+   - "the default output type of `Get-AzAccessToken` changed from a plain text
+     `String` to a `SecureString`, starting with **Az.Accounts 5.0.0** and
+     **Az 14.0.0**." Basis for the SecureString fix below.
+3. **`Get-AzAccessToken` reference** —
+   <https://learn.microsoft.com/powershell/module/az.accounts/get-azaccesstoken>
+   - Confirms `-ResourceUrl` and `-AsSecureString` are current parameters.
+4. **Managed environment sharing limits / agent sharing rules** —
+   <https://learn.microsoft.com/en-us/power-platform/admin/managed-environment-sharing-limits#agent-sharing-rules>
+   - Confirms native preventive sharing controls described in the README; UASD is
+     positioned as the complementary detective/corrective layer.
+
+## Gaps found & fixes applied
+
+| # | Severity | Finding | Fix |
+|---|----------|---------|-----|
+| 1 | High (bug) | `Restore-AgentSharingFromEvidence.ps1` `Get-DataverseAccessToken` returned `$tokenResponse.Token` directly for the ManagedIdentity/Interactive paths. On Az.Accounts 5.0.0+ that is a `SecureString`, yielding a `Bearer System.Security.SecureString` header → 401. The detector, export, and import scripts already convert correctly; this script did not. | Request `-AsSecureString` explicitly and convert with `ConvertFrom-SecureString -AsPlainText` (handles both `SecureString` and legacy `String`). |
+| 2 | High (script↔doc inconsistency) | The backout runbook only understood a legacy **principal-array** evidence shape applied via `GrantAccess`. The canonical UASD evidence (`fsi_evidencejson`) written by `Test-AgentSharingCompliance.ps1` and the detection flow (`docs/flow-configuration.md` step 8) records the prior **bot sharing columns** — so the runbook could not actually reverse a real remediation. | Added a canonical restore branch that PATCHes the `bot` record (`accesscontrolpolicy`, `authorizedsecuritygroupids`, and `authenticationmode`/`authenticationtrigger` when present) with `If-Match: *`. The legacy `GrantAccess` path is retained as a backward-compatible fallback. Docstring updated to document both shapes. |
+| 3 | Low (prereq gap) | `Restore-AgentSharingFromEvidence.ps1` used `Get-AzAccessToken` without declaring the module dependency. | Added `#Requires -Modules Az.Accounts`, matching the other governance scripts. |
+
+All three fixes are recorded in `CHANGELOG.md` under `[Unreleased]`.
+
+### Verified-correct (no change needed)
+
+- `accesscontrolpolicy` / `authenticationmode` / `authenticationtrigger` /
+  `authorizedsecuritygroupids` usage and the 4-value access-policy map.
+- Option-set integers (`fsi_UASD_violationtype` etc.) are 100000000-based and
+  match `create_uasd_dataverse_schema.py`; the `fsi_acv_zone` vs
+  `fsi_UASD_zoneclassification` divergence is documented and honored.
+- Dataverse logical column names (lowercase, no inter-word underscores).
+- Deprecated scripts (`Invoke-SharingAudit.ps1`, all `Deploy-*Flow.ps1`) fail
+  closed with redirect messages — correct per the no-runtime-artifacts policy.
+- Token audience uses the environment org URL as the Dataverse resource —
+  correct for the Dataverse Web API.
+- No prohibited compliance-language in docs.
+
+## Runtime-only caveats (cannot be verified without a live tenant)
+
+- **Bot PATCH for remediation/restore.** Whether `accesscontrolpolicy` /
+  `authorizedsecuritygroupids` are updatable for a given published agent, and
+  whether the service principal/managed identity holds the required Dataverse
+  privileges, can only be confirmed against a real environment.
+- **`authenticationmode = 0` (Unspecified).** The detector flags only `1 = None`
+  as public. `0 = Unspecified` is not treated as a violation; confirm desired
+  posture against tenant data before relying on this.
+- **Per-environment restore target.** `Restore-AgentSharingFromEvidence.ps1`
+  patches against the single `-DataverseUrl` provided; multi-environment evidence
+  must be restored one environment at a time.
+- **`GrantAccess` legacy fallback** operates on Dataverse record-level sharing
+  (POA), a different concept from `accesscontrolpolicy` chat access. It exists
+  only for legacy principal-array evidence and is not produced by current UASD.
+- Managed-identity token acquisition, environment enumeration
+  (`Get-AdminPowerAppEnvironment`), and Teams/Approvals flow wiring require a
+  provisioned tenant.
+
+## Lab-readiness assessment
+
+**Lab-ready (static).** Scripts parse and compile, the authoritative sharing-read
+and remediation model matches the current Microsoft Learn `bot` reference, and
+the rollback runbook now consumes the evidence the solution actually produces and
+authenticates correctly on Az.Accounts 5.x. Remaining items are inherently
+runtime-only and require a provisioned Power Platform tenant to exercise.

--- a/unrestricted-agent-sharing-detector/LAB-VALIDATION.md
+++ b/unrestricted-agent-sharing-detector/LAB-VALIDATION.md
@@ -47,7 +47,7 @@ restricting to approved security groups, and retains rollback evidence.
      **correct**.
    - `authenticationtrigger`: `0 = As Needed`, `1 = Always`. **Matches.**
    - `authorizedsecuritygroupids`: String, "comma-delimited list of **up to 20**
-     Azure AD Group IDs … ignored if Access Control Policy is not Group
+     Microsoft Entra ID group IDs … ignored if Access Control Policy is not Group
      membership", `MaxLength 739`. Remediation caps to the first 20 groups —
      **correct**.
 2. **Protect secrets in Azure PowerShell** —

--- a/unrestricted-agent-sharing-detector/scripts/Restore-AgentSharingFromEvidence.ps1
+++ b/unrestricted-agent-sharing-detector/scripts/Restore-AgentSharingFromEvidence.ps1
@@ -1,4 +1,5 @@
 ﻿#Requires -Version 7.0
+#Requires -Modules Az.Accounts
 
 <#
 .SYNOPSIS
@@ -28,10 +29,17 @@
     sharing configurations. Required.
 
     JSON format: Array of objects with agentId, environmentId, and
-    previousSharingConfig properties.
+    previousSharingConfig properties. previousSharingConfig may be either:
+      - Canonical (recommended): an object holding the prior bot-table sharing
+        columns captured by Test-AgentSharingCompliance.ps1 / the detection flow
+        in fsi_evidencejson — { accesscontrolpolicy, authorizedsecuritygroupids,
+        authenticationmode, authenticationtrigger }. The restore reverses
+        remediation by PATCHing these columns back onto the bot record.
+      - Legacy: an array of per-principal share objects
+        ({ principalId, principalType, roleName }) re-applied via GrantAccess.
 
     CSV format: Columns AgentId, EnvironmentId, PreviousSharingPrincipals
-    (JSON-encoded array of principal objects).
+    (JSON-encoded — either the canonical object or the legacy principal array).
 
 .PARAMETER DataverseUrl
     Target Dataverse environment URL (e.g., https://org.crm.dynamics.com).
@@ -142,16 +150,28 @@ function Get-DataverseAccessToken {
 
     $resource = "$($DataverseUrl.TrimEnd('/'))/"
 
+    # Az.Accounts 5.0.0+ / Az 14.0.0+ return the token as a SecureString by
+    # default. Request it explicitly and convert to plain text for the Bearer
+    # header. Handles both SecureString (current) and String (legacy Az) results.
+    # Ref: https://learn.microsoft.com/powershell/azure/protect-secrets
+    $toPlainText = {
+        param($Token)
+        if ($Token -is [System.Security.SecureString]) {
+            return ($Token | ConvertFrom-SecureString -AsPlainText)
+        }
+        return [string]$Token
+    }
+
     switch ($AuthMode) {
         'ManagedIdentity' {
             Write-Verbose 'Acquiring token via system-assigned managed identity'
-            $tokenResponse = Get-AzAccessToken -ResourceUrl $resource
-            return $tokenResponse.Token
+            $tokenResponse = Get-AzAccessToken -ResourceUrl $resource -AsSecureString
+            return (& $toPlainText $tokenResponse.Token)
         }
         'Interactive' {
             Write-Verbose 'Acquiring token via interactive authentication'
-            $tokenResponse = Get-AzAccessToken -ResourceUrl $resource -TenantId $TenantId
-            return $tokenResponse.Token
+            $tokenResponse = Get-AzAccessToken -ResourceUrl $resource -TenantId $TenantId -AsSecureString
+            return (& $toPlainText $tokenResponse.Token)
         }
         'ClientSecret' {
             # legacy: dev-only — replace with managed identity in production
@@ -251,10 +271,24 @@ function Restore-AgentSharing {
 
     $apiBase = "$($DataverseUrl.TrimEnd('/'))/api/data/v9.2"
 
+    # Determine the evidence shape. The canonical UASD evidence (fsi_evidencejson)
+    # produced by Test-AgentSharingCompliance.ps1 and the detection flow records the
+    # prior bot-table sharing columns (accesscontrolpolicy, authorizedsecuritygroupids,
+    # authenticationmode, authenticationtrigger). A restore therefore reverses the
+    # remediation by patching those columns back onto the bot record.
+    # A legacy evidence shape — an array of per-principal share objects — is still
+    # supported via record-level GrantAccess as a backward-compatible fallback.
+    $hasAccessPolicy = $false
+    if ($sharingConfig -isnot [System.Array] -and
+        $null -ne $sharingConfig.PSObject.Properties['accesscontrolpolicy']) {
+        $hasAccessPolicy = $true
+    }
+
     if ($DryRun) {
+        $mode = if ($hasAccessPolicy) { 'bot accesscontrolpolicy restore' } else { 'principal GrantAccess restore' }
         Add-AuditEntry -Action 'RESTORE_DRYRUN' -AgentId $agentId -EnvironmentId $envId `
-            -Status 'DryRun' -Details "Would restore sharing to: $($sharingConfig | ConvertTo-Json -Compress)"
-        Write-Host "  [DRY-RUN] Agent ${agentId}: Would restore sharing config" -ForegroundColor Yellow
+            -Status 'DryRun' -Details "Would restore via ${mode}: $($sharingConfig | ConvertTo-Json -Compress)"
+        Write-Host "  [DRY-RUN] Agent ${agentId}: Would restore sharing config ($mode)" -ForegroundColor Yellow
         return
     }
 
@@ -265,18 +299,50 @@ function Restore-AgentSharing {
     }
 
     try {
-        # Look up the bot record by agent ID
-        $lookupUri = "$apiBase/bots?`$filter=botid eq '$agentId'&`$select=botid"
-        $lookupResponse = Invoke-RestMethod -Uri $lookupUri -Headers $headers -Method Get
-
-        if (-not $lookupResponse.value -or $lookupResponse.value.Count -eq 0) {
+        # Confirm the bot record exists before attempting a restore.
+        $lookupUri = "$apiBase/bots($agentId)?`$select=botid"
+        try {
+            Invoke-RestMethod -Uri $lookupUri -Headers $headers -Method Get | Out-Null
+        } catch {
             Add-AuditEntry -Action 'RESTORE_FAIL' -AgentId $agentId -EnvironmentId $envId `
                 -Status 'Failed' -Details "Agent not found in Dataverse"
             Write-Warning "  Agent ${agentId}: Not found in Dataverse — skipping"
             return
         }
 
-        # Build the sharing restoration payload
+        if ($hasAccessPolicy) {
+            # ── Canonical restore: re-apply the prior bot sharing columns ──────
+            $restoreBody = [ordered]@{
+                accesscontrolpolicy = [int]$sharingConfig.accesscontrolpolicy
+            }
+            $priorGroups = $null
+            if ($null -ne $sharingConfig.PSObject.Properties['authorizedsecuritygroupids']) {
+                $priorGroups = $sharingConfig.authorizedsecuritygroupids
+            }
+            $restoreBody['authorizedsecuritygroupids'] = if ($null -ne $priorGroups) { [string]$priorGroups } else { '' }
+            if ($null -ne $sharingConfig.PSObject.Properties['authenticationmode'] -and
+                $null -ne $sharingConfig.authenticationmode) {
+                $restoreBody['authenticationmode'] = [int]$sharingConfig.authenticationmode
+            }
+            if ($null -ne $sharingConfig.PSObject.Properties['authenticationtrigger'] -and
+                $null -ne $sharingConfig.authenticationtrigger) {
+                $restoreBody['authenticationtrigger'] = [int]$sharingConfig.authenticationtrigger
+            }
+
+            $patchHeaders = $headers.Clone()
+            $patchHeaders['If-Match'] = '*'  # update-only; avoid accidental upsert
+            $patchUri = "$apiBase/bots($agentId)"
+            $patchBody = $restoreBody | ConvertTo-Json -Compress
+            Invoke-RestMethod -Uri $patchUri -Headers $patchHeaders -Method Patch -Body $patchBody | Out-Null
+
+            Add-AuditEntry -Action 'RESTORE_COMPLETE' -AgentId $agentId -EnvironmentId $envId `
+                -Status 'Success' `
+                -Details "Restored bot sharing columns: $patchBody"
+            Write-Host "  Agent ${agentId}: Restored accesscontrolpolicy=$($restoreBody.accesscontrolpolicy)" -ForegroundColor Green
+            return
+        }
+
+        # ── Legacy restore: per-principal record sharing via GrantAccess ───────
         $principalIds = @()
         foreach ($principal in $sharingConfig) {
             if ($principal.principalId) {


### PR DESCRIPTION
## Summary
Lab-readiness validation of **unrestricted-agent-sharing-detector** (v2.0.1, controls 1.1 / 3.8). Static validation only (no live tenant): parse/compile checks + authoritative Microsoft Learn verification + script/doc coherence. Full evidence in `unrestricted-agent-sharing-detector/LAB-VALIDATION.md`.

## What / why
- **Fix SecureString token bug** in `Restore-AgentSharingFromEvidence.ps1`. `Get-AzAccessToken` returns a `SecureString` on **Az.Accounts 5.0.0+ / Az 14.0.0+**; the ManagedIdentity/Interactive paths returned `.Token` directly, producing a `Bearer System.Security.SecureString` header → 401. Now requests `-AsSecureString` and converts to plain text, matching the detector/export/import scripts.
- **Repair the backout runbook so it consumes real UASD evidence.** The canonical `fsi_evidencejson` (written by `Test-AgentSharingCompliance.ps1` and the detection flow) records the prior `bot` sharing columns, but the runbook only understood a legacy principal-array shape via `GrantAccess` — so it could not reverse a real remediation. Added a canonical restore branch that PATCHes `accesscontrolpolicy` / `authorizedsecuritygroupids` (+ `authenticationmode`/`authenticationtrigger`) with `If-Match: *`; legacy `GrantAccess` path kept as fallback.
- **Declare** `#Requires -Modules Az.Accounts` on the restore script.
- **Add** `LAB-VALIDATION.md` evidence report.

## Authoritative sources
- bot (Copilot) table reference — accesscontrolpolicy 0/1/2/3, authenticationmode 1=None, authenticationtrigger 0/1, authorizedsecuritygroupids (up to 20 groups): https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/bot
- Get-AzAccessToken SecureString change (Az.Accounts 5.0.0): https://learn.microsoft.com/powershell/azure/protect-secrets
- Get-AzAccessToken (-ResourceUrl/-AsSecureString): https://learn.microsoft.com/powershell/module/az.accounts/get-azaccesstoken
- Managed environment / agent sharing rules: https://learn.microsoft.com/en-us/power-platform/admin/managed-environment-sharing-limits#agent-sharing-rules

## Verification
- All `.ps1` parse with zero errors; `Invoke-ScriptAnalyzer` shows only pre-existing `Write-Host` style warnings.
- All `.py` compile (`py_compile` exit 0).
- No prohibited compliance language in docs.
- `manifest.yaml` not modified.

## Runtime-only caveats
Bot PATCH update rights, managed-identity token acquisition, environment enumeration, and flow wiring require a provisioned Power Platform tenant. `authenticationmode=0` (Unspecified) is not flagged (only `1=None`). See LAB-VALIDATION.md.
