### PR TITLE
fix(action-confirmation-auditor): second-pass command-existence corrections

### DIFF
--- a/action-confirmation-auditor/CHANGELOG.md
+++ b/action-confirmation-auditor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Action Confirmation Auditor are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **`scripts/Get-PurviewAIHubEvidence.ps1`**: Removed the invalid `copilotInteraction` value from the Graph audit log query `recordTypeFilters`. `copilotInteraction` is not a member of the v1.0 `auditLogRecordType` enum (it is the beta `copilotInteractionAuditRecord` record subtype, not a filter value); sending an unknown evolvable-enum member returns HTTP 400 and fails the entire query. The filter now uses only the valid camelCase members `aipDiscover` and `aipSensitivityLabelAction`, and Copilot interaction activity is collected via the existing Activity Explorer fallback. (second-pass command-existence audit; verified against `https://learn.microsoft.com/graph/api/resources/security-auditlogrecordtype?view=graph-rest-1.0`)
+
 ## [1.2.1] - 2026-05-23
 
 ### Fixed

--- a/action-confirmation-auditor/LAB-VALIDATION.md
+++ b/action-confirmation-auditor/LAB-VALIDATION.md
@@ -36,7 +36,7 @@ action type, and supports exception management with Maker/Checker gating.
 
 | Topic | Source |
 |-------|--------|
-| Graph audit log query API on **v1.0**, `recordTypeFilters`, `auditLogRecordType` enum (`copilotInteraction`) | `https://learn.microsoft.com/graph/api/resources/security-auditlogquery` and `https://learn.microsoft.com/graph/api/security-auditlogquery-list-records` |
+| Graph audit log query API on **v1.0**, `recordTypeFilters`, `auditLogRecordType` enum (`aipDiscover`, `aipSensitivityLabelAction`) | `https://learn.microsoft.com/graph/api/resources/security-auditlogquery` and `https://learn.microsoft.com/graph/api/security-auditlogquery-list-records` |
 | `Get-MgContext` exposes ClientId/TenantId/Scopes/AuthType — **not** an access token | `https://learn.microsoft.com/powershell/microsoftgraph/authentication-commands` |
 | `Invoke-MgGraphRequest` for authenticated Graph REST calls in PowerShell | `https://learn.microsoft.com/powershell/module/microsoft.graph.authentication/invoke-mggraphrequest` |
 | `Get-AzAccessToken` default output changed to SecureString; `-ResourceUrl` usage | `https://learn.microsoft.com/powershell/module/az.accounts/get-azaccesstoken` |
@@ -67,9 +67,14 @@ action type, and supports exception management with Maker/Checker gating.
    The schema has no such column. **Fix:** query `fsi_confirmationstatus`
    (option set, `Present = 100000000`) and derive `HasConfirmation` as a boolean.
 
-4. **`Get-PurviewAIHubEvidence.ps1` — enum casing.** `recordTypeFilters` values
-   normalized to documented camelCase (`copilotInteraction`, `aipDiscover`,
-   `aipSensitivityLabelAction`).
+4. **`Get-PurviewAIHubEvidence.ps1` — recordTypeFilters values.** The
+   `recordTypeFilters` use documented camelCase members of the v1.0
+   `auditLogRecordType` enum (`aipDiscover`, `aipSensitivityLabelAction`).
+   `copilotInteraction` is **not** a member of that enum (it is a beta
+   record subtype, `copilotInteractionAuditRecord`, not a filter value), so
+   it was removed — an unknown evolvable-enum member returns HTTP 400 and
+   fails the whole query. Copilot interaction activity is collected via the
+   Activity Explorer fallback.
 
 5. **`Start-ActionConfirmationRunbook-MI.ps1` — wrong token audience for Power
    Platform admin.** Acquired a Graph token and passed it to
@@ -119,8 +124,9 @@ action type, and supports exception management with Maker/Checker gating.
 - **Graph audit log query latency.** The script polls once after a 5-second
   delay; real audit queries may take longer to return records. Confirm and tune
   poll/retry against a live tenant.
-- **DSPM for AI availability / Copilot audit record types.** Presence of
-  `copilotInteraction` records depends on tenant licensing and audit
+- **DSPM for AI availability / Copilot audit record types.** Copilot
+  interaction activity is collected via the Activity Explorer fallback;
+  presence of those records depends on tenant licensing and audit
   configuration.
 
 ## Final Lab-Readiness Assessment

--- a/action-confirmation-auditor/scripts/Get-PurviewAIHubEvidence.ps1
+++ b/action-confirmation-auditor/scripts/Get-PurviewAIHubEvidence.ps1
@@ -128,8 +128,13 @@ function Get-PurviewAIHubEvidence {
                 displayName     = "ACA-DSPM-Correlation-$(Get-Date -Format 'yyyyMMdd')"
                 filterStartDateTime = $startDate
                 filterEndDateTime   = (Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ')
-                # auditLogRecordType enum members are camelCase.
-                recordTypeFilters   = @('copilotInteraction', 'aipDiscover', 'aipSensitivityLabelAction')
+                # auditLogRecordType enum members are camelCase. Note: there is
+                # no 'copilotInteraction' member in the v1.0 auditLogRecordType
+                # enum (copilotInteractionAuditRecord is a beta record subtype,
+                # not a recordTypeFilters value); sending it returns HTTP 400 and
+                # fails the whole query. Copilot interaction activity is collected
+                # via the Activity Explorer fallback below.
+                recordTypeFilters   = @('aipDiscover', 'aipSensitivityLabelAction')
             } | ConvertTo-Json
 
             $auditResp = Invoke-MgGraphRequest -Method POST -Uri $auditUri -Body $auditBody -OutputType PSObject -ErrorAction Stop


### PR DESCRIPTION
## Second-pass command-existence audit

Independent re-derivation of the command surface for `action-confirmation-auditor`. One genuine command/value-existence defect found and fixed.

### Fixed
**`scripts/Get-PurviewAIHubEvidence.ps1`** — the Graph audit log query passed `copilotInteraction` in `recordTypeFilters`. That value is **not** a member of the v1.0 `auditLogRecordType` enum (`copilotInteractionAuditRecord` is a beta *record subtype*, not a `recordTypeFilters` value). Sending an unknown evolvable-enum member returns **HTTP 400** and fails the entire `POST /security/auditLog/queries` request, so the whole AI Hub evidence collection silently failed. Filter now uses only the valid camelCase members `aipDiscover` and `aipSensitivityLabelAction`; Copilot interaction activity continues to be collected via the existing Activity Explorer fallback.

Authoritative source: https://learn.microsoft.com/graph/api/resources/security-auditlogrecordtype?view=graph-rest-1.0 (enum members list — no `copilotInteraction`) and https://learn.microsoft.com/graph/api/security-auditcoreroot-post-auditlogqueries?view=graph-rest-1.0 (camelCase wire values).

### Verified EXISTS (no change)
- Graph `POST /v1.0/security/auditLog/queries` + `/records` navigation (GA in v1.0).
- `Invoke-MgGraphRequest`, `Get-MgContext`, `Connect-MgGraph` (Microsoft.Graph.Authentication).
- `Get-AdminPowerAppEnvironment` (Microsoft.PowerApps.Administration.PowerShell).
- `Get-AzAccessToken -ResourceUrl` (Az.Accounts), `Get-MsalToken` (MSAL.PS, deprecated but present).
- Dataverse Web API `v9.2` entity sets `fsi_actionauditresults`, `fsi_actionscanrun` (explicit singular), `fsi_actionconfirmationexceptions`, `botcomponents` — logical column names verified against `create_dataverse_schema.py`.

Docs updated: `LAB-VALIDATION.md` and `CHANGELOG.md` (new `## [Unreleased]` section).