### PR TITLE
fix(coi-testing): second-pass command-existence corrections

### DIFF
--- a/coi-testing/CHANGELOG.md
+++ b/coi-testing/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the COI Testing Framework.
 ### Fixed
 
 - **Docs**: Repaired a truncated/orphaned note blockquote at the top of `README.md` whose lead-in clause had been lost (it began mid-sentence with "> implemented; the agent-interaction layer..."). Reconstructed it into a complete scaffold-status note consistent with the *Overview* and *Implementation Status* sections. (lab-readiness validation)
+- **Minor**: `Get-CoiInventory.ps1` no longer passes `--json` to `pac connection list`. Unlike `pac admin list` and `pac solution list`, the `pac connection list` command does not support a `--json` flag (only `--environment`), so the unknown option would cause PAC to error and the connection enumeration to return empty. `Invoke-PacCommand` already falls back to capturing the tabular text output when JSON is unavailable. `scripts/Get-CoiInventory.ps1:227`. (second-pass command-existence audit)
 
 ## [1.1.2] - 2026-05-23
 

--- a/coi-testing/LAB-VALIDATION.md
+++ b/coi-testing/LAB-VALIDATION.md
@@ -56,7 +56,7 @@ prerequisites, and troubleshooting.
 | Dataverse Web API record create returns **204 No Content** (runner accepts `[201, 204]`) | https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/use-insomnia-web-api · https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/create-entity-web-api |
 | Custom Dataverse Choice (option set) values live in the **100000000+** range | https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/create-update-options-web-api |
 | App-only / confidential-client Dataverse token scope is `<environment-url>/.default` (runner uses `f"{environment}/.default"`) | https://learn.microsoft.com/en-us/power-apps/developer/data-platform/authenticate-oauth |
-| `pac admin list`, `pac solution list`, `pac connection list`, `--json` are valid PAC CLI commands | https://learn.microsoft.com/en-us/power-platform/developer/cli/reference/admin · https://learn.microsoft.com/en-us/power-platform/developer/cli/reference/solution · https://learn.microsoft.com/en-us/power-platform/developer/cli/reference/connection |
+| `pac admin list` and `pac solution list` support `--json`; `pac connection list` exists but supports only `--environment` (no `--json` flag) | https://learn.microsoft.com/en-us/power-platform/developer/cli/reference/admin · https://learn.microsoft.com/en-us/power-platform/developer/cli/reference/solution · https://learn.microsoft.com/en-us/power-platform/developer/cli/reference/connection |
 | `azure-identity` credential classes used by the runner (`ManagedIdentityCredential`, `WorkloadIdentityCredential`, `CertificateCredential`, `AzureCliCredential`, `DeviceCodeCredential`, `ClientSecretCredential`, `ChainedTokenCredential`) | https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme |
 | Direct Line 3.0 concepts (referenced as future/not-implemented in a `TODO`) | https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-direct-line-3-0-concepts |
 
@@ -65,6 +65,7 @@ prerequisites, and troubleshooting.
 | Severity | Gap | Fix |
 |----------|-----|-----|
 | Minor (docs) | `README.md` carried a **truncated/orphaned note blockquote** at the top — it began mid-sentence ("> implemented; the agent-interaction layer…") with its lead-in clause lost. | Reconstructed it into a complete scaffold-status note consistent with *Overview* / *Implementation Status*. Added an `[Unreleased]` CHANGELOG entry. |
+| Command-existence (second pass) | `Get-CoiInventory.ps1` invoked `pac connection list --json`, but `pac connection list` does not document a `--json` flag (only `--environment`) — the unknown option would cause PAC to error and the connection enumeration to return empty. `pac admin list` and `pac solution list` *do* support `--json`. | Removed `--json` from the `pac connection list` invocation; `Invoke-PacCommand` already falls back to capturing tabular text when JSON is unavailable. |
 
 No other defects were found. Scripts parse and run, exit codes match documentation,
 column names and option-set values are internally consistent, authentication is

--- a/coi-testing/scripts/Get-CoiInventory.ps1
+++ b/coi-testing/scripts/Get-CoiInventory.ps1
@@ -224,7 +224,10 @@ function Main {
     # ── Connections (optional) ───────────────────────────────────────────
     if ($IncludeConnections) {
         Write-Info 'Enumerating connections...'
-        $connections = Invoke-PacCommand -Command @('connection','list','--json') -Description 'Connection list' -DryRun:$DryRun
+        # Note: 'pac connection list' does not support the --json flag (only --environment),
+        # unlike 'pac admin list' and 'pac solution list'. Invoke-PacCommand falls back to
+        # capturing the tabular text output when JSON is unavailable.
+        $connections = Invoke-PacCommand -Command @('connection','list') -Description 'Connection list' -DryRun:$DryRun
         $inventory.connections = @($connections)
         Write-Info "Found $($connections.Count) connection(s)"
     }


### PR DESCRIPTION
## Second-pass command-existence audit — coi-testing

Independent, fresh-eyes re-derivation. Verified every cmdlet/CLI verb/flag/endpoint/column/option-set against Microsoft Learn.

### Fix (1)
**`Get-CoiInventory.ps1` invoked `pac connection list --json` — `--json` is not a valid flag for `pac connection list`.**

- `pac connection list` documents only `--environment` (no `--json`): https://learn.microsoft.com/en-us/power-platform/developer/cli/reference/connection
- By contrast `pac admin list` and `pac solution list` **do** support `--json`: https://learn.microsoft.com/en-us/power-platform/developer/cli/reference/admin · https://learn.microsoft.com/en-us/power-platform/developer/cli/reference/solution
- The unknown option would cause PAC to error (exit ≠ 0), so the `-IncludeConnections` enumeration would always return empty.
- **Fix:** removed `--json` from the `pac connection list` invocation (`scripts/Get-CoiInventory.ps1`). `Invoke-PacCommand` already falls back to capturing tabular text when JSON output is unavailable, so the command now runs.

### Surfaces verified EXISTS (no change)
- `pac admin list --json` and `pac solution list --json` — both flags documented (Learn refs above).
- `azure-identity` credential classes (`ManagedIdentityCredential`, `WorkloadIdentityCredential`, `CertificateCredential`, `AzureCliCredential`, `DeviceCodeCredential`, `ClientSecretCredential`, `ChainedTokenCredential`) and `azure.core.exceptions.ClientAuthenticationError` — all real.
- Dataverse Web API `POST /api/data/v9.2/fsi_coitestresults` (entity set = pluralized logical name `fsi_coitestresult`), logical columns `fsi_scenarioid/fsi_scenarioname/fsi_category/fsi_status/fsi_executedon/fsi_findings`, custom Choice ints `100000000`–`100000004`, token scope `{env}/.default` — internally consistent with `docs/dataverse-schema.md`.
- Direct Line 3.0 doc link is referenced only in a `TODO` (agent-interaction layer not implemented) — no live command.

### Docs aligned
- Corrected the LAB-VALIDATION.md claim that `pac connection list`/`--json` were all valid.
- Added `[Unreleased]` CHANGELOG entry above the latest release heading.

No banned compliance-absolute phrasing introduced.