### PR TITLE
fix(audit-compliance-manager): second-pass command-existence corrections

### DIFF
--- a/audit-compliance-manager/CHANGELOG.md
+++ b/audit-compliance-manager/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Invalid `RetentionDuration` enum values (second-pass command-existence):** `Test-PurviewRetention.ps1` mapped retention requirements to non-existent `UnifiedAuditLogRetentionDuration` values (`OneYear`, `TwoYears`, `ThreeYears`, `FiveYears`, `SevenYears`). The enum only accepts `ThreeMonths`, `SixMonths`, `NineMonths`, `TwelveMonths`, `TenYears`. `Get-RequiredRetentionDuration` now returns `TwelveMonths` (was `OneYear`) and maps any requirement above 365 days to `TenYears` (the only valid value that meets a 730-day Zone 3 minimum). The `RetentionDurationMap` lookup was corrected to key on the real enum values so a `TwelveMonths` policy is no longer mis-read as `$null`/below-minimum. Remediation guidance also now includes the **mandatory** `-Priority` parameter that `New-UnifiedAuditLogRetentionPolicy` requires. Source: Microsoft Learn `New-UnifiedAuditLogRetentionPolicy`.
 - `Compare-ValidationBaseline.ps1` now uses `$null -eq` baseline detection so array-shaped Dataverse responses are handled consistently.
 
 ## [1.0.5] - 2026-05-23

--- a/audit-compliance-manager/scripts/Test-PurviewRetention.ps1
+++ b/audit-compliance-manager/scripts/Test-PurviewRetention.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.2
+﻿#Requires -Version 7.2
 #Requires -Modules @{ ModuleName="ExchangeOnlineManagement"; ModuleVersion="3.0.0" }
 
 <#

--- a/audit-compliance-manager/scripts/Test-PurviewRetention.ps1
+++ b/audit-compliance-manager/scripts/Test-PurviewRetention.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Version 7.2
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName="ExchangeOnlineManagement"; ModuleVersion="3.0.0" }
 
 <#
@@ -180,17 +180,17 @@ function Test-PurviewRetention {
     # Critical record types for AI agent governance
     $RequiredRecordTypes = @("CopilotInteraction", "PowerPlatformAdmin")
 
-    # Retention duration enum to days mapping
+    # Retention duration enum to days mapping.
+    # Keys are the only values the UnifiedAuditLogRetentionDuration enum accepts
+    # (ThreeMonths, SixMonths, NineMonths, TwelveMonths, TenYears) and that
+    # Get-UnifiedAuditLogRetentionPolicy returns. There is no intermediate value
+    # between TwelveMonths (365 days) and TenYears (3650 days).
     $RetentionDurationMap = @{
-        "ThreeMonths" = 90
-        "SixMonths"   = 180
-        "NineMonths"  = 270
-        "OneYear"     = 365
-        "TwoYears"    = 730
-        "ThreeYears"  = 1095
-        "FiveYears"   = 1825
-        "SevenYears"  = 2555
-        "TenYears"    = 3650
+        "ThreeMonths"  = 90
+        "SixMonths"    = 180
+        "NineMonths"   = 270
+        "TwelveMonths" = 365
+        "TenYears"     = 3650
     }
 
     $checks = @()
@@ -254,7 +254,7 @@ function Test-PurviewRetention {
                     CurrentRetentionDays = $DefaultAuditStandardRetentionDays
                     RequiredRetentionDays = $minimumRequiredDays
                     Severity             = "Critical"
-                    Recommendation       = "Create custom retention policy: New-UnifiedAuditLogRetentionPolicy -Name 'Zone $Zone Retention' -RetentionDuration $(Get-RequiredRetentionDuration -Days $minimumRequiredDays)"
+                    Recommendation       = "Create custom retention policy: New-UnifiedAuditLogRetentionPolicy -Name 'Zone $Zone Retention' -RetentionDuration $(Get-RequiredRetentionDuration -Days $minimumRequiredDays) -Priority 100"
                 }
             }
             else {
@@ -283,7 +283,7 @@ function Test-PurviewRetention {
                         CurrentRetentionDays = $DefaultAuditStandardRetentionDays
                         RequiredRetentionDays = $minimumRequiredDays
                         Severity             = "Critical"
-                        Recommendation       = "Create record type-specific policy: New-UnifiedAuditLogRetentionPolicy -Name '$recordType Retention' -RecordTypes $recordType -RetentionDuration $(Get-RequiredRetentionDuration -Days $minimumRequiredDays)"
+                        Recommendation       = "Create record type-specific policy: New-UnifiedAuditLogRetentionPolicy -Name '$recordType Retention' -RecordTypes $recordType -RetentionDuration $(Get-RequiredRetentionDuration -Days $minimumRequiredDays) -Priority 100"
                     }
                 }
                 else {
@@ -421,7 +421,7 @@ function Test-PurviewRetention {
                             CurrentRetentionDays = $DefaultAuditStandardRetentionDays
                             RequiredRetentionDays = $minimumRequiredDays
                             Severity             = "High"
-                            Recommendation       = "Create record type-specific policy: New-UnifiedAuditLogRetentionPolicy -Name '$recordType Retention' -RecordTypes $recordType -RetentionDuration $(Get-RequiredRetentionDuration -Days $minimumRequiredDays)"
+                            Recommendation       = "Create record type-specific policy: New-UnifiedAuditLogRetentionPolicy -Name '$recordType Retention' -RecordTypes $recordType -RetentionDuration $(Get-RequiredRetentionDuration -Days $minimumRequiredDays) -Priority 100"
                         }
                     }
                     else {
@@ -549,14 +549,15 @@ function Test-PurviewRetention {
 function Get-RequiredRetentionDuration {
     param([int]$Days)
 
+    # Returns the smallest UnifiedAuditLogRetentionDuration enum value that meets
+    # or exceeds the required number of days. Valid enum values per
+    # New-UnifiedAuditLogRetentionPolicy are ThreeMonths, SixMonths, NineMonths,
+    # TwelveMonths, and TenYears. Any requirement above 365 days maps to TenYears
+    # because the enum has no intermediate value.
     if ($Days -le 90) { return "ThreeMonths" }
     elseif ($Days -le 180) { return "SixMonths" }
     elseif ($Days -le 270) { return "NineMonths" }
-    elseif ($Days -le 365) { return "OneYear" }
-    elseif ($Days -le 730) { return "TwoYears" }
-    elseif ($Days -le 1095) { return "ThreeYears" }
-    elseif ($Days -le 1825) { return "FiveYears" }
-    elseif ($Days -le 2555) { return "SevenYears" }
+    elseif ($Days -le 365) { return "TwelveMonths" }
     else { return "TenYears" }
 }
 


### PR DESCRIPTION
## Second-pass command-existence audit: audit-compliance-manager

Independent re-derivation of every command this solution invokes against Microsoft Learn. One real existence bug found and fixed in scripts/Test-PurviewRetention.ps1.

### Fixed
**Invalid UnifiedAuditLogRetentionDuration enum values + missing mandatory -Priority.**

Get-RequiredRetentionDuration mapped retention requirements to enum values that do not exist (OneYear, TwoYears, ThreeYears, FiveYears, SevenYears). Per Microsoft Learn the `-RetentionDuration` parameter only accepts **ThreeMonths, SixMonths, NineMonths, TwelveMonths, TenYears**. Any recommended `New-UnifiedAuditLogRetentionPolicy` command for Zone 2/3 (365/730-day minimums) would fail parameter binding.

- `Get-RequiredRetentionDuration`: returns `TwelveMonths` (was `OneYear`); anything > 365 days maps to `TenYears` (only valid value >= 730).
- `\`: keyed on real enum values, so a live `TwelveMonths` policy parses to 365 days instead of `\` (which previously read as below-minimum).
- Remediation strings now include the **mandatory** `-Priority` parameter that the cmdlet requires.

Source: https://learn.microsoft.com/en-us/powershell/module/exchange/new-unifiedauditlogretentionpolicy

### Verified EXISTS (no change)
- **Exchange/S&C cmdlets:** `Connect-ExchangeOnline`, `Connect-IPPSSession`, `Get-AdminAuditLogConfig` (`UnifiedAuditLogIngestionEnabled`), `Search-UnifiedAuditLog` (`-StartDate/-EndDate/-FreeText/-ResultSize`), `Get-UnifiedAuditLogRetentionPolicy`, `Get-OrganizationConfig`/`Set-OrganizationConfig -AuditDisabled`, `Get-EXOMailbox -PropertySets Audit`, `Set-Mailbox -CustomAttribute15`.
- **Modules:** `ExchangeOnlineManagement` 3.0.0+, `Microsoft.PowerApps.Administration.PowerShell` 2.0.180. `MSAL.PS` 4.37.0 is archived but still on PSGallery and already flagged in-code.
- **Managed Identity / Dataverse:** App Service MI `IDENTITY_ENDPOINT` + `api-version=2019-08-01`; Dataverse Web API `/api/data/v9.2/` with entity set `fsi_auditenvironmentcompliances` and alternate key `fsi_environmentid` matching the schema script.

No banned compliance phrasing introduced; CHANGELOG `[Unreleased]` updated.