### PR TITLE
fix(credential-oversharing-detector): second-pass command-existence corrections

### DIFF
--- a/credential-oversharing-detector/CHANGELOG.md
+++ b/credential-oversharing-detector/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this solution are documented here.
 
 ### Fixed
 
+- **Second-pass command-existence audit:** Migrated `Export-CredentialEvidence.ps1` off the deprecated/archived `MSAL.PS` module (`Get-MsalToken`) to `Az.Accounts` (`Connect-AzAccount` + `Get-AzAccessToken -ResourceUrl <DataverseUrl> -AsSecureString`), matching the Dataverse token-acquisition pattern already used by the other COD governance scripts. `MSAL.PS` is no longer maintained by Microsoft; removing it eliminates a future-break dependency and aligns the evidence-export auth path with the managed-identity-first standard. `-Interactive` and service-principal certificate (`-ClientId`/`-CertificateThumbprint`) flows are preserved. Updated `docs/prerequisites.md` to drop the `MSAL.PS` row.
 - **Wave 6 P4b:** Empty catch blocks now log via `Write-Verbose` instead of silently swallowing errors. Output is unchanged unless caller passes `-Verbose`.
 
 ### Validation

--- a/credential-oversharing-detector/docs/prerequisites.md
+++ b/credential-oversharing-detector/docs/prerequisites.md
@@ -7,8 +7,7 @@
 | PowerShell | 7.1+ | Core scanning and governance scripts |
 | Microsoft.PowerApps.Administration.PowerShell | 2.0.217+ | Power Platform environment and agent queries (`Add-PowerAppsAccount`, `Get-AdminPowerAppEnvironment`) |
 | Python | 3.9+ | Dataverse schema setup and evidence export |
-| Az.Accounts | 2.17.0+ (5.3.4 validated) | Dataverse token acquisition for compliance persistence |
-| MSAL.PS | 4.37.0.0+ | Dataverse evidence export authentication |
+| Az.Accounts | 2.17.0+ (5.3.4 validated) | Dataverse token acquisition for compliance persistence and evidence export |
 | Microsoft.Graph (optional) | 2.36.1+ | Entra ID service principal queries when Graph enrichment is enabled |
 
 ## Licensing

--- a/credential-oversharing-detector/scripts/governance/Export-CredentialEvidence.ps1
+++ b/credential-oversharing-detector/scripts/governance/Export-CredentialEvidence.ps1
@@ -1,5 +1,5 @@
 ﻿#Requires -Version 7.0
-#Requires -Modules @{ ModuleName='MSAL.PS'; ModuleVersion='4.37.0.0' }
+#Requires -Modules @{ ModuleName='Az.Accounts'; ModuleVersion='2.17.0' }
 
 <#
 .SYNOPSIS
@@ -156,57 +156,40 @@ if (-not (Test-Path -Path $OutputDirectory)) {
 
 Write-Host "  Authenticating to Dataverse..." -ForegroundColor Cyan
 
-$dataverseScope = "$($DataverseUrl.TrimEnd('/'))/.default"
+# Dataverse requires a token whose audience is the environment URL. Acquire it via
+# Az.Accounts (managed-identity-first per AGENTS.md authentication standard), matching
+# the token-acquisition pattern used by the other COD governance scripts.
+$dataverseResource = $DataverseUrl.TrimEnd('/')
 
-if ($Interactive) {
-    try {
-        if (-not (Get-Module -ListAvailable -Name MSAL.PS)) {
-            throw "MSAL.PS module is required for authentication. Install with: Install-Module MSAL.PS -Scope CurrentUser"
+try {
+    $azContext = Get-AzContext -ErrorAction SilentlyContinue
+
+    if ($Interactive) {
+        if (-not $azContext) {
+            $connectParams = @{ Tenant = $TenantId }
+            if ($ClientId) { $connectParams.AccountId = $ClientId }
+            Connect-AzAccount @connectParams | Out-Null
         }
-        Import-Module MSAL.PS -ErrorAction Stop
-
-        $msalParams = @{
-            TenantId    = $TenantId
-            Scopes      = @($dataverseScope)
-            Interactive = $true
+    }
+    else {
+        # Service principal with certificate
+        if (-not $ClientId) {
+            throw "ClientId is required for service principal authentication. Use -Interactive for browser-based auth."
         }
-        if ($ClientId) { $msalParams.ClientId = $ClientId }
+        if (-not $CertificateThumbprint) {
+            throw "CertificateThumbprint is required for service principal authentication."
+        }
 
-        $authResult = Get-MsalToken @msalParams
-        $accessToken = $authResult.AccessToken
+        Connect-AzAccount -ServicePrincipal -Tenant $TenantId `
+            -ApplicationId $ClientId -CertificateThumbprint $CertificateThumbprint | Out-Null
     }
-    catch {
-        Write-Error "Interactive authentication failed: $($_.Exception.Message)"
-        throw
-    }
+
+    $tokenResult = Get-AzAccessToken -ResourceUrl $dataverseResource -AsSecureString -ErrorAction Stop
+    $accessToken = $tokenResult.Token | ConvertFrom-SecureString -AsPlainText
 }
-else {
-    # Service principal with certificate
-    if (-not $ClientId) {
-        throw "ClientId is required for service principal authentication. Use -Interactive for browser-based auth."
-    }
-    if (-not $CertificateThumbprint) {
-        throw "CertificateThumbprint is required for service principal authentication."
-    }
-
-    try {
-        if (-not (Get-Module -ListAvailable -Name MSAL.PS)) {
-            throw "MSAL.PS module is required for authentication. Install with: Install-Module MSAL.PS -Scope CurrentUser"
-        }
-        Import-Module MSAL.PS -ErrorAction Stop
-
-        $authResult = Get-MsalToken `
-            -TenantId $TenantId `
-            -ClientId $ClientId `
-            -ClientCertificate (Get-Item "Cert:\CurrentUser\My\$CertificateThumbprint") `
-            -Scopes @($dataverseScope)
-
-        $accessToken = $authResult.AccessToken
-    }
-    catch {
-        Write-Error "Service principal authentication failed: $($_.Exception.Message)"
-        throw
-    }
+catch {
+    Write-Error "Dataverse authentication failed: $($_.Exception.Message)"
+    throw
 }
 
 Write-Host "  Authentication successful." -ForegroundColor Green


### PR DESCRIPTION
## Second-pass command-existence audit — credential-oversharing-detector

Independent re-derivation (did not trust LAB-VALIDATION.md). Verified every cmdlet, REST endpoint, api-version, Dataverse table/column, and option-set against Microsoft Learn / PSGallery.

### Fix
**`Export-CredentialEvidence.ps1`** depended on the **deprecated/archived `MSAL.PS`** module (`Get-MsalToken`). Microsoft no longer maintains MSAL.PS (AzureAD/MSAL.PS is archived), making it a future-break dependency.

- `#Requires` `MSAL.PS 4.37.0.0` -> `Az.Accounts 2.17.0`
- Auth block `Get-MsalToken` (interactive + `-ClientCertificate`) -> `Connect-AzAccount` (+ `-ServicePrincipal -CertificateThumbprint`) then `Get-AzAccessToken -ResourceUrl <DataverseUrl> -AsSecureString`
- Matches the Dataverse token-acquisition pattern already used by `Compare-OAuthScopeBaseline.ps1`, `Test-AgentAuthMethod.ps1`, `Test-CredentialCompliance.ps1`
- `-Interactive` and service-principal certificate flows preserved
- `docs/prerequisites.md`: dropped the MSAL.PS row (folded into Az.Accounts purpose)

Learn refs:
- Get-AzAccessToken (`-ResourceUrl`, `-AsSecureString`): https://learn.microsoft.com/powershell/module/az.accounts/get-azaccesstoken
- Connect-AzAccount (`-ServicePrincipal`/`-CertificateThumbprint`): https://learn.microsoft.com/powershell/module/az.accounts/connect-azaccount

### Verified EXISTS (no change needed)
- `Add-PowerAppsAccount -Endpoint/-TenantID/-ApplicationId/-ClientSecret` (Microsoft.PowerApps.Administration.PowerShell 2.0.217) and `Get-AdminPowerAppEnvironment`
- Graph v1.0 cmdlets: `Get-MgIdentityConditionalAccessPolicy`, `Get-MgServicePrincipal`, `Get-MgApplication`, `Get-MgApplicationFederatedIdentityCredential`
- Dataverse Web API v9.2 entity sets (`bots`, `connectionreferences`, `fsi_credentialscans`, `fsi_credentialviolations`, `fsi_agentconnectorscopes`) and logical column names cross-checked against `create_cod_dataverse_schema.py`
- Option-set integers (100000000+) for zone/violationtype/severity/status
- Edited script parses cleanly (`[Parser]::ParseFile`)