### PR TITLE
fix(cross-solution-integration): second-pass command-existence corrections

### DIFF
--- a/cross-solution-integration/CHANGELOG.md
+++ b/cross-solution-integration/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this solution will be documented in this file.
 
 ### Fixed
 
+- **Second-pass command-existence (P0 column fix):** Evidence registration in `Sync-SolutionAssessments.ps1` wrote the non-existent column `fsi_description` on `fsi_complianceevidence`; the schema defines the memo column as `fsi_evidencedescription` (`compliance-dashboard/scripts/create_cd_dataverse_schema.py:204`). A live Web API `POST`/`PATCH` would have returned `400` (property does not exist). Corrected both evidence writes (`scripts/powershell/Sync-SolutionAssessments.ps1`) and the documented payload in `docs/status-mapping.md`.
 - **Wave 6 P4b:** Empty catch blocks now log via `Write-Verbose` instead of silently swallowing errors. Output is unchanged unless caller passes `-Verbose`.
 
 ### Documentation

--- a/cross-solution-integration/LAB-VALIDATION.md
+++ b/cross-solution-integration/LAB-VALIDATION.md
@@ -136,3 +136,19 @@ material risk to a first lab deployment — the missing Dataverse Application Us
 security-role prerequisite for non-interactive auth — is now documented in
 `PREREQUISITES.md`. Remaining items are runtime confirmations that require a live
 tenant.
+
+## Second-pass command-existence addendum (2026-06-04)
+
+An independent fresh-eyes re-derivation of every entity set, logical column, and
+option-set value found one issue the first pass missed: the evidence-registration
+path in `Sync-SolutionAssessments.ps1` wrote `fsi_description` on
+`fsi_complianceevidence`, but that table's memo column is `fsi_evidencedescription`
+(`compliance-dashboard/scripts/create_cd_dataverse_schema.py:204`). A live Web API
+`POST`/`PATCH` would have returned `400` (property does not exist). The first pass
+verified the Tier 2 history tables and Compliance Dashboard option sets but did not
+cover the evidence-write column mapping. Corrected in both evidence writes and in
+`docs/status-mapping.md`. All other cross-solution references re-confirmed accurate.
+
+> Note: `fsi_collectedby` is `Required` on `fsi_complianceevidence` and is not set by
+> the script; whether a live create succeeds depends on tenant default-population of
+> that lookup. This is a runtime confirmation, not a command-existence defect.

--- a/cross-solution-integration/docs/status-mapping.md
+++ b/cross-solution-integration/docs/status-mapping.md
@@ -187,7 +187,7 @@ When Tier 2 solutions export evidence packages, register them in `fsi_compliance
   "fsi_name": "ACV Evidence Export — 2026-02-10",
   "fsi_controlassessmentid@odata.bind": "/fsi_controlassessments({assessment_guid})",
   "fsi_evidencetype": 5,
-  "fsi_description": "Automated evidence from Audit Configuration Validator. SHA-256 verified.",
+  "fsi_evidencedescription": "Automated evidence from Audit Configuration Validator. SHA-256 verified.",
   "fsi_collecteddate": "2026-02-10T06:00:00Z",
   "fsi_hash": "a1b2c3d4..."
 }

--- a/cross-solution-integration/scripts/powershell/Sync-SolutionAssessments.ps1
+++ b/cross-solution-integration/scripts/powershell/Sync-SolutionAssessments.ps1
@@ -532,7 +532,7 @@ function Register-SolutionEvidence {
         $evidenceRecord = @{
             'fsi_name'          = "$Solution Evidence Package — $($exportDate.Substring(0,10))"
             'fsi_evidencetype'  = Get-EvidenceTypeId
-            'fsi_description'   = "Automated evidence package from $((Get-SolutionTableConfig)[$Solution].SolutionName). Files: $fileNames. SHA-256 recomputed and verified against manifest at registration time."
+            'fsi_evidencedescription' = "Automated evidence package from $((Get-SolutionTableConfig)[$Solution].SolutionName). Files: $fileNames. SHA-256 recomputed and verified against manifest at registration time."
             'fsi_collecteddate' = $exportDate
             'fsi_hash'          = $packageHash
         }
@@ -597,7 +597,7 @@ function Register-SolutionEvidence {
     $evidenceRecord = @{
         'fsi_name'          = "$Solution Evidence Export — $([DateTime]::UtcNow.ToString('yyyy-MM-dd'))"
         'fsi_evidencetype'  = Get-EvidenceTypeId
-        'fsi_description'   = "Automated evidence from $((Get-SolutionTableConfig)[$Solution].SolutionName). SHA-256 recomputed at registration. File: $($evidenceFile.Name)"
+        'fsi_evidencedescription' = "Automated evidence from $((Get-SolutionTableConfig)[$Solution].SolutionName). SHA-256 recomputed at registration. File: $($evidenceFile.Name)"
         'fsi_collecteddate' = (Get-IsoUtcTimestamp)
         'fsi_hash'          = $hash
     }


### PR DESCRIPTION
## Second-pass command-existence audit — cross-solution-integration

Independent fresh-eyes re-derivation of every Dataverse entity set, logical column, and option-set value referenced by this integration layer against each sibling solution's authoritative `create_*_dataverse_schema.py`.

### Fix (1 P0 column-existence bug)
- **`fsi_description` → `fsi_evidencedescription`** on `fsi_complianceevidence`. The evidence-registration path wrote a column that does not exist on that table; the schema defines the memo column as `fsi_evidencedescription` (`compliance-dashboard/scripts/create_cd_dataverse_schema.py:204`). A live Web API `POST`/`PATCH` would have returned **400 (property does not exist)**.
  - `scripts/powershell/Sync-SolutionAssessments.ps1` (manifest-mode and legacy-mode evidence writes)
  - `docs/status-mapping.md` (documented payload)
  - Schema ref: [Dataverse Web API create/update](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/create-entity-web-api)

### Verified EXISTS (no change)
- All 6 Tier 2 history entity sets: `fsi_auditvalidationhistories` (ACV), `fsi_validationhistories` (SSC), `fsi_accessvalidationhistory` (AAM, explicit singular), `fsi_moderationvalidationhistory` (CMM, explicit singular), `fsi_fileuploadvalidationhistories` (FUS), `fsi_capolicyvalidationhistories` (CAA).
- Every `\` field in `Export-UnifiedComplianceEvidence.ps1` confirmed against each schema (incl. `{PUBLISHER_PREFIX}` f-string columns in SSC/CAA).
- ACV `fsi_environmentregistries` columns used by `Register-ProvisionedEnvironment.ps1` (`fsi_name/fsi_environmentid/fsi_zone/fsi_status/fsi_environmenttype/fsi_discoveredon/fsi_notes/fsi_environmenturl`) + GUID `fsi_environmentregistryid`.
- Compliance Dashboard tables/columns (`fsi_controlmasters`, `fsi_controlassessments` incl. `fsi_nextreviewdate`, `fsi_complianceevidences`, `fsi_compliancescores`) and option sets `fsi_cd_status` (1-4), `fsi_cd_zone` (1-3), `fsi_cd_evidencetype` (5=Test Result) — all 1-based, intentionally.
- Auth: `IntegrationConfig.psd1` `RequiredModules=@()` — no hard dependency on deprecated `MSAL.PS`; managed-identity-first with graceful `Get-MsalToken` fallback. IMDS api-versions `2018-02-01` / `2019-08-01` valid.

### UNVERIFIABLE (runtime only)
- `fsi_collectedby` is `Required` on `fsi_complianceevidence` and is not set by the script; success depends on tenant default-population. Documented as a runtime caveat, not an existence defect.

Second-pass note: one missed evidence-column mapping corrected; all other cross-solution command, endpoint, and column references re-confirmed against authoritative Microsoft schemas.