### PR TITLE
fix(deny-event-correlation-report): second-pass command-existence corrections

### DIFF
--- a/deny-event-correlation-report/CHANGELOG.md
+++ b/deny-event-correlation-report/CHANGELOG.md
@@ -21,6 +21,18 @@ All notable changes to the Deny Event Correlation Report are documented here.
 
 ### Fixed
 
+- **DLP audit extraction used an invalid `Search-UnifiedAuditLog -RecordType`.**
+  `DlpRuleMatch` is an audit *Operation*, not a member of the `AuditRecordType`
+  enum, so `Search-UnifiedAuditLog -RecordType "DlpRuleMatch"` failed parameter
+  binding and the DLP extractor could not run. `scripts/Export-DlpCopilotEvents.ps1`
+  now filters with `-Operations "DlpRuleMatch"` (returns DLP rule-match events
+  across all DLP workloads). In `kql-queries/dlp-copilot-matches.kql` the seven
+  `where RecordType == "DlpRuleMatch"  // Numeric equivalent: 55` filters were
+  corrected to `where Operation == "DlpRuleMatch"`; the "Numeric equivalent: 55"
+  comment was wrong (record type 55 is `SharePointContentTypeOperation`; valid DLP
+  record types are `ComplianceDLPSharePoint`/`ComplianceDLPExchange`). Corrected the
+  matching claim in `LAB-VALIDATION.md`. Source:
+  <https://learn.microsoft.com/office/office-365-management-api/office-365-management-activity-api-schema#auditlogrecordtype>
 - **Wave 6 P4b:** Empty catch blocks now log via `Write-Verbose` instead of silently swallowing errors. Output is unchanged unless caller passes `-Verbose`.
 
 ## [2.0.4] — 2026-05-23

--- a/deny-event-correlation-report/LAB-VALIDATION.md
+++ b/deny-event-correlation-report/LAB-VALIDATION.md
@@ -30,6 +30,7 @@ reporting). Regulatory alignment: helps support FINRA 4511, SEC 17a-3/17a-4, GLB
 | `Get-AzAccessToken -ResourceUrl … -AsSecureString` | Az.Accounts 5.x behavior | Correct SecureString contract, defensive plaintext fallback present |
 | Language rules (no compliance-overclaim phrasing) | grep across solution | **Zero** violations |
 | KQL parse-coherence (5 query files) | Manual review | Coherent; ingestion-pattern caveats already documented |
+| DLP audit filter (`Export-DlpCopilotEvents.ps1`, `dlp-copilot-matches.kql`) | Microsoft Learn (Management Activity API schema) | **Second-pass fix:** `DlpRuleMatch` is an Operation, not a RecordType — moved to `-Operations` / KQL `Operation`; removed wrong "Numeric equivalent: 55" comment (55 = SharePointContentTypeOperation) |
 
 ## Authoritative Sources Cited
 
@@ -81,11 +82,11 @@ March 31, 2026 date only as historical context. **No runtime code path changed**
 - **Graph Defender extractor** (`Export-DefenderCopilotEvents.ps1`): uses the GA
   `https://graph.microsoft.com/v1.0/security/runHuntingQuery` endpoint with
   `ThreatHunting.Read.All`, matching the authoritative v1.0 contract.
-- **Unified audit extractors** (`Export-CopilotDenyEvents.ps1`,
-  `Export-DlpCopilotEvents.ps1`): `Search-UnifiedAuditLog` with `RecordType`
-  `CopilotInteraction` / `DlpRuleMatch` is the correct, current path. The Graph
-  `/security/auditLog/queries` beta is accurately described as a not-yet-production
-  migration path.
+- **CopilotInteraction extractor** (`Export-CopilotDenyEvents.ps1`):
+  `Search-UnifiedAuditLog -RecordType CopilotInteraction` is correct —
+  `CopilotInteraction` (AuditLogRecordType 261) is a valid `AuditRecordType`
+  enum member. The Graph `/security/auditLog/queries` beta is accurately
+  described as a not-yet-production migration path.
 - **DLP Workload literals** `Copilot` / `MicrosoftCopilotStudio` are used consistently
   across script and KQL (the incorrect `MicrosoftCopilot` literal was already removed in
   v2.0.2).

--- a/deny-event-correlation-report/kql-queries/dlp-copilot-matches.kql
+++ b/deny-event-correlation-report/kql-queries/dlp-copilot-matches.kql
@@ -32,7 +32,7 @@
 // -----------------------------------------------------------------------------
 OfficeActivity
 | where TimeGenerated > ago(24h)
-| where RecordType == "DlpRuleMatch"  // Numeric equivalent: 55
+| where Operation == "DlpRuleMatch"  // DlpRuleMatch is an audit Operation; in OfficeActivity the DLP RecordType name is ComplianceDLPSharePoint/ComplianceDLPExchange
 | extend AuditData = parse_json(OfficeObjectId)
 | where tostring(AuditData.Workload) in ("Copilot","MicrosoftCopilotStudio")
     or tostring(AuditData.PolicyDetails) contains "Copilot"
@@ -65,7 +65,7 @@ OfficeActivity
 // -----------------------------------------------------------------------------
 OfficeActivity
 | where TimeGenerated > ago(7d)
-| where RecordType == "DlpRuleMatch"  // Numeric equivalent: 55
+| where Operation == "DlpRuleMatch"  // DlpRuleMatch is an audit Operation; in OfficeActivity the DLP RecordType name is ComplianceDLPSharePoint/ComplianceDLPExchange
 | extend AuditData = parse_json(OfficeObjectId)
 | where tostring(AuditData.Workload) in ("Copilot","MicrosoftCopilotStudio")
     or tostring(AuditData.PolicyDetails) contains "Copilot"
@@ -85,7 +85,7 @@ OfficeActivity
 // -----------------------------------------------------------------------------
 OfficeActivity
 | where TimeGenerated > ago(7d)
-| where RecordType == "DlpRuleMatch"  // Numeric equivalent: 55
+| where Operation == "DlpRuleMatch"  // DlpRuleMatch is an audit Operation; in OfficeActivity the DLP RecordType name is ComplianceDLPSharePoint/ComplianceDLPExchange
 | extend AuditData = parse_json(OfficeObjectId)
 | where tostring(AuditData.Workload) in ("Copilot","MicrosoftCopilotStudio")
     or tostring(AuditData.PolicyDetails) contains "Copilot"
@@ -108,7 +108,7 @@ OfficeActivity
 // -----------------------------------------------------------------------------
 OfficeActivity
 | where TimeGenerated > ago(1h)
-| where RecordType == "DlpRuleMatch"  // Numeric equivalent: 55
+| where Operation == "DlpRuleMatch"  // DlpRuleMatch is an audit Operation; in OfficeActivity the DLP RecordType name is ComplianceDLPSharePoint/ComplianceDLPExchange
 | extend AuditData = parse_json(OfficeObjectId)
 | where tostring(AuditData.Workload) in ("Copilot","MicrosoftCopilotStudio")
     or tostring(AuditData.PolicyDetails) contains "Copilot"
@@ -134,7 +134,7 @@ OfficeActivity
 // -----------------------------------------------------------------------------
 OfficeActivity
 | where TimeGenerated > ago(30d)
-| where RecordType == "DlpRuleMatch"  // Numeric equivalent: 55
+| where Operation == "DlpRuleMatch"  // DlpRuleMatch is an audit Operation; in OfficeActivity the DLP RecordType name is ComplianceDLPSharePoint/ComplianceDLPExchange
 | extend AuditData = parse_json(OfficeObjectId)
 | where tostring(AuditData.Workload) in ("Copilot","MicrosoftCopilotStudio")
     or tostring(AuditData.PolicyDetails) contains "Copilot"
@@ -156,7 +156,7 @@ OfficeActivity
 // -----------------------------------------------------------------------------
 OfficeActivity
 | where TimeGenerated > ago(30d)
-| where RecordType == "DlpRuleMatch"  // Numeric equivalent: 55
+| where Operation == "DlpRuleMatch"  // DlpRuleMatch is an audit Operation; in OfficeActivity the DLP RecordType name is ComplianceDLPSharePoint/ComplianceDLPExchange
 | extend AuditData = parse_json(OfficeObjectId)
 | where tostring(AuditData.Workload) in ("Copilot","MicrosoftCopilotStudio")
     or tostring(AuditData.PolicyDetails) contains "Copilot"
@@ -178,7 +178,7 @@ OfficeActivity
 // -----------------------------------------------------------------------------
 OfficeActivity
 | where TimeGenerated > ago(7d)
-| where RecordType == "DlpRuleMatch"  // Numeric equivalent: 55
+| where Operation == "DlpRuleMatch"  // DlpRuleMatch is an audit Operation; in OfficeActivity the DLP RecordType name is ComplianceDLPSharePoint/ComplianceDLPExchange
 | extend AuditData = parse_json(OfficeObjectId)
 | where tostring(AuditData.Workload) in ("Copilot","MicrosoftCopilotStudio")
     or tostring(AuditData.PolicyDetails) contains "Copilot"

--- a/deny-event-correlation-report/scripts/Export-DlpCopilotEvents.ps1
+++ b/deny-event-correlation-report/scripts/Export-DlpCopilotEvents.ps1
@@ -105,8 +105,13 @@ function Get-DlpAuditEvents {
     Write-Host "Searching for DlpRuleMatch events from $Start to $End..." -ForegroundColor Cyan
 
     do {
+        # `DlpRuleMatch` is an audit Operation, not a RecordType. Search-UnifiedAuditLog
+        # `-RecordType` binds to the AuditRecordType enum (valid DLP record types are
+        # ComplianceDLPSharePoint / ComplianceDLPExchange / DLPEndpoint), so passing
+        # "DlpRuleMatch" there fails parameter binding. Filter on `-Operations` instead,
+        # which returns DlpRuleMatch events across all DLP workloads.
         $params = @{
-            RecordType     = "DlpRuleMatch"
+            Operations     = "DlpRuleMatch"
             StartDate      = $Start
             EndDate        = $End
             SessionId      = $sessionId


### PR DESCRIPTION
## Second-pass command-existence audit — deny-event-correlation-report

Independent re-derivation (not trusting LAB-VALIDATION.md). One genuine existence/runtime bug found and fixed; remaining surfaces verified against Microsoft Learn.

### Fix: invalid `Search-UnifiedAuditLog -RecordType "DlpRuleMatch"` (would not run)
`DlpRuleMatch` is an audit **Operation**, not a member of the `AuditRecordType` enum that `-RecordType` binds to. Passing it fails PowerShell parameter binding, so the DLP extractor could never run. Valid DLP record types are `ComplianceDLPSharePoint` (11) / `ComplianceDLPExchange` (13) / `DLPEndpoint` (63).

- `scripts/Export-DlpCopilotEvents.ps1` — `RecordType = "DlpRuleMatch"` → `Operations = "DlpRuleMatch"` (returns DLP rule-match events across all DLP workloads, then filtered for Copilot).
- `kql-queries/dlp-copilot-matches.kql` — 7× `where RecordType == "DlpRuleMatch"  // Numeric equivalent: 55` → `where Operation == "DlpRuleMatch"`. The "Numeric equivalent: 55" comment was also wrong: record type **55 = SharePointContentTypeOperation**, not DLP.
- `LAB-VALIDATION.md` — corrected the pass-1 claim that `RecordType DlpRuleMatch` was "the correct, current path".

Source: <https://learn.microsoft.com/office/office-365-management-api/office-365-management-activity-api-schema#auditlogrecordtype> · <https://learn.microsoft.com/powershell/module/exchange/search-unifiedauditlog>

### Verified EXISTS (no change)
- Graph `POST https://graph.microsoft.com/v1.0/security/runHuntingQuery` + `ThreatHunting.Read.All` — GA v1.0 contract. <https://learn.microsoft.com/graph/api/security-security-runhuntingquery?view=graph-rest-1.0>
- `CloudAppEvents` columns `Timestamp`, `AccountDisplayName`, `AccountId`, `Application`, `ActionType`, `RawEventData` — Defender XDR advanced hunting schema (Defender-XDR-only table). <https://learn.microsoft.com/defender-xdr/advanced-hunting-cloudappevents-table>
- `Search-UnifiedAuditLog -RecordType CopilotInteraction` (AuditLogRecordType 261) — valid enum member.
- `OfficeActivity` columns `TimeGenerated`/`RecordType`/`Operation`/`OfficeObjectId`/`UserId` (Log Analytics) — exist; queries correctly caveated as requiring custom raw-JSON ingestion.
- App Insights `customEvents`/`AppEvents` + `api.applicationinsights.io/v1/apps/{id}/query`; `Get-AzAccessToken -ResourceUrl … -AsSecureString`; `Connect-ExchangeOnline -ManagedIdentity`/`Get-ConnectionInformation` — all current.

All 6 PowerShell scripts parse with zero errors after the change.