### PR TITLE
fix(file-upload-security): second-pass command-existence corrections

### DIFF
--- a/file-upload-security/CHANGELOG.md
+++ b/file-upload-security/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the File Upload Security Configurator will be documented 
 
 ## [Unreleased]
 
+### Fixed
+
+- **HIGH (command-existence): `Get-FUSEnvironmentVariable` used a non-existent `$expand` navigation property.** The Dataverse environment-variable lookup expanded `environmentvariablevalues`, which is not a valid navigation property on `environmentvariabledefinition` and fails the OData request ("Could not find a property named 'environmentvariablevalues'"). Replaced with the canonical one-to-many navigation property `environmentvariabledefinition_environmentvariablevalue($select=value)` and updated the downstream property read. `scripts/private/FUSClient.psm1`. Verified against the [Environment Variable Definition table reference](https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/environmentvariabledefinition) (relationship `environmentvariabledefinition_environmentvariablevalue`). (validation2 second-pass)
+
 ### Changed
 
 - **Docs (lab-readiness validation):** README "Copilot Studio file input limits" note re-verified against the current [Allow file input from users](https://learn.microsoft.com/microsoft-copilot-studio/image-input-analysis) Microsoft Learn page. Added DOCX to the supported user-upload types and the XLSX/PPTX experimental caveat; replaced the stale per-format limits (4 MB DirectLine cap, 40-page PDF, 180 KB TXT/CSV) with the currently documented limits (15 MB individual file size; 30,000-character text limit without code interpreter, no limit with code interpreter); clarified that knowledge-source uploads are a separate 512 MB feature.

--- a/file-upload-security/scripts/private/FUSClient.psm1
+++ b/file-upload-security/scripts/private/FUSClient.psm1
@@ -151,9 +151,11 @@ function Get-FUSEnvironmentVariable {
 
     try {
         $schemaName = "fsi_FUS_$Name"
+        # Canonical one-to-many navigation property is environmentvariabledefinition_environmentvariablevalue;
+        # 'environmentvariablevalues' is not a valid navigation property and fails $expand.
         $uri = "$script:DataverseUrl/api/data/v9.2/environmentvariabledefinitions?" +
                "`$filter=schemaname eq '$schemaName'&" +
-               "`$expand=environmentvariablevalues"
+               "`$expand=environmentvariabledefinition_environmentvariablevalue(`$select=value)"
 
         $headers = @{
             'Authorization'    = "Bearer $script:AccessToken"
@@ -166,8 +168,9 @@ function Get-FUSEnvironmentVariable {
 
         if ($response.value.Count -gt 0) {
             $varDef = $response.value[0]
-            if ($varDef.environmentvariablevalues.Count -gt 0) {
-                return $varDef.environmentvariablevalues[0].value
+            $envValues = $varDef.environmentvariabledefinition_environmentvariablevalue
+            if ($envValues -and $envValues.Count -gt 0) {
+                return $envValues[0].value
             }
             return $varDef.defaultvalue
         }


### PR DESCRIPTION
## Second-pass command-existence audit: file-upload-security

Independent fresh-eyes re-derivation (did not trust LAB-VALIDATION.md). Verified PowerShell cmdlets, Dataverse Web API routes, `bot` table columns, custom `fsi_` columns/option-sets, and Python imports against Microsoft Learn.

### Fixed (1 HIGH command-existence bug)

**`scripts/private/FUSClient.psm1` — `Get-FUSEnvironmentVariable` invalid `\` navigation property**
- Wrong: `\=environmentvariablevalues`
- Right: `\=environmentvariabledefinition_environmentvariablevalue(\=value)`
- `environmentvariablevalues` is not a navigation property on `environmentvariabledefinition`; the request fails with *Could not find a property named 'environmentvariablevalues'*. Updated the downstream read accordingly.
- Source: [Environment Variable Definition (EnvironmentVariableDefinition) table reference](https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/environmentvariabledefinition) — one-to-many relationship `environmentvariabledefinition_environmentvariablevalue`.
- This is the same recurring class fixed earlier in `session-security-configurator` (Goldeneye #2). The other sibling clients (ACA/ACRD/AAM/GAC/CMM/HWG) carry the same pattern but are out of scope for this solution's PR.

### Verified EXISTS (no change needed)
- `bots` entity set, PK `botid`, columns `name/statecode/statuscode/configuration/publishedon/schemaname` — confirmed against the [Copilot (bot) table reference](https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/bot). This solution reads agents from `bots` only; **no `botcomponent` / `_parentbotid_value` / `componenttype` surface is used**, so the recurring botcomponent-lookup bug class does not apply here.
- `Get-AdminPowerAppEnvironment` (Microsoft.PowerApps.Administration.PowerShell), `Get-AzAccessToken` (with `-ResourceUri`/`-ResourceUrl` version fallback), `Get-AzContext` — all real.
- Custom `fsi_` columns, entity sets (`fsi_fileuploadbaselines`/`fsi_fileuploadvalidationhistories`/`fsi_fileuploadviolations`), and option-set integers (`fsi_acv_zone`/`fsi_acv_severity`) match `create_dataverse_schema.py`.
- Python imports (`msal`, `requests`, `azure-identity`) match `requirements.txt`.

### UNVERIFIABLE (caveated, not invented)
- `bot.configuration` JSON keys for file-upload/moderation enablement are undocumented; the helper probes multiple candidate keys and returns Indeterminate when absent — left as-is.