### PR TITLE
fix(model-risk-management-automation): second-pass command-existence corrections

### DIFF
--- a/model-risk-management-automation/CHANGELOG.md
+++ b/model-risk-management-automation/CHANGELOG.md
@@ -6,7 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [1.0.4] — 2026-05-23
+## [Unreleased]
+
+### Fixed
+
+- **Command existence (second-pass audit)**: The agent-metadata enrichment call cited a non-existent Power Platform API endpoint. `docs/flow-configuration.md` step 4.2 used `https://api.powerplatform.com/appmanagement/environments/{env}/bots/{bot}?api-version=2022-03-01-preview` and `SOLUTION-DOCUMENTATION.md` §3 used a `powervirtualagents/...bots` path; neither namespace exposes a bot read (the Power Platform API only documents bot-scoped sub-resources under the `copilotstudio` namespace — `botQuarantine`, `makerevaluation`). Both now read the documented Dataverse `bot` table (`GET .../api/data/v9.2/bots({botId})?$select=name,schemaname,statecode,publishedon,_ownerid_value`), whose `botid` equals the Power Platform Bot ID stored in `fsi_agentid`. Ref: https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/bot
+- **Doc consistency**: Updated `DELIVERY-CHECKLIST.md` API field-confirmation rows, `docs/prerequisites.md` network/role tables, `README.md` role table, and the `fsi_cr_http_mrm` usage descriptions in `docs/flow-configuration.md` and `scripts/create_mrm_connection_references.py` to reference the Dataverse `bot` table instead of the non-existent "Power Platform Bots API".
+
+### Notes
+
+- Verified EXISTS against Microsoft Learn: the Graph beta Agent 365 package inventory `GET /beta/copilot/admin/catalog/packages?$filter=supportedHosts/any(h:h eq 'Copilot')` with delegated `CopilotPackages.Read.All`; the beta `GET /beta/agentRegistry/agentInstances/{id}` legacy identity cross-reference (with the documented May 2026 Agent 365 convergence); the Graph v1.0 user-profile read; and `Get-AzAccessToken -ResourceUrl -AsSecureString` (Az.Accounts). Dataverse custom entity sets and logical columns matched `create_mrm_dataverse_schema.py`.
+
+---
 
 ### Fixed
 

--- a/model-risk-management-automation/CHANGELOG.md
+++ b/model-risk-management-automation/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.0.4] — 2026-05-23
+
 ### Fixed
 
 - **Critical**: Flow 2 step 3.7 Change Frequency Score used a nonexistent lookup `_fsi_validationcycle_lookup_value` on `fsi_mrmcomplianceevent`; corrected to `_fsi_modelinventory_lookup_value eq @{model.id}` per the schema (only `fsi_ModelInventory_Lookup` exists on that table). `docs/flow-configuration.md` ~line 355. (council review C-1)

--- a/model-risk-management-automation/DELIVERY-CHECKLIST.md
+++ b/model-risk-management-automation/DELIVERY-CHECKLIST.md
@@ -40,9 +40,9 @@ OptionSet integer values are defined in `scripts/create_mrm_dataverse_schema.py`
 
 | API | Field | Expected | Confirmed |
 |-----|-------|----------|-----------|
-| Power Platform Bots API (2022-03-01-preview) | ownerObjectId | Present in response | [ ] |
-| Power Platform Bots API | displayName | Present in response | [ ] |
-| Power Platform Bots API | lastModifiedTime | Present in response | [ ] |
+| Dataverse bot table | _ownerid_value | Present in response | [ ] |
+| Dataverse bot table | name | Present in response | [ ] |
+| Dataverse bot table | modifiedon | Present in response | [ ] |
 
 ### Infrastructure Setup
 

--- a/model-risk-management-automation/README.md
+++ b/model-risk-management-automation/README.md
@@ -124,7 +124,7 @@ This solution addresses three operational gaps that examiners consistently cite:
 
 | Role | Required For |
 |------|--------------|
-| **Power Platform Admin** | Environment enumeration and Bots API access |
+| **Power Platform Admin** | Environment enumeration and Dataverse `bot` table access |
 | **System Administrator** | Dataverse table creation and security role configuration |
 | **Microsoft Entra Global Administrator** or **Application Administrator** | Managed identity API permission grants |
 

--- a/model-risk-management-automation/SOLUTION-DOCUMENTATION.md
+++ b/model-risk-management-automation/SOLUTION-DOCUMENTATION.md
@@ -85,7 +85,7 @@ This solution requires `agent-registry-automation` to be deployed in the same Da
 
 ### Required APIs
 
-1. **Power Platform Bots API** — `GET https://api.powerplatform.com/powervirtualagents/environments/{envId}/bots/{botId}?api-version=2022-03-01-preview`
+1. **Dataverse bot table** — `GET https://{org}.crm.dynamics.com/api/data/v9.2/bots({botId})?$select=name,schemaname,statecode,publishedon,_ownerid_value` — documented source for agent metadata (`botId` equals the Power Platform Bot ID stored in `fsi_agentid`)
 2. **Microsoft Graph — Agent 365 package inventory (preview)** — `GET https://graph.microsoft.com/beta/copilot/admin/catalog/packages?$filter=supportedHosts/any(h:h eq 'Copilot')` for delegated administrator inventory exports when `IsAgent365LifecycleEnabled` is enabled
 3. **Microsoft Graph — Agent Registry agent instances (legacy/beta)** — `GET https://graph.microsoft.com/beta/agentRegistry/agentInstances/{agentInstanceId}` for identity-only cross-reference while Microsoft converges registry APIs into Agent 365
 4. **Microsoft Graph — User Profile** — `GET https://graph.microsoft.com/v1.0/users/{userUPN}?$select=id,displayName,mail,jobTitle,department`

--- a/model-risk-management-automation/docs/flow-configuration.md
+++ b/model-risk-management-automation/docs/flow-configuration.md
@@ -28,7 +28,7 @@ All flows use connection references deployed by `create_mrm_connection_reference
 | `fsi_cr_dataverse_mrm` | Dataverse - MRM | Common Data Service | Model inventory CRUD, risk ratings, validation cycles, findings, monitoring, compliance events |
 | `fsi_cr_teams_mrm` | Teams - MRM | Microsoft Teams | Risk scoring cards, validation alerts, SLA breach alerts, revalidation requests |
 | `fsi_cr_approvals_mrm` | Approvals - MRM | Approvals | Validator assignment approval, revalidation confirmation, examiner alert choices |
-| `fsi_cr_http_mrm` | HTTP with Microsoft Entra ID - MRM | HTTP with Microsoft Entra ID | Power Platform Bots API, Graph API user resolution, Agent 365 / Microsoft Entra Agent ID registry enrichment |
+| `fsi_cr_http_mrm` | HTTP with Microsoft Entra ID - MRM | HTTP with Microsoft Entra ID | Dataverse bot table enrichment, Graph API user resolution, Agent 365 / Microsoft Entra Agent ID registry enrichment |
 | `fsi_cr_sharepoint_mrm` | SharePoint - MRM | SharePoint Online | Agent Card upload, folder creation, metadata updates |
 | `fsi_cr_wordonline_mrm` | Word Online - MRM | Word Online (Business) | Agent Card document generation from template |
 
@@ -90,7 +90,7 @@ Synchronizes registered agents from the Agent Registry (`fsi_agentinventory`) in
 | Connection Reference | Purpose |
 |---------------------|---------|
 | `fsi_cr_dataverse_mrm` | Read agent inventory, upsert model inventory, create compliance events |
-| `fsi_cr_http_mrm` | Power Platform Bots API enrichment, Graph API owner resolution, optional Agent 365 / Microsoft Entra Agent ID registry cross-reference |
+| `fsi_cr_http_mrm` | Dataverse bot table enrichment, Graph API owner resolution, optional Agent 365 / Microsoft Entra Agent ID registry cross-reference |
 | `fsi_cr_teams_mrm` | API failure alerts to FlowAdministrators |
 
 ### Step-by-Step Build Instructions
@@ -141,12 +141,17 @@ Synchronizes registered agents from the Agent Registry (`fsi_agentinventory`) in
        - Initialize variable: IsNewRecord (Boolean)
          Value: @{equals(length(outputs('List_MRM_Records')?['body/value']), 0)}
 
-   4.2 HTTP - Enrich with PPAC Bots API
+   4.2 HTTP - Enrich from the Dataverse bot table
        Connection: fsi_cr_http_mrm
        Method: GET
-       URI: https://api.powerplatform.com/appmanagement/environments/@{agent.environmentid}/bots/@{agent.agentid}?api-version=2022-03-01-preview
+       URI: https://<your-environment>.crm.dynamics.com/api/data/v9.2/bots(@{agent.agentid})?$select=name,schemaname,statecode,publishedon,_ownerid_value
        Headers: Authorization: Bearer (from connection)
        Configure Run After: Continue on failure (enrichment is best-effort)
+       Note: The Dataverse `bot` table (entity set `bots`, primary key `botid`,
+             which equals the Power Platform Bot ID stored in fsi_agentid) is the
+             documented source for agent metadata. You can also use the Dataverse
+             connector "Get a row by ID" action on the bot table instead of HTTP.
+             Ref: https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/bot
 
    4.3 HTTP - Resolve owner from Microsoft Graph
        Connection: fsi_cr_http_mrm
@@ -240,7 +245,7 @@ Synchronizes registered agents from the Agent Registry (`fsi_agentinventory`) in
 ### Error Handling
 
 - **Agent inventory inaccessible (step 2):** Creates Critical compliance event, alerts FlowAdministrators, terminates — no partial sync
-- **PPAC Bots API failure (step 4.2):** Continue processing with available data; enrichment fields left null
+- **Dataverse `bot` table enrichment failure (step 4.2):** Continue processing with available data; enrichment fields left null
 - **Graph API failure (step 4.3):** Continue; owner fields populated from agent inventory source data
 - **Individual agent failure (within step 4):** Log error to compliance events, continue processing remaining agents
 - **All errors:** Configure `Scope` run-after to catch failures and log to `fsi_mrmcomplianceevents`

--- a/model-risk-management-automation/docs/prerequisites.md
+++ b/model-risk-management-automation/docs/prerequisites.md
@@ -18,7 +18,7 @@ Complete all prerequisites before deploying the Model Risk Management Automation
 
 | Role | Required For |
 |------|--------------|
-| Power Platform Admin | Environment enumeration, Bots API access, and Managed Environment configuration |
+| Power Platform Admin | Environment enumeration, Dataverse `bot` table access, and Managed Environment configuration |
 | System Administrator (Dataverse) | Dataverse table creation, solution import, and alternate key configuration |
 | Microsoft Entra Global Administrator or Application Administrator | Managed identity creation and API permission grants |
 | SharePoint Admin | MRM Governance site creation and permission configuration |
@@ -100,9 +100,8 @@ Feature flags are implemented as Dataverse environment variables. Both default t
 | Endpoint | Protocol | Purpose |
 |----------|----------|---------|
 | `graph.microsoft.com` | HTTPS (443) | Graph API calls for user resolution and Agent Registry |
-| `api.powerplatform.com` | HTTPS (443) | Power Platform API for agent metadata |
+| `{org}.crm.dynamics.com` | HTTPS (443) | Dataverse Web API (model inventory and `bot` table agent metadata) |
 | `{tenant}.sharepoint.com` | HTTPS (443) | Agent Card document operations |
-| `{org}.crm.dynamics.com` | HTTPS (443) | Dataverse Web API |
 
 > **Note:** If your environment uses a firewall or proxy, verify that these endpoints are accessible from the Power Automate service. Refer to [Microsoft Power Automate IP addresses](https://learn.microsoft.com/en-us/power-automate/ip-address-configuration) for the current IP ranges.
 

--- a/model-risk-management-automation/scripts/create_mrm_connection_references.py
+++ b/model-risk-management-automation/scripts/create_mrm_connection_references.py
@@ -13,7 +13,7 @@ Connection References:
     alerts, SLA breach alerts, and revalidation approval requests
   - fsi_cr_approvals_mrm: Validator assignment approval, revalidation
     confirmation, and Tier 1 examiner alert choices
-  - fsi_cr_http_mrm: Power Platform Bots API, Microsoft Graph API calls
+  - fsi_cr_http_mrm: Dataverse bot table enrichment, Microsoft Graph API calls
     for user profile resolution and Agent 365 / Microsoft Entra Agent ID registry
   - fsi_cr_sharepoint_mrm: Agent Card document upload, folder creation,
     and metadata updates in the Agent Card Library
@@ -72,8 +72,8 @@ CONNECTION_REF_DEFINITIONS = [
         "display_name": "HTTP with Microsoft Entra ID - Model Risk Management",
         "connector_id": "shared_webcontents",
         "description": (
-            "HTTP with Microsoft Entra ID connection for MRM. Used for Power "
-            "Platform Bots API, Microsoft Graph API calls for user "
+            "HTTP with Microsoft Entra ID connection for MRM. Used for "
+            "Dataverse bot table enrichment, Microsoft Graph API calls for user "
             "profile resolution and Agent 365 / Microsoft Entra Agent ID registry."
         ),
     },


### PR DESCRIPTION
## Second-pass command-existence audit — model-risk-management-automation

Independent re-derivation of every invoked command/endpoint against Microsoft Learn.

### Fix: non-existent Power Platform Bots API endpoint
The agent-metadata enrichment cited a Power Platform API path that does not exist:
- `docs/flow-configuration.md` step 4.2: `https://api.powerplatform.com/appmanagement/environments/{env}/bots/{bot}?api-version=2022-03-01-preview`
- `SOLUTION-DOCUMENTATION.md` §3: `https://api.powerplatform.com/powervirtualagents/environments/{envId}/bots/{botId}?api-version=2022-03-01-preview`

The Power Platform API only documents **bot-scoped sub-resources under the `copilotstudio` namespace** (`botQuarantine`, `makerevaluation`); the `appmanagement` namespace is for `/operations/{id}` and `powervirtualagents` is not a namespace. There is no generic GET-bot endpoint at api-version=2022-03-01-preview.

**Corrected** both to the documented Dataverse `bot` table read:
`GET {org}.crm.dynamics.com/api/data/v9.2/bots({botId})?\=name,schemaname,statecode,publishedon,_ownerid_value` — `botid` equals the Power Platform Bot ID stored in `fsi_agentid`.
Ref: https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/bot

Aligned consequential prose in `DELIVERY-CHECKLIST.md` (API field rows), `docs/prerequisites.md` (network + role tables), `README.md` (role table), `docs/flow-configuration.md` and `scripts/create_mrm_connection_references.py` (`fsi_cr_http_mrm` usage).

### Verified EXISTS (no change)
- Graph beta Agent 365 package inventory `GET /beta/copilot/admin/catalog/packages?\=supportedHosts/any(h:h eq 'Copilot')` + delegated `CopilotPackages.Read.All`.
- Graph beta `GET /beta/agentRegistry/agentInstances/{id}` (with documented May 2026 Agent 365 convergence note).
- Graph v1.0 `/users/{id}` profile read; `Get-AzAccessToken -ResourceUrl -AsSecureString` (Az.Accounts).
- All custom `fsi_*` entity sets (`fsi_modelinventories`, `fsi_validationfindings`, `fsi_monitoringrecords`, `fsi_validationcycles`, `fsi_mrmcomplianceevents`) and logical columns match `create_mrm_dataverse_schema.py`; option-set ints verified.
- Connector IDs (`shared_commondataserviceforapps`, `shared_teams`, `shared_approvals`, `shared_webcontents`, `shared_sharepointonline`, `shared_wordonlinebusiness`) and shared `DataverseClient` method/kwarg surface valid.