### PR TITLE
fix(action-confirmation-auditor): technical accuracy review vs Microsoft Learn

### DIFF
--- a/action-confirmation-auditor/CHANGELOG.md
+++ b/action-confirmation-auditor/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Action Confirmation Auditor are documented in this fi
 
 ### Fixed
 
+- **`scripts/Start-ActionConfirmationRunbook-MI.ps1`**: Corrected an inaccurate version reference in the `ConvertFrom-AzAccessTokenValue` helper comment. It stated `Get-AzAccessToken` returns a `SecureString` "(Az.Accounts >= 2.17)"; Microsoft Learn documents that the default output type changed from plain-text `String` to `SecureString` starting with **Az.Accounts 5.0.0** (Az 14.0.0), not 2.17. No behavior change — the helper already type-checks and handles both shapes (and matches the already-correct note in `Get-PurviewAIHubEvidence.ps1`). (technical-accuracy review; verified against `https://learn.microsoft.com/powershell/azure/context-persistence` / Protect secrets in Azure PowerShell — "the default output type of the `Get-AzAccessToken` cmdlet changed ... starting with Az.Accounts version 5.0.0 and Az version 14.0.0")
+
 - **`scripts/Get-PurviewAIHubEvidence.ps1`**: Removed the invalid `copilotInteraction` value from the Graph audit log query `recordTypeFilters`. `copilotInteraction` is not a member of the v1.0 `auditLogRecordType` enum (it is the beta `copilotInteractionAuditRecord` record subtype, not a filter value); sending an unknown evolvable-enum member returns HTTP 400 and fails the entire query. The filter now uses only the valid camelCase members `aipDiscover` and `aipSensitivityLabelAction`, and Copilot interaction activity is collected via the existing Activity Explorer fallback. (second-pass command-existence audit; verified against `https://learn.microsoft.com/graph/api/resources/security-auditlogrecordtype?view=graph-rest-1.0`)
 
 ## [1.2.1] - 2026-05-23

--- a/action-confirmation-auditor/scripts/Start-ActionConfirmationRunbook-MI.ps1
+++ b/action-confirmation-auditor/scripts/Start-ActionConfirmationRunbook-MI.ps1
@@ -114,8 +114,9 @@ try {
 # ===================================================================
 Write-Verbose "Acquiring Power Platform admin token..."
 
-# Helper: convert SecureString token (Az.Accounts >= 2.17) to plain string
-# while preserving compatibility with earlier versions that returned a String.
+# Helper: convert SecureString token to plain string. Get-AzAccessToken
+# returns a SecureString by default starting with Az.Accounts 5.0.0 (Az 14.0.0);
+# earlier versions returned a plain String. This helper handles both.
 function ConvertFrom-AzAccessTokenValue {
     param([Parameter(Mandatory)]$TokenValue)
     if ($TokenValue -is [System.Security.SecureString]) {


### PR DESCRIPTION
## Technical accuracy review — action-confirmation-auditor

Owl-mode review of every Microsoft product/API/config claim in the solution, verified against Microsoft Learn. The solution had already been through a council review + a prior accuracy pass, so the bulk of claims verified **accurate**. One genuine inaccuracy was found and corrected (a code-comment version reference).

### Corrections made (1)

| # | Claim (as written) | File:line | Verdict | Microsoft Learn URL | Action |
|---|---|---|---|---|---|
| 1 | `Get-AzAccessToken` returns a `SecureString` "(Az.Accounts >= 2.17)" | `scripts/Start-ActionConfirmationRunbook-MI.ps1:117` | **inaccurate** | https://learn.microsoft.com/powershell/azure/context-persistence (Protect secrets in Azure PowerShell) — *"the default output type of the `Get-AzAccessToken` cmdlet changed from a plain text `String` to a `SecureString`, starting with **Az.Accounts version 5.0.0** and **Az version 14.0.0**"* | Fixed comment to cite Az.Accounts 5.0.0 / Az 14.0.0. No behavior change — helper already type-checks and handles both String and SecureString (matching the already-correct note in `Get-PurviewAIHubEvidence.ps1:218`). |

### Claims verified accurate (no change)

| Claim | File:line | Verdict | Microsoft Learn URL |
|---|---|---|---|
| `Microsoft.PowerApps.Administration.PowerShell` uses .NET Framework, incompatible with PowerShell 6.0+ / requires Windows PowerShell 5.x | `docs/prerequisites.md:78,86`, `.ralph-config.json` | accurate | https://learn.microsoft.com/power-platform/admin/powerapps-powershell — verbatim *"The modules described in this document use .NET Framework, which is incompatible with PowerShell 6.0 and later"* and *"requires Windows PowerShell version 5.x"* |
| Graph scope `AuditLogsQuery.Read.All` for `security/auditLog/queries` records API | `scripts/Get-PurviewAIHubEvidence.ps1:57-59,98` | accurate | https://learn.microsoft.com/graph/api/security-auditlogquery-list-records — `AuditLogsQuery.Read.All` listed as a higher-privileged Delegated + Application permission |
| `security/auditLog/queries` POST body props (`displayName`, `filterStartDateTime`, `filterEndDateTime`, `recordTypeFilters`) | `scripts/Get-PurviewAIHubEvidence.ps1:126-138` | accurate | https://learn.microsoft.com/graph/api/security-auditcoreroot-post-auditlogqueries (Create auditLogQuery) |
| `copilotInteraction` is NOT a valid v1.0 `auditLogRecordType` member; `aipDiscover` / `aipSensitivityLabelAction` are valid | `scripts/Get-PurviewAIHubEvidence.ps1:131-137` | accurate | https://learn.microsoft.com/graph/api/resources/security-auditlogrecordtype — `AipDiscover` and `AipSensitivityLabelAction` present; no `CopilotInteraction` member (wire format camelCase) |
| `bot` / `botcomponent` Dataverse tables hold Copilot Studio agents and topic/component definitions | `scripts/Get-AgentActionSettings.ps1:9-15`, `docs/prerequisites.md:39-40` | accurate | https://learn.microsoft.com/power-platform/admin/powerapps-powershell (Power Platform / Dataverse admin context) |
| Azure Automation managed identity replaces deprecated RunAs accounts | `README.md:89`, `CHANGELOG.md` (1.2.0) | accurate | https://learn.microsoft.com/azure/automation/learn/powershell-runbook-managed-identity |
| Purview AI Hub (DSPM for AI) reference | `scripts/Get-PurviewAIHubEvidence.ps1:23,319` | accurate | https://learn.microsoft.com/purview/ai-microsoft-purview |

### Internal consistency (verified clean)

- Dataverse logical column names, entity-set pluralization, and option-set values (`100000000+`) all match `scripts/create_dataverse_schema.py`. The `.ralph-config.json` domain facts (singular `fsi_actionscanrun` entity set; `fsi_validationtime`; `fsi_justification`; no `fsi_scantime`/`fsi_reason`) are respected throughout scripts and flow docs. No drift found (prior reviews already remediated these).
- `fsi_cr_*` connection-reference names and `fsi_acv_*` shared option-set names legitimately contain underscores (not column logical names) — not violations.

### Language rules / product naming

- No forbidden phrases (`ensures compliance|guarantees|will prevent|eliminates risk`) outside historical CHANGELOG entries.
- No legacy "Azure AD" / "Azure Active Directory" branding outside historical CHANGELOG entries.

### Claims escalated (unverifiable)

None. Every Microsoft technical claim was verifiable against Microsoft Learn.

### Versioning note

The single correction is a non-behavioral code-comment fix. Per the repo pattern (the existing `[Unreleased]` `copilotInteraction` fix likewise did not trigger a bump), this is recorded under `CHANGELOG.md [Unreleased] → Fixed` **without** a version bump; the manifest version remains `1.2.1`.

### Validation gates

- `python scripts/build-manifest.py` → wrote artifacts; `--check` → exit 0 (no drift)
- `python -m mkdocs build --strict` → exit 0
- PowerShell AST parse of `Start-ActionConfirmationRunbook-MI.ps1` → OK
- Language grep → clean
- No `.py` changed (no `py_compile` needed)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
