### PR TITLE
fix(conditional-access-automation): technical accuracy review vs Microsoft Learn

### DIFF
--- a/conditional-access-automation/CHANGELOG.md
+++ b/conditional-access-automation/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Conditional Access Automation solution are documented
 
 ### Fixed
 
+- Corrected the `.EXAMPLE` in `scripts/private/Get-CAAValidationResults.ps1` to acquire the Dataverse token via `Get-AzAccessToken -AsSecureString` and extract the plaintext with `[System.Net.NetworkCredential]`. The prior example used `(Get-AzAccessToken ...).Token` as a plaintext string, which is outdated: `Get-AzAccessToken` returns a `SecureString` by default starting with Az.Accounts 5.0.0 ([Microsoft Learn](https://learn.microsoft.com/powershell/module/az.accounts/get-azaccesstoken)). The runtime scripts (`Export-CAAComplianceEvidence.ps1`, `Start-CAAValidationRunbook.ps1`) already used the secure pattern; this aligns the helper's documentation.
 - **Wave 6 P4b:** Empty catch blocks now log via `Write-Verbose` instead of silently swallowing errors. Output is unchanged unless caller passes `-Verbose`.
 - `Test-EvidenceIntegrity.ps1` now processes `ValueFromPipeline` evidence paths inside a `process {}` block so piped file lists are evaluated one item at a time.
 

--- a/conditional-access-automation/scripts/private/Get-CAAValidationResults.ps1
+++ b/conditional-access-automation/scripts/private/Get-CAAValidationResults.ps1
@@ -33,7 +33,8 @@
     Optional validation run identifier to filter validation history records.
 
 .EXAMPLE
-    $token = (Get-AzAccessToken -ResourceUrl $dvUrl).Token
+    $secured = Get-AzAccessToken -ResourceUrl $dvUrl -AsSecureString
+    $token = [System.Net.NetworkCredential]::new('', $secured.Token).Password
     Get-CAAValidationResults -DataverseUrl 'https://org.crm.dynamics.com' `
         -AccessToken $token -Table 'fsi_capolicyvalidationhistories' `
         -FromDate (Get-Date).AddDays(-30)


### PR DESCRIPTION
## Technical accuracy review — conditional-access-automation

Reviewed all Microsoft technical claims in the solution (README, docs, scripts, templates) against current Microsoft Learn. The solution is in strong shape: authentication-strength vs `builtInControls` modeling, P2-gated risk evaluation, CAE caveats, and Power Platform CA scope notes were all verified accurate. One outdated API-usage example was corrected.

### Correction applied

| Claim / usage | Location | Verdict | Microsoft Learn | Action |
|---|---|---|---|---|
| `(Get-AzAccessToken -ResourceUrl ...).Token` used as a plaintext string | `scripts/private/Get-CAAValidationResults.ps1` `.EXAMPLE` (line 36) | Outdated | https://learn.microsoft.com/powershell/module/az.accounts/get-azaccesstoken | Updated example to `Get-AzAccessToken -AsSecureString` + `[System.Net.NetworkCredential]` plaintext extraction — matches runtime scripts |

**Why:** `Get-AzAccessToken` returns a `SecureString` by default starting with **Az.Accounts 5.0.0** (Learn: *"the default output type has been changed from a plain text `String` to `SecureString`"*). The prior example would assign a `SecureString` into a `[string]` parameter and emit `Bearer System.Security.SecureString`. `Export-CAAComplianceEvidence.ps1` and `Start-CAAValidationRunbook.ps1` already use the secure pattern; this aligns the helper's documentation.

### Claims verified accurate (no change)
- Authentication strength modeled as `grantControls.authenticationStrength` (not `builtInControls:["mfa"]`); phishing-resistant built-in strength — https://learn.microsoft.com/entra/identity/authentication/concept-authentication-strengths
- Risk-based `signInRiskLevels` / `userRiskLevels` require Microsoft Entra ID P2 — verified.
- CAE on by default; strict location enforcement preview — verified.
- Dataverse logical column names (`fsi_validationtime`, `fsi_detectedat`, `fsi_capturedat`, `fsi_overallseverity`) and entity sets match `create_caa_dataverse_schema.py` and `.ralph-config.json` domain facts.

### Claims escalated (unverifiable)
None.

### Validation gates (all exit 0)
- `python scripts/build-manifest.py` — wrote 238 artifacts
- `python scripts/build-manifest.py --check` — no drift
- `python -m mkdocs build --strict` — built clean
- PowerShell AST parse of `Get-CAAValidationResults.ps1` — OK
- Language grep (`ensures|guarantees|will prevent|eliminates risk`) — clean

No manifest version bump: appended to the existing shared `[Unreleased]` CHANGELOG batch per review process.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
