### PR TITLE
fix(deny-event-correlation-report): technical accuracy review vs Microsoft Learn

### DIFF
--- a/deny-event-correlation-report/CHANGELOG.md
+++ b/deny-event-correlation-report/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the Deny Event Correlation Report are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Corrected `Get-AzAccessToken` SecureString version claims.** Inline comments
+  in `scripts/Export-RaiTelemetry.ps1` ("Az.Accounts >=2.17 returns SecureString
+  by default") and `docs/troubleshooting.md` ("Az.Accounts ≥3.0 returns Token as
+  SecureString") were wrong. Per Microsoft Learn, the `Token` property changed
+  from a plain-text `String` to a `SecureString` **by default starting in
+  Az.Accounts 5.0.0 (Az 14.0.0)**; the opt-in `-AsSecureString` switch was added
+  in 2.17.0. The script already requests `-AsSecureString` explicitly and keeps a
+  defensive plaintext fallback, so no runtime behavior changed. Source:
+  <https://learn.microsoft.com/powershell/azure/protect-secrets>
+
 ### Changed
 
 - **App Insights query API-key retirement date corrected to September 30, 2026.**

--- a/deny-event-correlation-report/docs/troubleshooting.md
+++ b/deny-event-correlation-report/docs/troubleshooting.md
@@ -77,7 +77,7 @@ Connect-AzAccount -Identity  # Azure Automation managed identity
 # Or, on non-Azure schedulers:
 # Connect-AzAccount -ServicePrincipal -ApplicationId $AppId -TenantId $TenantId -CertificateThumbprint $Thumbprint
 $tokenResult = Get-AzAccessToken -ResourceUrl "https://api.applicationinsights.io"
-# Az.Accounts ≥3.0 returns Token as SecureString; convert to plaintext for HTTP header
+# Az.Accounts ≥5.0 returns Token as SecureString by default (opt-in via -AsSecureString since 2.17.0); convert to plaintext for HTTP header
 $token = if ($tokenResult.Token -is [System.Security.SecureString]) {
     $tokenResult.Token | ConvertFrom-SecureString -AsPlainText
 } else {

--- a/deny-event-correlation-report/scripts/Export-RaiTelemetry.ps1
+++ b/deny-event-correlation-report/scripts/Export-RaiTelemetry.ps1
@@ -105,8 +105,12 @@ function Invoke-AppInsightsQuery {
 
     # Get access token for Application Insights API.
     # Migrated from deprecated x-api-key to Entra ID token-based authentication (February 2026).
-    # Az.Accounts >=2.17 returns SecureString by default; >=5.0 emits a deprecation
-    # warning unless `-AsSecureString` is explicitly requested with `-ResourceUrl`.
+    # Az.Accounts 2.17.0 added the opt-in `-AsSecureString` switch; the SecureString
+    # return type became the DEFAULT in Az.Accounts 5.0.0 (Az 14.0.0). On pre-5.0
+    # builds the default is plain text and a deprecation warning is emitted unless
+    # `-AsSecureString` is requested. Requesting it explicitly works on 2.17.0+ and
+    # keeps the SecureString contract on every supported version.
+    # Ref: https://learn.microsoft.com/powershell/azure/protect-secrets
     try {
         $token = Get-AzAccessToken -ResourceUrl "https://api.applicationinsights.io" -AsSecureString -ErrorAction Stop
         if (-not $token) {


### PR DESCRIPTION
## Technical accuracy review - deny-event-correlation-report

Owl-mode review of every Microsoft product/API/cmdlet/KQL/SKU claim in README.md, manifest.yaml, docs/, scripts/, and kql-queries/, verified against official Microsoft Learn. This solution was already heavily reviewed (see LAB-VALIDATION.md and prior CHANGELOG entries), so the net diff is small and surgical.

### Corrected (with Microsoft Learn citation)
| Claim | File:line | Verdict | Learn URL | Action |
|---|---|---|---|---|
| "Az.Accounts >=2.17 returns SecureString by default; >=5.0 emits a deprecation warning unless -AsSecureString" | scripts/Export-RaiTelemetry.ps1:108-109 | inaccurate | https://learn.microsoft.com/powershell/azure/protect-secrets | Rewrote:  -AsSecureString switch added in 2.17.0; SecureString became the **default** in Az.Accounts 5.0.0 / Az 14.0.0 |
| "Az.Accounts ≥3.0 returns Token as SecureString" | docs/troubleshooting.md:80 | inaccurate | https://learn.microsoft.com/powershell/azure/protect-secrets | Corrected to ≥5.0 default (opt-in via -AsSecureString since 2.17.0) |

Microsoft Learn ("Protect secrets in Azure PowerShell"): *"the default output type of the Get-AzAccessToken cmdlet changed from a plain text String to a SecureString, starting with Az.Accounts version 5.0.0 and Az version 14.0.0."* The -AsSecureString opt-in switch itself was added in Az.Accounts 2.17.0. No runtime code path changed — the script already requests -AsSecureString explicitly and keeps a defensive plaintext fallback, and the README's MinimumVersion 2.17.0 pin remains valid (that is the version that introduced the switch).

### Verified-accurate (no change)
- **Search-UnifiedAuditLog -RecordType CopilotInteraction** is correct (AuditLogRecordType 261). Graph /security/auditLog/queries accurately described as a beta migration path.
- **DLP extraction** correctly uses -Operations "DlpRuleMatch" (an audit Operation, not a RecordType) in both script and KQL; "Numeric equivalent 55" comment was already removed (record 55 = SharePointContentTypeOperation). Valid DLP record types: ComplianceDLPSharePoint / ComplianceDLPExchange.
- **Defender** uses GA POST https://graph.microsoft.com/v1.0/security/runHuntingQuery with least-privilege ThreatHunting.Read.All; CloudAppEvents schema with RawEventData (dynamic) and ActionType == "CopilotInteraction" aligns with the public schema. parsedFields is just a local alias for parse_json(RawEventData) — consistent with the file's own comment.
- **App Insights** x-api-key query-auth retirement = **September 30, 2026** (extended from March 31, 2026) — matches Microsoft release communications; extractor already uses Entra ID and is unaffected.
- **Workload literals** Copilot / MicrosoftCopilotStudio consistent across scripts and KQL.
- **Limits**: Search-UnifiedAuditLog 50,000 records/query and App Insights 500,000 rows / 64MB are accurate.
- **Get-AzAccessToken -AsSecureString** with defensive SecureString→plaintext conversion is correct on all supported versions.
- **Language rules**: no "ensures compliance / guarantees / will prevent / eliminates risk" phrasing.

### Internal-consistency findings
- Dataverse: solution is documentation/script/KQL only — no create_*_dataverse_schema.py and no si_* logical-column usage, so no column-naming drift applies.
- KQL DLP filters consistently use Operation == "DlpRuleMatch"; cloud-app-events.kql comment/code consistent.
- manifest.yaml controls (1.5, 1.7, 1.8, 3.4) match README and LAB-VALIDATION.

### Escalated / unverifiable (live-tenant only)
- Defender CloudAppEvents Copilot ThreatCategory values (PromptInjection/Jailbreak/XPIA) are raw-event-shaped and tenant/licensing dependent.
- CopilotInteraction deny indicators (AccessedResources[].Status == "failure", PolicyDetails) depend on live Copilot/DLP usage.
- App Insights ContentFiltered emission depends on per-agent Copilot Studio config and classic (customEvents) vs workspace (AppEvents) resource shape.
- Exchange Online unattended auth (managed identity / certificate app-only) not exercised against a tenant.

### Validation gates (all exit 0)
- python scripts/build-manifest.py — wrote 238 artifacts
- python scripts/build-manifest.py --check — OK, no drift
- python -m mkdocs build --strict — built (only INFO anchor notes in other solutions)
- PowerShell AST parse of Export-RaiTelemetry.ps1 — OK
- Language grep on changed files — clean

No version bump (comment/doc-only correction); appended a [Unreleased] CHANGELOG entry.
