### PR TITLE
fix(cross-tenant-external-sharing-governance): technical accuracy review vs Microsoft Learn

### DIFF
--- a/cross-tenant-external-sharing-governance/CHANGELOG.md
+++ b/cross-tenant-external-sharing-governance/CHANGELOG.md
@@ -6,6 +6,30 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed (technical accuracy review vs Microsoft Learn)
+
+- **Fabricated Power Platform API permission scopes removed.** README, `docs/prerequisites.md`,
+  `docs/troubleshooting.md`, and `DELIVERY-CHECKLIST.md` listed
+  `PowerPlatform.Admin.Read.All` and `PowerPlatform.Admin.ReadWrite.All` as Microsoft
+  Graph-style "Application" permissions on a "Power Platform API". No such scopes exist.
+  The Power Platform admin (BAP) API this solution calls does not expose granular
+  application permission scopes; a service principal or managed identity is granted
+  tenant-admin-equivalent access by registering it as a Power Platform admin management
+  application via `New-PowerAppManagementApp`. The Microsoft Graph scopes (Policy.Read.All,
+  User.Read.All, CrossTenantInformation.ReadBasic.All, Organization.Read.All,
+  Policy.ReadWrite.CrossTenantAccess) are unchanged. Added a note that the read-only vs.
+  read-write separation between the two managed identities is enforced operationally, and
+  that the newer `api.powerplatform.com` surface uses delegated permissions plus RBAC roles
+  (Reader/Contributor) for service principals. Source:
+  https://learn.microsoft.com/power-platform/admin/programmability-authentication-v2
+- **Corrected the Power Platform environment-list endpoint in `docs/flow-configuration.md`.**
+  Flow 2 step 8 ("Get All Power Platform Environments") used
+  `/appmanagement/environments?api-version=2022-03-01-preview`. The documented GA
+  listing endpoint is `/environmentmanagement/environments?api-version=2024-10-01`
+  (`appmanagement/environments/{id}/operations` is the app-install operations path, not
+  the environment list). Source:
+  https://learn.microsoft.com/power-platform/admin/programmability-authentication-v2
+
 ### Fixed (lab-readiness validation)
 
 - **`Scan-ManagedEnvBotSharingBaseline.ps1` used non-existent governance

--- a/cross-tenant-external-sharing-governance/DELIVERY-CHECKLIST.md
+++ b/cross-tenant-external-sharing-governance/DELIVERY-CHECKLIST.md
@@ -64,11 +64,13 @@ Pre-deployment validation items for Cross-Tenant External Sharing Governance. Co
 ## Managed Identity Configuration
 
 - [ ] `MI-CrossTenantReadOnly` provisioned
-  - Assigned permissions: Policy.Read.All, User.Read.All, CrossTenantInformation.ReadBasic.All, Organization.Read.All, PowerPlatform.Admin.Read.All
+  - Assigned Graph permissions: Policy.Read.All, User.Read.All, CrossTenantInformation.ReadBasic.All, Organization.Read.All
+  - Power Platform admin (BAP) access: registered as management application via `New-PowerAppManagementApp`
   - Date configured: _______________
 
 - [ ] `MI-CrossTenantReadWrite` provisioned
-  - Assigned permissions: Policy.ReadWrite.CrossTenantAccess, User.Read.All, CrossTenantInformation.ReadBasic.All, PowerPlatform.Admin.ReadWrite.All
+  - Assigned Graph permissions: Policy.ReadWrite.CrossTenantAccess, User.Read.All, CrossTenantInformation.ReadBasic.All
+  - Power Platform admin (BAP) access: registered as management application via `New-PowerAppManagementApp`
   - Policy.ReadWrite.CrossTenantAccess approved by Entra Global Admin: Yes / Pending
   - Date configured: _______________
 

--- a/cross-tenant-external-sharing-governance/README.md
+++ b/cross-tenant-external-sharing-governance/README.md
@@ -143,10 +143,10 @@ The solution continuously detects unauthorized cross-tenant configurations, main
 
 | Identity | Assigned To | Permissions |
 |----------|-------------|-------------|
-| **MI-CrossTenantReadOnly** | Flows 1, 2, 3, 6 | Policy.Read.All, User.Read.All, CrossTenantInformation.ReadBasic.All, Organization.Read.All, PowerPlatform.Admin.Read.All |
-| **MI-CrossTenantReadWrite** | Flows 4, 5 | Policy.ReadWrite.CrossTenantAccess, User.Read.All, CrossTenantInformation.ReadBasic.All, PowerPlatform.Admin.ReadWrite.All |
+| **MI-CrossTenantReadOnly** | Flows 1, 2, 3, 6 | Graph: Policy.Read.All, User.Read.All, CrossTenantInformation.ReadBasic.All, Organization.Read.All. Power Platform admin (BAP) access via management-application registration (`New-PowerAppManagementApp`) |
+| **MI-CrossTenantReadWrite** | Flows 4, 5 | Graph: Policy.ReadWrite.CrossTenantAccess, User.Read.All, CrossTenantInformation.ReadBasic.All. Power Platform admin (BAP) access via management-application registration (`New-PowerAppManagementApp`) |
 
-> **Note:** `Policy.ReadWrite.CrossTenantAccess` requires Entra Global Admin approval. See [Prerequisites](docs/prerequisites.md) for the consent workflow.
+> **Note:** `Policy.ReadWrite.CrossTenantAccess` requires Entra Global Admin approval. The Power Platform admin (BAP) API used by this solution has no granular read-only vs. read-write application scopes; service principals (including managed identities) are granted tenant-admin-equivalent access via `New-PowerAppManagementApp`, so the read-only/read-write split is enforced operationally. See [Prerequisites](docs/prerequisites.md) for the consent and registration workflow.
 
 ## Quick Start
 

--- a/cross-tenant-external-sharing-governance/docs/flow-configuration.md
+++ b/cross-tenant-external-sharing-governance/docs/flow-configuration.md
@@ -350,7 +350,7 @@ Wrap Steps 4–11 in a **Scope: Main Logic** action. Add a parallel **Scope: Cat
    | Method | `GET` |
    | Base Resource URL | `https://api.powerplatform.com` |
    | Microsoft Entra ID Resource URI | `https://api.powerplatform.com` |
-   | URI | `/appmanagement/environments?api-version=2022-03-01-preview` |
+   | URI | `/environmentmanagement/environments?api-version=2024-10-01` |
 
 9. **For Each Environment**
    - Action: Apply to each on environments from Step 8

--- a/cross-tenant-external-sharing-governance/docs/prerequisites.md
+++ b/cross-tenant-external-sharing-governance/docs/prerequisites.md
@@ -23,7 +23,7 @@ Used by: Flow 1, Flow 2, Flow 3, Flow 6, PowerShell scripts
 | `User.Read.All` | Application | Microsoft Graph | Read guest user profiles |
 | `CrossTenantInformation.ReadBasic.All` | Application | Microsoft Graph | Resolve tenant IDs to display names |
 | `Organization.Read.All` | Application | Microsoft Graph | Read home tenant organization details |
-| `PowerPlatform.Admin.Read.All` | Application | Power Platform API | Read tenant isolation, agent shares, environments |
+| Power Platform admin management application (`New-PowerAppManagementApp`) | Service principal registration | Power Platform admin API (BAP) | Read tenant isolation, agent shares, environments |
 
 ### MI-CrossTenantReadWrite
 
@@ -34,7 +34,9 @@ Used by: Flow 4, Flow 5 only
 | `Policy.ReadWrite.CrossTenantAccess` | Application | Microsoft Graph | Update Entra CTA partner policies |
 | `User.Read.All` | Application | Microsoft Graph | Resolve user profiles during onboarding |
 | `CrossTenantInformation.ReadBasic.All` | Application | Microsoft Graph | Resolve tenant IDs during onboarding |
-| `PowerPlatform.Admin.ReadWrite.All` | Application | Power Platform API | Remove agent role assignments |
+| Power Platform admin management application (`New-PowerAppManagementApp`) | Service principal registration | Power Platform admin API (BAP) | Remove agent role assignments |
+
+> **Note:** The Power Platform admin (BAP) API used by this solution does not expose granular read-only vs. read-write application permission scopes. A service principal (including a managed identity) is granted access by registering it as a Power Platform admin management application with `New-PowerAppManagementApp`, which grants tenant-admin-equivalent access. The separation between `MI-CrossTenantReadOnly` and `MI-CrossTenantReadWrite` is therefore enforced operationally (by which identity each flow uses), not by distinct API permission scopes. Microsoft Graph permissions in the tables above remain granular. See [Power Platform API authentication](https://learn.microsoft.com/power-platform/admin/programmability-authentication-v2); the newer `api.powerplatform.com` surface uses delegated permissions plus RBAC roles (Reader/Contributor) for service principals rather than application permissions.
 
 > **IAM Note:** `Policy.ReadWrite.CrossTenantAccess` is a highly privileged Graph permission that may require Entra Global Admin approval in FSI tenants. If approval is delayed, Flows 4 and 5 can operate in manual-instruction-only mode.
 
@@ -86,11 +88,21 @@ az rest --method POST \
 
 Refer to [Microsoft Graph permission reference](https://learn.microsoft.com/en-us/graph/permissions-reference) for app role IDs.
 
-### Step 3: Assign Power Platform Admin API Permissions
+### Step 3: Grant Power Platform Admin API Access
 
-1. Register each Managed Identity as a service principal in the Power Platform admin center
-2. Assign `PowerPlatform.Admin.Read.All` to **MI-CrossTenantReadOnly**
-3. Assign `PowerPlatform.Admin.ReadWrite.All` to **MI-CrossTenantReadWrite**
+The Power Platform admin (BAP) API does not use Microsoft Graph-style application permission scopes. Grant each Managed Identity tenant-admin-equivalent access by registering its service principal as a Power Platform admin management application:
+
+```powershell
+# Run as a Power Platform tenant administrator
+Add-PowerAppsAccount -Endpoint prod -TenantID <tenant-id>
+
+# Register each Managed Identity's service principal (use the MI Application ID).
+# This grants the service principal the same permissions as a tenant admin.
+New-PowerAppManagementApp -ApplicationId <MI-CrossTenantReadOnly-AppId>
+New-PowerAppManagementApp -ApplicationId <MI-CrossTenantReadWrite-AppId>
+```
+
+> **Note:** `New-PowerAppManagementApp` grants tenant-admin-equivalent access; the BAP API offers no granular read-only vs. read-write scopes. Maintain least-privilege separation operationally by ensuring only Flows 4 and 5 act through `MI-CrossTenantReadWrite`. On the newer Power Platform API (`api.powerplatform.com`), service principals are scoped via RBAC roles (Reader/Contributor) instead. See [Power Platform API authentication](https://learn.microsoft.com/power-platform/admin/programmability-authentication-v2).
 
 ### Step 4: Validate Permissions
 

--- a/cross-tenant-external-sharing-governance/docs/troubleshooting.md
+++ b/cross-tenant-external-sharing-governance/docs/troubleshooting.md
@@ -117,7 +117,7 @@
 ### Flow 1: Tenant Isolation Audit
 
 - **Issue:** Flow returns empty results for tenant isolation status
-  - **Check:** Verify `MI-CrossTenantReadOnly` has `PowerPlatform.Admin.Read.All` permission
+  - **Check:** Verify `MI-CrossTenantReadOnly` is registered as a Power Platform admin management application (`New-PowerAppManagementApp`)
   - **Check:** Confirm the Power Platform API endpoint URL is correct for your region
 
 - **Issue:** Historical comparison fails on first run
@@ -160,7 +160,7 @@
   - **Check:** Review the Dataverse update action for correct record ID binding
 
 - **Issue:** Agent share removal fails with permission error
-  - **Check:** Verify `MI-CrossTenantReadWrite` has `PowerPlatform.Admin.ReadWrite.All` permission
+  - **Check:** Verify `MI-CrossTenantReadWrite` is registered as a Power Platform admin management application (`New-PowerAppManagementApp`)
   - **Check:** Confirm the target agent share has not already been removed by another process
 
 ### Flow 6: Compliance Event Logging


### PR DESCRIPTION
## Technical accuracy review — cross-tenant-external-sharing-governance

Owl-mode review of every Microsoft product/API/permission/cmdlet/SKU claim in the solution against official Microsoft Learn. Scope limited to the `cross-tenant-external-sharing-governance/` folder.

### Corrected (with Microsoft Learn citations)

| # | Claim (file) | Verdict | Fix | Learn URL |
|---|---|---|---|---|
| 1 | `PowerPlatform.Admin.Read.All` / `PowerPlatform.Admin.ReadWrite.All` as Graph-style "Application" scopes on a "Power Platform API" (README.md, docs/prerequisites.md, docs/troubleshooting.md, DELIVERY-CHECKLIST.md) | **inaccurate (fabricated)** | No such scopes exist. The BAP admin API has no granular app-permission scopes; SPN/MI gets tenant-admin-equivalent access via `New-PowerAppManagementApp`. Read/write split is operational. Newer api.powerplatform.com uses delegated perms + RBAC (Reader/Contributor) for SPNs. | https://learn.microsoft.com/power-platform/admin/programmability-authentication-v2 |
| 2 | Environment list endpoint `/appmanagement/environments?api-version=2022-03-01-preview` (docs/flow-configuration.md Flow 2 step 8) | **inaccurate/outdated** | Corrected to GA `/environmentmanagement/environments?api-version=2024-10-01`. `appmanagement/environments/{id}/operations` is the app-install path, not the list path. | https://learn.microsoft.com/power-platform/admin/programmability-authentication-v2 |

### Verified accurate (no change)

- `Get-PowerAppTenantIsolationPolicy` / `Set-PowerAppTenantIsolationPolicy` (Microsoft.PowerApps.Administration.PowerShell) — confirmed real cmdlets.
- Managed Environment agent-sharing properties `bot-limitSharingMode` (`noLimit` / `ExcludeSharingToSecurityGroups`), `bot-authoringSharingDisabled` (True), `bot-maxLimitUserSharing` (-1 = unlimited) — confirmed verbatim in `Scan-ManagedEnvBotSharingBaseline.ps1`. Source: https://learn.microsoft.com/power-platform/admin/managed-environment-sharing-limits
- BAP admin endpoints `api.bap.microsoft.com/.../scopes/admin/tenantSettings` and `.../crossTenantConnectionAllowPolicy` (api-version 2020-10-01), audience `https://service.powerapps.com/`.
- Graph CTA endpoints `/v1.0/policies/crossTenantAccessPolicy`, `/default`, `/partners`, `/partners/{tenantId}` and property shapes (`b2bCollaborationInbound/Outbound`, `b2bDirectConnectInbound/Outbound`, `inboundTrust`, `automaticUserConsentSettings`, `isServiceProvider`, `isInMultiTenantOrganization`). Source: crossTenantAccessPolicyConfigurationDefault resource type.
- Graph `tenantRelationships/findTenantInformationByDomainName(...)`, `/v1.0/organization`, `/v1.0/users?$filter=userType eq 'Guest'` — accurate; matching scopes (`CrossTenantInformation.ReadBasic.All`, `Organization.Read.All`, `User.Read.All`).
- Graph scopes `Policy.Read.All`, `Policy.ReadWrite.CrossTenantAccess` — accurate, correctly flagged as admin-consent.
- Connector unique names `shared_powerplatformforadmins`, `shared_webcontents` — accurate (per prior v1.0.2 review).
- `Get-AzAccessToken -AsSecureString` + Az.Accounts 2.17.0 pin — accurate (the `-AsSecureString` switch was introduced in 2.17.0; default-SecureString change in 5.0.0 does not invalidate the explicit-switch usage).
- M365 E5 SKU reference — accurate.

### Internal consistency

- Dataverse logical column names verified against `create_ctsg_dataverse_schema.py` (source of truth) — no inter-word-underscore drift. `fsi_externaltenantid` appears only in historical CHANGELOG entries (already-fixed to `fsi_externaltenanttenantid`).
- Entity-set pluralization (`fsi_crosstenantcomplianceevents`, `fsi_tenantisolationrecords`, `fsi_externalsharefindings`, `fsi_approvedexternaltenants`) — correct.
- Option-set values (100000000-based CTSG sets; `fsi_acv_zone` intentional 0-based shared carve-out) — consistent with `.ralph-config.json` domain facts and v1.1.0 CHANGELOG.
- Forbidden compliance language scan (ensures compliance|guarantees|will prevent|eliminates risk) — 0 hits.

### Escalated / unverifiable

- **Layer 3 architecture diagram `GET .../bots/{botId}/roleAssignments`** (README) is a schematic representation; Copilot Studio agent sharing is Dataverse record-level (no literal documented REST path of that shape). The flow doc itself describes it abstractly ("Retrieve role assignments for the current agent"), so no fabricated URL was introduced. Left as-is (conceptual); flagged for awareness.
- Live property names on BAP `tenantSettings` / `crossTenantConnectionAllowPolicy` responses (`isolationEnabled` vs `tenantIsolationEnabled`) require live-tenant confirmation — the scripts already hedge this and route it through the delivery checklist.

### Gate results
- `python scripts/build-manifest.py` → exit 0
- `python scripts/build-manifest.py --check` → exit 0
- `python -m mkdocs build --strict` → exit 0 (only pre-existing INFO anchor notes in other solutions)
- Forbidden-language grep on changed docs → clean
- No `.py`/`.ps1` files changed (docs-only fixes), so no compile/AST gate required.

Counts: **2 corrected · ~14 verified-accurate · 2 escalated**.
