### PR TITLE
fix(scope-drift-monitor): technical accuracy review vs Microsoft Learn

### DIFF
--- a/scope-drift-monitor/CHANGELOG.md
+++ b/scope-drift-monitor/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to the Scope Drift Monitor.
 
 ### Fixed
 
+- **National cloud Management API endpoints** — corrected the `fsi_SDM_ManagementApiEndpoint`
+  allow-list (both PowerShell scripts' `ValidateSet`, `README.md`, and `docs/flow-configuration.md`)
+  to match the four published Office 365 Management Activity API roots: `manage.office.com`
+  (Enterprise), `manage-gcc.office.com` (GCC), `manage.office365.us` (GCC High), and
+  `manage.protection.apps.mil` (DoD). The previous DoD value (`manage.protection.outlook.com`)
+  was inaccurate and an undocumented IC/eaglex value (`manage.office.eaglex.ic.gov`) was removed.
+  Updated the client-secret-fallback login-authority `switch` accordingly (GCC High / DoD →
+  `login.microsoftonline.us`; Enterprise / GCC moderate → `login.microsoftonline.com`). Source:
+  [Office 365 Management Activity API reference](https://learn.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-reference).
+  (technical accuracy review vs Microsoft Learn)
 - **`docs/troubleshooting.md`** — "Export Flow Run Data" referenced non-existent
   `pac flow list` / `pac flow run list` / `pac flow run show` commands. There is no `pac flow`
   CLI command group; replaced with accurate guidance (portal 28-day run history export, Power

--- a/scope-drift-monitor/LAB-VALIDATION.md
+++ b/scope-drift-monitor/LAB-VALIDATION.md
@@ -101,9 +101,16 @@ GDPR Art. 5(1)(c), GLBA Section 501(b), and CCPA purpose limitation.
   `Invoke-DriftScan.ps1` does not. If no active `Audit.General` subscription exists, the
   first scan can return `AF20024`. Start the subscription once before initial scanning (the
   troubleshooting guide documents this).
-- **Sovereign IC cloud (eaglex):** the client-secret fallback maps the IC endpoint to the
-  `login.microsoftonline.us` authority. The IC (eaglex) login authority may differ; out of
-  scope for a commercial-cloud lab — verify before any IC deployment.
+- **National cloud Management API endpoints (corrected 2026-06-05):** the
+  `ManagementApiEndpoint` allow-list now matches the four published Office 365 Management
+  Activity API roots — `manage.office.com` (Enterprise), `manage-gcc.office.com` (GCC),
+  `manage.office365.us` (GCC High), `manage.protection.apps.mil` (DoD) — per
+  https://learn.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-reference.
+  The previous DoD value (`manage.protection.outlook.com`) and an undocumented IC/eaglex
+  value (`manage.office.eaglex.ic.gov`) were removed. GCC High / DoD map to the
+  `login.microsoftonline.us` authority; Enterprise and GCC moderate use
+  `login.microsoftonline.com`. Confirm authority and endpoint reachability before any
+  sovereign-cloud deployment.
 
 ## Lab-Readiness Assessment
 

--- a/scope-drift-monitor/README.md
+++ b/scope-drift-monitor/README.md
@@ -110,7 +110,7 @@ After import, configure these environment variables in Power Apps:
 | `fsi_SDM_ClientSecret` | Legacy dev-only Microsoft Entra ID application secret for local script fallback — use managed identity for Azure-hosted production automation |
 | `fsi_SDM_DetectionWindowMinutes` | Detection lookback window in minutes (default: 15) |
 | `fsi_SDM_ActiveScopeStatus` | Option-set value for Active status on fsi_agentscope (default: 10002) |
-| `fsi_SDM_ManagementApiEndpoint` | Office 365 Management API base URL (default: `https://manage.office.com`; use `https://manage.office365.us` for GCC High, `https://manage.office.eaglex.ic.gov` for GCC IC, `https://manage.protection.outlook.com` for DoD) |
+| `fsi_SDM_ManagementApiEndpoint` | Office 365 Management API base URL (default: `https://manage.office.com`; use `https://manage-gcc.office.com` for GCC, `https://manage.office365.us` for GCC High, `https://manage.protection.apps.mil` for DoD) |
 
 ### 3. Configure Connection References
 

--- a/scope-drift-monitor/docs/flow-configuration.md
+++ b/scope-drift-monitor/docs/flow-configuration.md
@@ -82,7 +82,7 @@ Configure environment variables for your organization.
 | `fsi_SDM_ActiveScopeStatus` | Option-set value for Active status on `fsi_agentscope` (default: `10002`) | `10002` |
 | `fsi_SDM_ManagementApiEndpoint` | Office 365 Management API base URL | `https://manage.office.com` (commercial) |
 
-> **Security:** The `fsi_SDM_ManagementApiEndpoint` value is validated at runtime against known Microsoft Management API endpoints (`manage.office.com`, `manage.office365.us`, `manage.office.eaglex.ic.gov`, `manage.protection.outlook.com`). Unrecognized values are replaced with the commercial default to prevent token leakage to untrusted endpoints. PowerShell scripts now try managed identity first and use client-secret OAuth only as a legacy development fallback.
+> **Security:** The `fsi_SDM_ManagementApiEndpoint` value is validated at runtime against the published Microsoft Office 365 Management Activity API endpoints (`manage.office.com` for Enterprise, `manage-gcc.office.com` for GCC, `manage.office365.us` for GCC High, `manage.protection.apps.mil` for DoD). Unrecognized values are replaced with the commercial default to prevent token leakage to untrusted endpoints. PowerShell scripts now try managed identity first and use client-secret OAuth only as a legacy development fallback.
 
 ### Configuring Environment Variables
 

--- a/scope-drift-monitor/scripts/Invoke-DriftScan.ps1
+++ b/scope-drift-monitor/scripts/Invoke-DriftScan.ps1
@@ -71,7 +71,7 @@ param(
     [securestring]$ClientSecret,
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("https://manage.office.com", "https://manage.office365.us", "https://manage.office.eaglex.ic.gov", "https://manage.protection.outlook.com")]
+    [ValidateSet("https://manage.office.com", "https://manage-gcc.office.com", "https://manage.office365.us", "https://manage.protection.apps.mil")]
     [string]$ManagementApiEndpoint = "https://manage.office.com",
 
     [Parameter(Mandatory = $false)]
@@ -192,10 +192,9 @@ function Get-AccessToken {
 
     # legacy: dev-only -- replace with managed identity in production
     $loginEndpoint = switch -Wildcard ($Scope) {
-        "*office365.us*"           { "https://login.microsoftonline.us" }
-        "*eaglex.ic.gov*"          { "https://login.microsoftonline.us" }
-        "*protection.outlook.com*" { "https://login.microsoftonline.us" }
-        default                    { "https://login.microsoftonline.com" }
+        "*office365.us*"        { "https://login.microsoftonline.us" }
+        "*protection.apps.mil*" { "https://login.microsoftonline.us" }
+        default                 { "https://login.microsoftonline.com" }
     }
     $tokenUrl = "$loginEndpoint/$TenantId/oauth2/v2.0/token"
     $body = @{

--- a/scope-drift-monitor/scripts/New-AgentBaseline.ps1
+++ b/scope-drift-monitor/scripts/New-AgentBaseline.ps1
@@ -84,7 +84,7 @@ param(
     [securestring]$ClientSecret,
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("https://manage.office.com", "https://manage.office365.us", "https://manage.office.eaglex.ic.gov", "https://manage.protection.outlook.com")]
+    [ValidateSet("https://manage.office.com", "https://manage-gcc.office.com", "https://manage.office365.us", "https://manage.protection.apps.mil")]
     [string]$ManagementApiEndpoint = "https://manage.office.com",
 
     [Parameter(Mandatory = $false)]
@@ -190,10 +190,9 @@ function Get-AccessToken {
 
     # legacy: dev-only -- replace with managed identity in production
     $loginEndpoint = switch -Wildcard ($Scope) {
-        "*office365.us*"           { "https://login.microsoftonline.us" }
-        "*eaglex.ic.gov*"          { "https://login.microsoftonline.us" }
-        "*protection.outlook.com*" { "https://login.microsoftonline.us" }
-        default                    { "https://login.microsoftonline.com" }
+        "*office365.us*"        { "https://login.microsoftonline.us" }
+        "*protection.apps.mil*" { "https://login.microsoftonline.us" }
+        default                 { "https://login.microsoftonline.com" }
     }
     $tokenUrl = "$loginEndpoint/$TenantId/oauth2/v2.0/token"
     $body = @{


### PR DESCRIPTION
## Scope Drift Monitor — Technical Accuracy Review vs Microsoft Learn

Owl-mode accuracy review of every Microsoft product/API/permission/endpoint/cmdlet claim in `README.md`, `manifest.yaml`, `docs/`, and `scripts/`.

### Corrected (with Microsoft Learn citations)

| Claim | File:line | Issue | Fix | Learn URL |
|-------|-----------|-------|-----|-----------|
| O365 Management API DoD endpoint = `manage.protection.outlook.com` | scripts ValidateSet, README:113, flow-configuration.md:85 | **Inaccurate** — published DoD root is `manage.protection.apps.mil` | Replaced DoD value | [API reference](https://learn.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-reference) |
| "GCC IC" endpoint = `manage.office.eaglex.ic.gov` | scripts ValidateSet, README:113, flow-configuration.md:85 | **Unverifiable/undocumented** — no such published Management API root | Removed; added documented GCC moderate `manage-gcc.office.com` | same |
| Login-authority `switch` mapping (`*eaglex*`, `*protection.outlook.com*`) | Invoke-DriftScan.ps1:194, New-AgentBaseline.ps1:192 | Tied to removed endpoints | Remapped: GCC High/DoD -> `login.microsoftonline.us`; Enterprise/GCC -> `login.microsoftonline.com` | [Azure Government auth](https://learn.microsoft.com/en-us/azure/azure-government/documentation-government-aad-auth) |

Final allow-list (all 4 published roots): `manage.office.com` (Enterprise), `manage-gcc.office.com` (GCC), `manage.office365.us` (GCC High), `manage.protection.apps.mil` (DoD).

### Verified accurate (no change)

- **RecordType 261 = `CopilotInteraction`**, `CopilotEventData` with `AISystemPlugin` / `AccessedResources` — matches [Audit logs for Copilot](https://learn.microsoft.com/en-us/purview/audit-copilot).
- **O365 Management Activity API**: start time <= 7 days in past, 24-hour max window, `NextPageUri` header pagination, `Audit.General` content type, `subscriptions/start` — matches the API reference.
- **`ActivityFeed.Read` (Application)** permission and `manage.office.com` token audience — correct.
- **Managed-identity IMDS / App Service / legacy MSI api-versions** (2018-02-01 / 2019-08-01 / 2017-09-01) — correct.
- **`Send-MgUserMail` / `Connect-MgGraph -Scopes Mail.Send`** (Test-AlertDelivery email path) — matches [Graph sendMail](https://learn.microsoft.com/en-us/graph/api/user-sendmail).
- **Sensitivity labels in Copilot Studio**, README "GA June 2026" — matches [2026 wave 1 release plan](https://learn.microsoft.com/en-us/power-platform/release-plan/2026wave1/power-platform-governance-administration/view-sensitivity-labels-copilot-studio) (GA Jun 2026, preview Nov 30 2025).
- **Dataverse logical column names** (`fsi_agentid`, `fsi_environmentid`, `fsi_violationtype`, etc.) and **option-set values** (10001+) — consistent across scripts and `docs/dataverse-schema.md`; entity sets `fsi_agentscopes` / `fsi_scopeviolations` correct.
- **FSI language rules** — no prohibited compliance-absolute phrasing in changed docs.

### Escalated / unverifiable (require live tenant)

1. **`AISystemPlugin` connector extraction** — `New-AgentBaseline.ps1` reads `\.Name` as the connector name, but the documented audit sample is `{Id:"BingWebSearch", Name:"BuiltIn"}` (Name = plugin *type*, not connector identity). Real-world payload shape for non-builtin connectors is unconfirmed without live `CopilotInteraction` events; left unchanged and flagged (already a runtime caveat in LAB-VALIDATION.md). Validate against real events.
2. **`@odata.bind` navigation-property names** (`fsi_owner@odata.bind`, `fsi_agentscopeid@odata.bind`) — depend on deployed entity metadata; confirm on first write.
3. **GCC/DoD endpoint reachability + authority** — corrected per docs but not exercised in a sovereign-cloud lab.

### Internal-consistency findings

- No Dataverse snake_case violations; option-set values and entity-set pluralization consistent.
- `.ralph-config.json` domain facts (WARN-8579-01, WARN-7f17-01, WARN-390f-01) respected — not touched.
- No manifest version bump (correction folded into existing `[Unreleased]` CHANGELOG section, consistent with current repo state).

### Validation gates (all exit 0)

- `python scripts/build-manifest.py` ✅
- `python scripts/build-manifest.py --check` ✅ (no drift)
- `python -m mkdocs build --strict` ✅
- PowerShell AST parse of both changed `.ps1` ✅
- Forbidden-language grep on changed docs ✅ clean
