### PR TITLE
fix(unrestricted-agent-sharing-detector): technical accuracy review vs Microsoft Learn

### DIFF
--- a/unrestricted-agent-sharing-detector/CHANGELOG.md
+++ b/unrestricted-agent-sharing-detector/CHANGELOG.md
@@ -14,7 +14,14 @@ All notable changes to the Unrestricted Agent Sharing Detector are documented he
 
 ### Changed
 
+- README "Components" tree now lists `scripts/Restore-AgentSharingFromEvidence.ps1`, the rollback runbook referenced throughout the CHANGELOG and `LAB-VALIDATION.md` but previously omitted from the file listing.
 - Added `#Requires -Modules Az.Accounts` to `Restore-AgentSharingFromEvidence.ps1` so the `Get-AzAccessToken` dependency is declared, matching the other governance scripts.
+
+### Verified (Microsoft Learn 2026-Q2 accuracy review)
+
+- Dataverse `bot` table sharing model confirmed against the [Copilot (bot) table reference](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/bot): `accesscontrolpolicy` (`0`=Any, `1`=Copilot readers, `2`=Group membership, `3`=Any (multi-tenant)), `authenticationmode` (`1`=None), and `authorizedsecuritygroupids` ("comma-delimited list of up to 20 ... Group IDs", `MaxLength 739`) — all solution claims accurate.
+- Native agent sharing rules confirmed GA (May 23, 2025) with the four documented controls against [Limit sharing — Agent sharing rules](https://learn.microsoft.com/en-us/power-platform/admin/managed-environment-sharing-limits#agent-sharing-rules).
+- Copilot Studio chat-sharing scopes (individuals, security groups, everyone in the organization) and the Microsoft Entra ID + "Require users to sign-in" prerequisite confirmed against [Share agents with other users](https://learn.microsoft.com/en-us/microsoft-copilot-studio/admin-share-bots).
 
 ## [2.0.1] — 2026-05-04
 

--- a/unrestricted-agent-sharing-detector/README.md
+++ b/unrestricted-agent-sharing-detector/README.md
@@ -41,6 +41,7 @@ unrestricted-agent-sharing-detector/
     ├── create_uasd_connection_references.py
     ├── requirements.txt
     ├── uasd_client.py               # Deprecated stub (v1.0.1) — raises ImportError, use shared DataverseClient
+    ├── Restore-AgentSharingFromEvidence.ps1  # Rollback runbook — restores prior bot sharing config from fsi_evidencejson
     └── governance/
         ├── Invoke-SharingAudit.ps1
         ├── Test-AgentSharingCompliance.ps1


### PR DESCRIPTION
## Technical Accuracy Review — unrestricted-agent-sharing-detector

Owl-mode review of every Microsoft product/API/SKU/cmdlet/option-set claim in this solution against official Microsoft Learn. Result: **all core Microsoft claims verified accurate.** One documentation internal-consistency fix applied.

### Changes
- **README "Components" tree** now lists `scripts/Restore-AgentSharingFromEvidence.ps1` — a real, heavily-referenced rollback runbook that was omitted from the file listing (the only concrete drift found).
- **CHANGELOG** [Unreleased] updated with the doc fix and a "Verified" block citing the Learn references.

### Claims inventoried & verified (claim → Learn URL → verdict)
| Claim | File | Learn URL | Verdict |
|---|---|---|---|
| `bot.accesscontrolpolicy` Picklist 0=Any, 1=Copilot readers, 2=Group membership, 3=Any (multi-tenant) | README, Test-AgentSharingCompliance.ps1, flow-configuration.md, SOLUTION-DOCUMENTATION.md | https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/bot | ACCURATE (exact match) |
| `bot.authenticationmode` 1 = None (anyone with link can chat) | scripts, SOLUTION-DOCUMENTATION.md | (bot table reference, authenticationmode: 0=Unspecified,1=None,2=Integrated,3=Custom AAD,4=Generic OAuth2) | ACCURATE |
| `authorizedsecuritygroupids` = comma-delimited list of up to 20 Entra group IDs (MaxLength 739), used when accesscontrolpolicy=2 | flow-configuration.md, LAB-VALIDATION.md | https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/bot#authorizedsecuritygroupids | ACCURATE ("up to 20" is the Learn-documented wording; MaxLength 739 confirmed) |
| Native agent sharing rules GA May 2025; 4 controls (Editor/Viewer grant, only-individuals, viewer limit); env + env-group scope | README | https://learn.microsoft.com/en-us/power-platform/admin/managed-environment-sharing-limits#agent-sharing-rules | ACCURATE (release plan: GA May 23, 2025; anchor valid) |
| Copilot Studio chat sharing scopes = individuals / security groups / everyone in org; scoped sharing requires Entra ID auth + "Require users to sign-in" | README "Microsoft Learn Alignment" | https://learn.microsoft.com/en-us/microsoft-copilot-studio/admin-share-bots | ACCURATE |
| M365 Copilot Agent Store + Agent/app Package Management API (preview) | README "Platform Update Notes" | https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/api/admin-settings/package/overview | ACCURATE (page exists; preview) |
| Get-AzAccessToken returns SecureString on Az.Accounts 5.0.0+/Az 14.0.0+; detector/export/import convert correctly | CHANGELOG, LAB-VALIDATION.md, scripts | https://learn.microsoft.com/powershell/azure/protect-secrets | ACCURATE (matches ground-truth; detector uses Convert-UasdAccessTokenToPlainText helper handling both types) |
| `sharingtype` column does NOT exist on bot table (prior-cycle correction) | CHANGELOG v2.0.0 | bot table reference | ACCURATE (no sharingtype attribute present) |
| AccessRights enum: `ReadAccess` valid, `CanView` invalid (prior-cycle fix) | CHANGELOG [Unreleased] | https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/reference/accessrights | ACCURATE |
| Regulatory citations FINRA 4511(a)/3110, SEC 17a-3/17a-4 (7-yr retention), SOX 302/404 | SOLUTION-DOCUMENTATION.md | n/a (section-level, language-rule compliant) | ACCURATE |

### Internal consistency
- Option-set values (violationtype/violationstatus/zoneclassification 100000000+) consistent across schema script, scripts, flow docs, and `.ralph-config.json` domainFacts; `fsi_UASD_zoneclassification` vs `fsi_acv_zone` divergence documented and respected.
- Dataverse logical column names correct (no inter-word underscores); entity sets `fsi_sharingviolations` / `fsi_sharingexceptions` consistent script↔docs.
- Found & fixed: README components tree missing `Restore-AgentSharingFromEvidence.ps1`.

### Escalated / unverifiable
- None. (No live-tenant-state-dependent Microsoft claims required escalation.)

### Validation gates (all exit 0)
- `python scripts/build-manifest.py` ✅
- `python scripts/build-manifest.py --check` ✅ (no drift)
- `python -m mkdocs build --strict` ✅
- Forbidden-language grep on changed docs (ensures compliance|guarantees|will prevent|eliminates risk) ✅ clean
- No `.py`/`.ps1` changed (docs-only edits).
