### PR TITLE
fix(scope-drift-monitor): read connector identity from AISystemPlugin.Id not .Name

### DIFF
--- a/scope-drift-monitor/CHANGELOG.md
+++ b/scope-drift-monitor/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to the Scope Drift Monitor.
 
 ### Fixed
 
+- **Connector identity in `AISystemPlugin` parsing** — `Invoke-DriftScan.ps1` and
+  `New-AgentBaseline.ps1` read the connector identity from `AISystemPlugin[].Name`, which
+  is the plugin *type* (e.g. `"BuiltIn"`), not the connector. The documented Copilot audit
+  sample is `{"Id":"BingWebSearch","Name":"BuiltIn"}`, where `.Id` is the connector identity.
+  Both scripts now prefer `$plugin.Id` (falling back to `$plugin.Name` when absent) so the
+  baseline and drift scan key on the actual connector rather than recording every built-in
+  plugin as `"BuiltIn"`. **Operational note:** regenerate existing agent baselines with
+  `New-AgentBaseline.ps1` after upgrading — baselines captured before this fix store the
+  plugin type and will not match `.Id`-keyed scan results. Source:
+  [CopilotInteraction audit schema](https://learn.microsoft.com/office/office-365-management-api/copilot-schema)
+  and [Audit Copilot Studio activities](https://learn.microsoft.com/microsoft-copilot-studio/admin-logging-copilot-studio#see-audited-events-agent-usage).
+  (technical accuracy review vs Microsoft Learn)
 - **National cloud Management API endpoints** — corrected the `fsi_SDM_ManagementApiEndpoint`
   allow-list (both PowerShell scripts' `ValidateSet`, `README.md`, and `docs/flow-configuration.md`)
   to match the four published Office 365 Management Activity API roots: `manage.office.com`

--- a/scope-drift-monitor/LAB-VALIDATION.md
+++ b/scope-drift-monitor/LAB-VALIDATION.md
@@ -56,9 +56,10 @@ GDPR Art. 5(1)(c), GLBA Section 501(b), and CCPA purpose limitation.
 
 - **RecordType 261 = `CopilotInteraction`** filter in both collector scripts — matches the
   authoritative audit schema (source 1).
-- **`CopilotEventData` parsing** (`AISystemPlugin[].Name`, `AccessedResources`, `Contexts[].Id`,
+- **`CopilotEventData` parsing** (`AISystemPlugin[].Id` for connector identity, `AccessedResources`, `Contexts[].Id`,
   agent identity via `AgentId`/`BotId`/`AppIdentity`) — field names match the documented
-  Copilot audit schema (source 1).
+  Copilot audit schema (source 1). The documented sample is `{"Id":"BingWebSearch","Name":"BuiltIn"}`,
+  where `.Id` is the connector identity and `.Name` is the plugin type.
 - **Office 365 Management API usage** — `subscriptions/content?contentType=Audit.General`,
   `NextPageUri` header pagination, `contentUri` blob fetch, the **24-hour windowing** in
   `New-AgentBaseline.ps1`, and `-Days` `ValidateRange(1,7)` all align with the documented

--- a/scope-drift-monitor/scripts/Invoke-DriftScan.ps1
+++ b/scope-drift-monitor/scripts/Invoke-DriftScan.ps1
@@ -515,8 +515,12 @@ function Compare-ScopeVsActual {
     # Check connectors from AISystemPlugin
     if ($eventData.AISystemPlugin) {
         foreach ($plugin in @($eventData.AISystemPlugin)) {
-            if ($plugin.Name) {
-                $connectorName = $plugin.Name
+            # In CopilotEventData.AISystemPlugin, .Id is the connector/plugin identity
+            # (e.g. "BingWebSearch") and .Name is the plugin type (e.g. "BuiltIn").
+            # Prefer .Id for the connector identity; fall back to .Name if absent.
+            # Ref: https://learn.microsoft.com/office/office-365-management-api/copilot-schema
+            $connectorName = if ($plugin.Id) { $plugin.Id } else { $plugin.Name }
+            if ($connectorName) {
                 if ($connectorName -notin $allowedConnectors) {
                     $violations += @{
                         Type        = "Unauthorized Connector"

--- a/scope-drift-monitor/scripts/New-AgentBaseline.ps1
+++ b/scope-drift-monitor/scripts/New-AgentBaseline.ps1
@@ -469,8 +469,11 @@ function Get-AccessedResources {
         # Extract connectors from AISystemPlugin array
         if ($eventData.AISystemPlugin) {
             foreach ($plugin in @($eventData.AISystemPlugin)) {
-                if ($plugin.Name) {
-                    $connectorName = $plugin.Name
+                # .Id is the connector/plugin identity (e.g. "BingWebSearch"); .Name is the
+                # plugin type (e.g. "BuiltIn"). Prefer .Id; fall back to .Name if absent.
+                # Ref: https://learn.microsoft.com/office/office-365-management-api/copilot-schema
+                $connectorName = if ($plugin.Id) { $plugin.Id } else { $plugin.Name }
+                if ($connectorName) {
                     if ($connectorName -notin $resources.Connectors) {
                         $resources.Connectors += $connectorName
                     }


### PR DESCRIPTION
## Technical accuracy fix (F1) — connector identity in Copilot audit events

**Finding:** Invoke-DriftScan.ps1 and New-AgentBaseline.ps1 derive the connector identity from `AISystemPlugin[].Name`. Per the Microsoft Learn CopilotInteraction audit schema, the documented sample is:

`"AISystemPlugin":[{"Id":"BingWebSearch","Name":"BuiltIn"}]`

.Id is the connector/plugin **identity**; .Name is the plugin **type** (e.g. `BuiltIn`). Reading .Name records every built-in plugin as `BuiltIn`, so connector drift detection compares the literal type against the allowed-connector list — it never sees the real connector.

**Fix:** Both scripts now prefer $plugin.Id (falling back to $plugin.Name when absent) so the baseline and scan key on the actual connector. `AccessedResources[].Name` parsing is unchanged (there .Name is the resource name, which is correct).

**Operational note:** baselines captured before this fix store the plugin type and will not match `.Id`-keyed scan results — regenerate baselines with New-AgentBaseline.ps1 after upgrading. Noted in CHANGELOG.

### Citations
| Claim | Microsoft Learn |
|---|---|
| `AISystemPlugin` sample `{Id:"BingWebSearch", Name:"BuiltIn"}` | https://learn.microsoft.com/microsoft-copilot-studio/admin-logging-copilot-studio#see-audited-events-agent-usage |
| CopilotInteraction (RecordType 261) schema | https://learn.microsoft.com/office/office-365-management-api/copilot-schema |

### Validation
- PowerShell AST parse: both scripts OK
- uild-manifest.py + --check: clean (no manifest version bump — [Unreleased] CHANGELOG)
- Only 4 intended files changed
