### PR TITLE
fix(model-risk-management-automation): correct non-existent PowerPlatform.Admin.Read.All permission

### DIFF
--- a/model-risk-management-automation/CHANGELOG.md
+++ b/model-risk-management-automation/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Non-existent `PowerPlatform.Admin.Read.All` permission**: `docs/prerequisites.md` listed a
+  fabricated `PowerPlatform.Admin.Read.All` application permission on the Power Platform API.
+  Power Platform API scopes are namespaced — the
+  [permission reference](https://learn.microsoft.com/power-platform/admin/programmability-permission-reference#defined-permissions)
+  defines scopes such as `EnvironmentManagement.Settings.Read`, not a single `*.Admin.Read.All`.
+  Corrected the row to `EnvironmentManagement.Settings.Read` for environment-config reads and
+  noted that agent/bot metadata is read via the Dataverse Web API with an application user +
+  security role. Updated the `LAB-VALIDATION.md` open-item note accordingly.
+  (technical accuracy review vs Microsoft Learn)
 - **Command existence (second-pass audit)**: The agent-metadata enrichment call cited a non-existent Power Platform API endpoint. `docs/flow-configuration.md` step 4.2 used `https://api.powerplatform.com/appmanagement/environments/{env}/bots/{bot}?api-version=2022-03-01-preview` and `SOLUTION-DOCUMENTATION.md` §3 used a `powervirtualagents/...bots` path; neither namespace exposes a bot read (the Power Platform API only documents bot-scoped sub-resources under the `copilotstudio` namespace — `botQuarantine`, `makerevaluation`). Both now read the documented Dataverse `bot` table (`GET .../api/data/v9.2/bots({botId})?$select=name,schemaname,statecode,publishedon,_ownerid_value`), whose `botid` equals the Power Platform Bot ID stored in `fsi_agentid`. Ref: https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/bot
 - **Doc consistency**: Updated `DELIVERY-CHECKLIST.md` API field-confirmation rows, `docs/prerequisites.md` network/role tables, `README.md` role table, and the `fsi_cr_http_mrm` usage descriptions in `docs/flow-configuration.md` and `scripts/create_mrm_connection_references.py` to reference the Dataverse `bot` table instead of the non-existent "Power Platform Bots API".
 - **Connector naming (technical-accuracy review)**: `docs/flow-configuration.md` connection-reference table listed the `fsi_cr_dataverse_mrm` connector as "Common Data Service" — the legacy CDS 2.0 connector that has been deprecated since October 2022. Corrected to "Microsoft Dataverse", which matches the `shared_commondataserviceforapps` connector actually deployed by `scripts/create_mrm_connection_references.py`. Refs: https://learn.microsoft.com/power-platform/important-changes-coming and https://learn.microsoft.com/connectors/commondataserviceforapps/

--- a/model-risk-management-automation/LAB-VALIDATION.md
+++ b/model-risk-management-automation/LAB-VALIDATION.md
@@ -97,8 +97,9 @@ changes were required.
   emerging surfaces. The solution gates them behind `IsAgent365LifecycleEnabled`
   (default `false`) and documents "use the API path your tenant has approved" —
   operators must verify against current Microsoft Learn at deployment time.
-- **`PowerPlatform.Admin.Read.All`** is documented as illustrative; confirm the
-  exact Power Platform API scope your tenant exposes during managed-identity setup.
+- **`PowerPlatform.Admin.Read.All` does not exist.** The Power Platform API uses namespaced
+  scopes (e.g. `EnvironmentManagement.Settings.Read`); agent/bot metadata is read via the
+  Dataverse Web API with an application user + security role. Corrected in `docs/prerequisites.md`.
 
 ## Final Assessment
 

--- a/model-risk-management-automation/docs/prerequisites.md
+++ b/model-risk-management-automation/docs/prerequisites.md
@@ -33,7 +33,15 @@ Grant the following application permissions to the managed identity used by prod
 |-----------|------|-------|---------|
 | `User.Read.All` | Application | Microsoft Graph | Resolve owner and validator UPNs to user profiles (department, display name) |
 | `Sites.ReadWrite.All` | Application | Microsoft Graph / SharePoint | Agent Card document creation, update, and folder management |
-| `PowerPlatform.Admin.Read.All` | Application | Power Platform API | Read agent metadata and environment configurations |
+| `EnvironmentManagement.Settings.Read` | Application | Power Platform API | Read environment management settings via the Power Platform programmability API |
+
+> **Power Platform API scopes are namespaced.** There is no `PowerPlatform.Admin.Read.All`
+> permission; the [Power Platform API permission reference](https://learn.microsoft.com/power-platform/admin/programmability-permission-reference#defined-permissions)
+> defines namespaced scopes such as `EnvironmentManagement.Settings.Read` and
+> `ResourceQuery.Resources.Read`. **Agent (bot) metadata** lives in Dataverse — read it
+> through the [Dataverse Web API](https://learn.microsoft.com/power-apps/developer/data-platform/webapi/overview)
+> using an application user granted a security role (for example, a read-only custom role),
+> not a Power Platform API scope.
 
 Optional Agent 365 registry enrichment depends on which Microsoft Graph preview path your tenant uses:
 


### PR DESCRIPTION
## Technical accuracy fix (C1) — non-existent Power Platform API permission

**Finding:** docs/prerequisites.md listed `PowerPlatform.Admin.Read.All` as an Application permission on the Power Platform API for "Read agent metadata and environment configurations." This scope does not exist.

Per the Microsoft Learn [Power Platform API permission reference](https://learn.microsoft.com/power-platform/admin/programmability-permission-reference#defined-permissions), Power Platform API scopes are **namespaced** — e.g. `EnvironmentManagement.Settings.Read`, `ResourceQuery.Resources.Read` — there is no `*.Admin.Read.All` scope. Agent (bot) metadata is not a Power Platform API resource at all; it lives in **Dataverse** and is read via the Dataverse Web API.

**Fix (documentation only — no code path used this scope):**
- Replaced the table row with `EnvironmentManagement.Settings.Read` (Power Platform API) for environment-config reads.
- Added a note that agent/bot metadata is read via the Dataverse Web API using an application user + security role.
- Updated the `LAB-VALIDATION.md` open-item note (previously "documented as illustrative") to record the correction.

### Citations
| Claim | Microsoft Learn |
|---|---|
| PP API scopes are namespaced; no `*.Admin.Read.All` | https://learn.microsoft.com/power-platform/admin/programmability-permission-reference#defined-permissions |
| Agent/bot metadata via Dataverse Web API | https://learn.microsoft.com/power-apps/developer/data-platform/webapi/overview |

### Validation
- uild-manifest.py + --check: clean (no version bump — [Unreleased] CHANGELOG)
- 3 intended doc files changed; no script/behavior change
