### PR TITLE
fix(cross-tenant-external-sharing-governance): correct non-existent agent-share endpoint

### DIFF
--- a/cross-tenant-external-sharing-governance/CHANGELOG.md
+++ b/cross-tenant-external-sharing-governance/CHANGELOG.md
@@ -8,6 +8,17 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed (technical accuracy review vs Microsoft Learn)
 
+- **Non-existent `bots/{botId}/roleAssignments` agent-share endpoint corrected.** The README
+  architecture diagram (Layer 3), `DELIVERY-CHECKLIST.md`, and Flow 2 (`Detect-ExternalAgentShares-Daily`)
+  in `docs/flow-configuration.md` described reading agent shares via a
+  `GET .../bots/{botId}/roleAssignments` REST path, which Microsoft does not document. Copilot
+  Studio agents are Dataverse `bot` records, so the documented way to enumerate who an agent is
+  shared with is the Dataverse `RetrieveSharedPrincipalsAndAccess` Web API function on the `bot`
+  record, whose `PrincipalAccess` array yields each shared `Principal` (mapped to `principalId`)
+  and `AccessMask`. Updated the diagram, checklist, and Flow 2 steps 9a/9b-i/9b-ii accordingly.
+  Refs:
+  [RetrieveSharedPrincipalsAndAccess](https://learn.microsoft.com/power-apps/developer/data-platform/webapi/reference/retrievesharedprincipalsandaccess)
+  and [Verifying access in code](https://learn.microsoft.com/power-apps/developer/data-platform/security-access-coding).
 - **Fabricated Power Platform API permission scopes removed.** README, `docs/prerequisites.md`,
   `docs/troubleshooting.md`, and `DELIVERY-CHECKLIST.md` listed
   `PowerPlatform.Admin.Read.All` and `PowerPlatform.Admin.ReadWrite.All` as Microsoft

--- a/cross-tenant-external-sharing-governance/DELIVERY-CHECKLIST.md
+++ b/cross-tenant-external-sharing-governance/DELIVERY-CHECKLIST.md
@@ -18,11 +18,11 @@ Pre-deployment validation items for Cross-Tenant External Sharing Governance. Co
   - Write endpoint/cmdlet availability confirmed: Yes / Not available (use manual PPAC steps)
   - Date validated: _______________
 
-- [ ] **Copilot Studio agent role assignments:** `GET .../bots/{botId}/roleAssignments?api-version=<confirmed-version>`
-  - Returns guest user role assignments: Yes / No
-  - Identifiable `principalType` field: Yes / No
+- [ ] **Copilot Studio agent role assignments:** Copilot Studio agents are Dataverse `bot` records; enumerate who an agent is shared with via the Dataverse `RetrieveSharedPrincipalsAndAccess` Web API function on the `bot` record (`GET .../api/data/v9.2/RetrieveSharedPrincipalsAndAccess(Target=@t)?@t={...}`). There is no documented `bots/{botId}/roleAssignments` REST endpoint.
+  - Returns guest/team principals and their access rights: Yes / No
+  - Identifiable principal in the `PrincipalAccess` array (`Principal` + `AccessMask`): Yes / No
   - Confirmed response field names: _______________
-  - If principalType not available, fallback to guestUserIndex comparison: Confirmed / Not needed
+  - If a principal's home tenant is not resolvable from the share, fallback to guestUserIndex comparison: Confirmed / Not needed
 
 ## Dependent Solution Validation
 

--- a/cross-tenant-external-sharing-governance/README.md
+++ b/cross-tenant-external-sharing-governance/README.md
@@ -88,7 +88,7 @@ The solution continuously detects unauthorized cross-tenant configurations, main
 ├─────────────────────────────────────────────────────────────────┤
 │  LAYER 3: Copilot Studio Agent Shares                           │
 │  Scope: Agent-level sharing with external/guest users           │
-│  API: GET .../bots/{botId}/roleAssignments                      │
+│  API: Dataverse RetrieveSharedPrincipalsAndAccess (bot record)  │
 │  Detection: Flow 2 — Detect-ExternalAgentShares-Daily           │
 └─────────────────────────────────────────────────────────────────┘
 ```

--- a/cross-tenant-external-sharing-governance/docs/flow-configuration.md
+++ b/cross-tenant-external-sharing-governance/docs/flow-configuration.md
@@ -357,19 +357,26 @@ Wrap Steps 4–11 in a **Scope: Main Logic** action. Add a parallel **Scope: Cat
    - **Concurrency:** Set degree of parallelism to `5`
 
    9a. **Get Agents in Environment**
-   - Retrieve agent list from the environment's Copilot Studio inventory
+   - Action: "List rows" (Dataverse) against the environment's `bot` table
+     (`GET .../api/data/v9.2/bots?$select=botid,name,_owninguser_value`) — Copilot Studio
+     agents are stored as Dataverse `bot` records.
 
    9b. **For Each Agent**
    - Action: Apply to each on agents
 
-   9b-i. **Get Agent Role Assignments**
-   - Action: HTTP with Microsoft Entra ID
-   - Retrieve role assignments for the current agent
-   - **Schema validation:** Confirm response contains expected `principalId` field before processing
+   9b-i. **Get Agent Shares (record sharing)**
+   - Action: HTTP with Microsoft Entra ID (Dataverse Web API)
+   - Call the documented `RetrieveSharedPrincipalsAndAccess` function on the agent's `bot`
+     record to list every user/team/organization the agent is shared with:
+     `GET .../api/data/v9.2/RetrieveSharedPrincipalsAndAccess(Target=@t)?@t={'@odata.id':'bots(<botid>)'}`
+   - **Schema validation:** Confirm the response `PrincipalAccess` array is present; each entry
+     exposes `Principal` (the shared user/team, whose `id` maps to `principalId` below) and
+     `AccessMask`. Ref:
+     https://learn.microsoft.com/power-apps/developer/data-platform/webapi/reference/retrievesharedprincipalsandaccess
 
-   9b-ii. **For Each Role Assignment**
+   9b-ii. **For Each Shared Principal**
 
-   - **Condition:** `principalId` exists in `guestUserIndex`
+   - **Condition:** `principalId` (the `Principal.id` from each `PrincipalAccess` entry) exists in `guestUserIndex`
    - **If true (guest found):**
 
      1. **Check Approved Status**


### PR DESCRIPTION
## Technical accuracy fix (D1) — non-existent agent-share endpoint

**Finding:** The README architecture diagram (Layer 3), `DELIVERY-CHECKLIST.md`, and Flow 2 (`Detect-ExternalAgentShares-Daily`) described reading Copilot Studio agent shares via `GET .../bots/{botId}/roleAssignments`. Microsoft does not document this REST path.

Copilot Studio agents are stored as **Dataverse ot records**. The documented way to enumerate who a record is shared with is the Dataverse **RetrieveSharedPrincipalsAndAccess** Web API function, whose `PrincipalAccess` array returns each shared `Principal` (user/team — its `id` maps to the flow's `principalId`) and `AccessMask`.

**Fix (documentation + flow build instructions — no exported runtime artifact):**
- README diagram Layer 3 API line → `Dataverse RetrieveSharedPrincipalsAndAccess (bot record)` (box alignment preserved).
- `DELIVERY-CHECKLIST.md` validation item rewritten to the Dataverse function + `PrincipalAccess` fields.
- Flow 2 steps 9a/9b-i/9b-ii made concrete: list agents from the Dataverse `bot` table, call `RetrieveSharedPrincipalsAndAccess`, iterate `PrincipalAccess` entries.

### Citations
| Claim | Microsoft Learn |
|---|---|
| Enumerate record shares via `RetrieveSharedPrincipalsAndAccess` | https://learn.microsoft.com/power-apps/developer/data-platform/webapi/reference/retrievesharedprincipalsandaccess |
| Verifying access / sharing in code | https://learn.microsoft.com/power-apps/developer/data-platform/security-access-coding |

### Validation
- `build-manifest.py` + `--check`: clean (no version bump — `[Unreleased]` CHANGELOG)
- `mkdocs build --strict`: built successfully
- README diagram box width unchanged (67 chars); 4 intended files changed
