### PR TITLE
fix(env-vars): correct Dataverse 'Decimal' env-var type code (JSON->Number) [#72]

### DIFF
--- a/dr-testing-framework/scripts/create_drt_environment_variables.py
+++ b/dr-testing-framework/scripts/create_drt_environment_variables.py
@@ -103,15 +103,18 @@ def create_environment_variables(client: DataverseClient, dry_run: bool = False)
                 print(f"    Type: {var['type']}, Default: {var['defaultvalue']}")
                 results["created"] += 1
             else:
-                # Map type to Dataverse environment variable type code:
-                # 100000000 = String, 100000001 = Number, 100000002 = Boolean, 100000003 = JSON, 100000004 = DataSource, 100000005 = Secret
-                # NOTE: there is no native "Decimal" type for environment variables; "Decimal" entries below are stored as JSON.
+                # Map type to Dataverse environment variable type code
+                # (environmentvariabledefinition_type global choice):
+                # 100000000 = String, 100000001 = Number, 100000002 = Boolean,
+                # 100000003 = JSON, 100000004 = Data Source, 100000005 = Secret.
+                # "Number" (100000001) is surfaced in the maker UI as the
+                # "Decimal number" data type, so "Decimal" maps to 100000001.
                 type_code_map = {
                     "String": 100000000,
                     "Number": 100000001,
                     "Boolean": 100000002,
                     "JSON": 100000003,
-                    "Decimal": 100000003,  # treated as JSON; Power Automate flows must JSON-parse the value
+                    "Decimal": 100000001,  # "Decimal number" == Number type
                 }
                 type_code = type_code_map.get(var["type"], 100000000)
 
@@ -169,8 +172,8 @@ def main() -> None:
         epilog="""
 Environment variables created:
   - fsi_DRT_DataverseUrl (String, "")
-  - fsi_DRT_ProbeBudgetMinutes (Decimal-as-JSON, 60)
-  - fsi_DRT_MaxMinutesSinceLastResult (Decimal-as-JSON, 1440)
+  - fsi_DRT_ProbeBudgetMinutes (Number, 60)
+  - fsi_DRT_MaxMinutesSinceLastResult (Number, 1440)
   - fsi_DRT_TeamsGroupId (String, "")
   - fsi_DRT_TeamsChannelId (String, "")
   - fsi_DRT_NotificationEmail (String, "")

--- a/file-upload-security/scripts/create_environment_variables.py
+++ b/file-upload-security/scripts/create_environment_variables.py
@@ -112,8 +112,9 @@ TYPE_MAP = {
     "JSON":       100000003,
     "DataSource": 100000004,
     "Secret":     100000005,
-    # "Decimal" is not a native env-var type — flows must JSON-parse the value
-    "Decimal":    100000003,
+    # "Number" (100000001) is shown in the maker UI as the "Decimal number"
+    # data type, so "Decimal" maps to the same numeric type code.
+    "Decimal":    100000001,
 }
 
 


### PR DESCRIPTION
## Summary
Weekend audit (Issue #72) of the **Power Platform / Dataverse** solution assets — schema-layer scope. The Dataverse schema scripts, connection references, environment-variable definitions, and the shared `DataverseClient` were audited against current Microsoft platform behavior. One genuine accuracy defect was found and fixed; the rest of the schema layer verified accurate (see "Audit findings" below).

## The defect
Two environment-variable setup scripts mapped the `"Decimal"` type to the wrong Dataverse option-set value:

| Script | Before | After |
|---|---|---|
| `dr-testing-framework/scripts/create_drt_environment_variables.py` | `"Decimal": 100000003` (JSON) | `"Decimal": 100000001` (Number) |
| `file-upload-security/scripts/create_environment_variables.py` | `"Decimal": 100000003` (JSON) | `"Decimal": 100000001` (Number) |

Per the Dataverse `environmentvariabledefinition_type` global choice, **100000001 = Number** (surfaced in the maker UI as the **"Decimal number"** data type) and **100000003 = JSON**. The two scripts created numeric variables (e.g. `fsi_DRT_ProbeBudgetMinutes=60`, `fsi_FUS_GracePeriodHours=24`) as **JSON-typed** definitions, with inline comments claiming "there is no native Decimal type… flows must JSON-parse the value." That claim is false: Dataverse has a native numeric env-var type (100000001). The misleading notes/epilog were also corrected.

The other 11 `create_*environment_variables.py` scripts already map the numeric type to 100000001; this aligns the two outliers.

### Why safe
The affected DRT variables are documented as "Reserved (v2.0.0) … currently informational only" and the env-var **value** is always stored as a string regardless of type — so correcting the type metadata has no downstream-binding breakage and is the right time to fix it.

## Audit findings — verified accurate (no change needed)
- **Web API version** `v9.2` (current GA) and OData 4.0 headers in the shared client.
- **Attribute metadata `@odata.type` values** — all 17 distinct types (String/Memo/Integer/Decimal/Money/DateTime/Boolean/Picklist/Lookup/EntityKey/relationship/etc.) are valid current Dataverse metadata types.
- **Connectors** — all connection references use current internal names incl. `shared_commondataserviceforapps` (current Dataverse connector; deprecated `shared_commondataservice` is **not** used). `connectorid` uses the live `/providers/Microsoft.PowerApps/apis/{connector}` format.
- **String `MaxLength`** — no `StringAttributeMetadata` exceeds the 4000 limit; larger values (10000/100000) are on `MemoAttributeMetadata`.
- **Auth** — managed-identity-first; client-secret correctly marked legacy/dev-only.

## Sources (Microsoft Learn)
- Environment Variable Definition entity reference — `environmentvariabledefinition_type` choices (100000000 String, 100000001 Number, 100000002 Boolean, 100000003 JSON, 100000004 Data Source, 100000005 Secret): https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/environmentvariabledefinition
- Environment variables overview — Data Type list incl. "Decimal number": https://learn.microsoft.com/en-us/power-apps/maker/data-platform/environmentvariables
- Create/update column & table definitions using the Web API (v9.2 metadata): https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/create-update-entity-definitions-using-web-api

## Validation
- `ruff check scripts */scripts` — clean
- repo-wide `pytest` — 258 passed, 2 skipped
- `pytest message-center-monitor/tests` (hard-gated) — 13 passed
- `lint-odata-columns.py` / `lint-odata-existence.py` — exit 0
- `py_compile` both edited files — OK

## Scope
Technical correctness only. No regulatory/compliance wording was edited.

Refs #72
