### PR TITLE
docs: fix stale framework control links and modernize Purview terminology (#70)

### DIFF
--- a/agent-access-monitor/README.md
+++ b/agent-access-monitor/README.md
@@ -113,8 +113,6 @@ agent-access-monitor/
 | Control | Relationship |
 |---------|--------------|
 | [3.8 - Copilot Hub](https://judeper.github.io/FSI-AgentGov/controls/pillar-3-reporting/3.8-copilot-hub-and-governance-dashboard/) | Primary — Agent Access Control settings |
-| [2.5 - Agent Sharing Scope](https://judeper.github.io/FSI-AgentGov/controls/pillar-2-management/2.5-agent-sharing-scope/) | Agent sharing scope validation |
-| [2.6 - Restrict Team-Created Agent Sharing](https://judeper.github.io/FSI-AgentGov/controls/pillar-2-management/2.6-restrict-team-created-agent-sharing/) | Team-created agent sharing limits |
 | [1.1 - Restrict Publishing](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.1-restrict-agent-publishing-by-authorization/) | Publishing authorization |
 | [2.1 - Managed Environments](https://judeper.github.io/FSI-AgentGov/controls/pillar-2-management/2.1-managed-environments/) | Sharing limits |
 

--- a/agent-communication-restriction-detector/README.md
+++ b/agent-communication-restriction-detector/README.md
@@ -148,7 +148,7 @@ The following placeholder values in solution files must be replaced with your or
 | Control | Relationship |
 |---------|-------------|
 | [2.17 -- Multi-Agent Orchestration Limits](https://judeper.github.io/FSI-AgentGov/controls/pillar-2-management/2.17-multi-agent-orchestration-limits/) | Primary -- validates agent-to-agent communication restrictions |
-| [1.8 -- Runtime Protection](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.8-runtime-security-monitoring/) | Supporting -- runtime communication validation |
+| [1.8 -- Runtime Protection](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.8-runtime-protection-and-external-threat-detection/) | Supporting -- runtime communication validation |
 | [2.1 -- Managed Environments](https://judeper.github.io/FSI-AgentGov/controls/pillar-2-management/2.1-managed-environments/) | Dependency -- zone classification source |
 | [3.8 -- Copilot Hub](https://judeper.github.io/FSI-AgentGov/controls/pillar-3-reporting/3.8-copilot-hub-and-governance-dashboard/) | Downstream -- evidence export for governance dashboard |
 

--- a/agent-knowledge-source-scanner/docs/prerequisites.md
+++ b/agent-knowledge-source-scanner/docs/prerequisites.md
@@ -171,4 +171,4 @@ Key configuration options:
 
 ## Related Controls
 
-This solution supports compliance with controls [4.3](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-4-sharepoint/4.3-sharepoint-oversharing-prevention-for-agents.md), [1.4](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.4-data-boundary-enforcement.md), and [1.5](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.5-dlp-policy-application.md). Organizations should verify that scanning coverage meets their specific regulatory obligations.
+This solution supports compliance with controls [4.3](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-4-sharepoint/4.3-site-and-document-retention-management.md), [1.4](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.4-advanced-connector-policies-acp.md), and [1.5](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.5-data-loss-prevention-dlp-and-sensitivity-labels.md). Organizations should verify that scanning coverage meets their specific regulatory obligations.

--- a/agent-observability-foundation/governance-mapping.md
+++ b/agent-observability-foundation/governance-mapping.md
@@ -41,7 +41,7 @@ The governance mapping uses an **artifact-first approach**: each observability c
 
 | Control | Gap | Resolution |
 |---------|-----|------------|
-| [2.6 - Model Risk Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md) | Telemetry available; KQL queries needed for governance evidence extraction | Delivered in v1.1.0: KQL Query Library (see queries/) |
+| [2.6 - Model Risk Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md) | Telemetry available; KQL queries needed for governance evidence extraction | Delivered in v1.1.0: KQL Query Library (see queries/) |
 
 ---
 
@@ -160,7 +160,7 @@ The governance mapping uses an **artifact-first approach**: each observability c
 | [1.7 - Comprehensive Audit Logging](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md) | Structured audit trail extraction queries |
 | [3.2 - Usage Analytics and Activity Monitoring](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-3-reporting/3.2-usage-analytics-and-activity-monitoring.md) | Session analytics and trend analysis |
 | [2.9 - Agent Performance Monitoring](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.9-agent-performance-monitoring-and-optimization.md) | P50/P95/P99 latency distribution queries |
-| [2.6 - Model Risk Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md) | Decision audit trail and model output analysis |
+| [2.6 - Model Risk Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md) | Decision audit trail and model output analysis |
 
 ---
 

--- a/agent-observability-foundation/queries/governance-queries.md
+++ b/agent-observability-foundation/queries/governance-queries.md
@@ -169,13 +169,13 @@ This document complements the solution-level [governance-mapping.md](../governan
 | Control | Requirement | Regulatory Alignment |
 |---------|-------------|---------------------|
 | [1.7 - Audit Logging](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md) | Complete audit trail of agent interactions | SEC 17a-4(b)(4), FINRA 4511 |
-| [2.12 - FINRA 3110 Supervision](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.12-ai-supervision-and-review-procedures-finra-3110-alignment.md) | Supervisory procedures documentation | FINRA 3110 |
+| [2.12 - FINRA 3110 Supervision](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.12-supervision-and-oversight-finra-rule-3110.md) | Supervisory procedures documentation | FINRA 3110 |
 
 **Supporting evidence for:**
 
 | Control | Requirement | Regulatory Alignment |
 |---------|-------------|---------------------|
-| [2.6 - Model Risk Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md) | Model decision audit trail | SR 11-7 |
+| [2.6 - Model Risk Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md) | Model decision audit trail | SR 11-7 |
 
 **Sample Output:**
 
@@ -196,7 +196,7 @@ This document complements the solution-level [governance-mapping.md](../governan
 | Control | Requirement | Regulatory Alignment |
 |---------|-------------|---------------------|
 | [1.7 - Audit Logging](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md) | Audit trail quality monitoring | SEC 17a-4 record integrity |
-| [2.12 - FINRA 3110 Supervision](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.12-ai-supervision-and-review-procedures-finra-3110-alignment.md) | Evidence completeness | FINRA 3110 |
+| [2.12 - FINRA 3110 Supervision](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.12-supervision-and-oversight-finra-rule-3110.md) | Evidence completeness | FINRA 3110 |
 
 **Sample Output:**
 
@@ -249,7 +249,7 @@ This document complements the solution-level [governance-mapping.md](../governan
 
 | Control | Requirement | Regulatory Alignment |
 |---------|-------------|---------------------|
-| [2.6 - Model Risk Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md) | Model output quality | SR 11-7 outcome analysis |
+| [2.6 - Model Risk Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md) | Model output quality | SR 11-7 outcome analysis |
 
 **Sample Output:**
 
@@ -297,7 +297,7 @@ This document complements the solution-level [governance-mapping.md](../governan
 
 | Control | Requirement | Regulatory Alignment |
 |---------|-------------|---------------------|
-| [2.6 - Model Risk Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md) | Ongoing monitoring | SR 11-7 Section III |
+| [2.6 - Model Risk Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md) | Ongoing monitoring | SR 11-7 Section III |
 
 **Sample Output:**
 
@@ -318,7 +318,7 @@ This document complements the solution-level [governance-mapping.md](../governan
 
 | Control | Requirement | Regulatory Alignment |
 |---------|-------------|---------------------|
-| [2.6 - Model Risk Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md) | Model recalibration trigger | SR 11-7 Section III |
+| [2.6 - Model Risk Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md) | Model recalibration trigger | SR 11-7 Section III |
 
 **Sample Output:**
 
@@ -339,7 +339,7 @@ This document complements the solution-level [governance-mapping.md](../governan
 
 | Control | Requirement | Regulatory Alignment |
 |---------|-------------|---------------------|
-| [2.6 - Model Risk Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md) | Validation evidence | SR 11-7 Section II |
+| [2.6 - Model Risk Management](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md) | Validation evidence | SR 11-7 Section II |
 
 **Sample Output:**
 

--- a/audit-compliance-manager/docs/authentication.md
+++ b/audit-compliance-manager/docs/authentication.md
@@ -54,7 +54,7 @@ Navigate to **API permissions** → **+ Add a permission** and add the following
 |-----------|------|---------|
 | `Exchange.ManageAsApp` | Application | Service principal access to Exchange Online cmdlets (`Get-AdminAuditLogConfig`, `Search-UnifiedAuditLog`) |
 
-### 2.4 Office 365 Security & Compliance Center (Purview / IPPS)
+### 2.4 Security & Compliance PowerShell (Microsoft Purview / IPPS)
 
 | Permission | Type | Purpose |
 |-----------|------|---------|

--- a/cross-tenant-external-sharing-governance/README.md
+++ b/cross-tenant-external-sharing-governance/README.md
@@ -29,11 +29,11 @@ The solution continuously detects unauthorized cross-tenant configurations, main
 | Control | Relationship |
 |---------|--------------|
 | [1.1 - Restrict Agent Publishing](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.1-restrict-agent-publishing-by-authorization/) | Publishing authorization enforcement for externally shared agents |
-| [1.18 - RBAC and Access Control](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.18-rbac-and-access-control/) | Role-based access control for cross-tenant governance workflows |
-| [2.1 - Managed Environments](https://judeper.github.io/FSI-AgentGov/controls/pillar-2-governance/2.1-managed-environments/) | Environment-level governance for cross-tenant policy enforcement |
-| [2.8 - Access Control and Segregation of Duties](https://judeper.github.io/FSI-AgentGov/controls/pillar-2-governance/2.8-access-control-and-segregation-of-duties/) | Dual-approval separation for tenant onboarding |
-| [1.7 - Audit Logging and Monitoring](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.7-audit-logging-and-monitoring/) | Append-only compliance event logging for cross-tenant activity |
-| [1.11 - Conditional Access](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.11-conditional-access/) | Conditional Access policy alignment for external access |
+| [1.18 - RBAC and Access Control](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.18-application-level-authorization-and-role-based-access-control-rbac/) | Role-based access control for cross-tenant governance workflows |
+| [2.1 - Managed Environments](https://judeper.github.io/FSI-AgentGov/controls/pillar-2-management/2.1-managed-environments/) | Environment-level governance for cross-tenant policy enforcement |
+| [2.8 - Access Control and Segregation of Duties](https://judeper.github.io/FSI-AgentGov/controls/pillar-2-management/2.8-access-control-and-segregation-of-duties/) | Dual-approval separation for tenant onboarding |
+| [1.7 - Audit Logging and Monitoring](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance/) | Append-only compliance event logging for cross-tenant activity |
+| [1.11 - Conditional Access](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.11-conditional-access-and-phishing-resistant-mfa/) | Conditional Access policy alignment for external access |
 
 ## Regulatory Alignment
 

--- a/generative-ai-config-auditor/README.md
+++ b/generative-ai-config-auditor/README.md
@@ -170,8 +170,8 @@ Copilot Studio now supports [real-time voice agents](https://learn.microsoft.com
 
 | Control | Relationship |
 |---------|-------------|
-| [2.24 -- Agent Feature Enablement Governance](https://judeper.github.io/FSI-AgentGov/controls/pillar-2-management/2.24-agent-feature-enablement-governance/) | Primary -- validates generative AI feature configurations |
-| [1.8 -- Runtime Protection](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.8-runtime-security-monitoring/) | Supporting -- runtime feature validation |
+| [2.24 -- Agent Feature Enablement Governance](https://judeper.github.io/FSI-AgentGov/controls/pillar-2-management/2.24-agent-feature-enablement-and-restriction-governance/) | Primary -- validates generative AI feature configurations |
+| [1.8 -- Runtime Protection](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.8-runtime-protection-and-external-threat-detection/) | Supporting -- runtime feature validation |
 | [2.1 -- Managed Environments](https://judeper.github.io/FSI-AgentGov/controls/pillar-2-management/2.1-managed-environments/) | Dependency -- zone classification source |
 | [3.8 -- Copilot Hub](https://judeper.github.io/FSI-AgentGov/controls/pillar-3-reporting/3.8-copilot-hub-and-governance-dashboard/) | Downstream -- evidence export for governance dashboard |
 

--- a/pipeline-governance-cleanup/docs/automation-guide.md
+++ b/pipeline-governance-cleanup/docs/automation-guide.md
@@ -297,7 +297,7 @@ Create a dedicated DLP policy for your pipelines host environment:
 3. Block high-risk connectors (anonymous HTTP, social media, etc.)
 4. Document policy for compliance audit
 
-See [FSI-AgentGov Control 1.5: DLP Enforcement](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.5-data-loss-prevention-enforcement.md) for comprehensive DLP guidance.
+See [FSI-AgentGov Control 1.5: DLP Enforcement](https://github.com/judeper/FSI-AgentGov/blob/main/docs/controls/pillar-1-security/1.5-data-loss-prevention-dlp-and-sensitivity-labels.md) for comprehensive DLP guidance.
 
 ---
 

--- a/session-security-configurator/README.md
+++ b/session-security-configurator/README.md
@@ -272,8 +272,8 @@ This solution supports the following FSI-AgentGov controls:
 
 | Control | Description |
 |---------|-------------|
-| [1.23](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.23-session-security-step-up-authentication/) | Session Security and Step-Up Authentication |
-| [1.11](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.11-conditional-access-and-mfa/) | Conditional Access and MFA |
+| [1.23](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.23-step-up-authentication-for-agent-operations/) | Session Security and Step-Up Authentication |
+| [1.11](https://judeper.github.io/FSI-AgentGov/controls/pillar-1-security/1.11-conditional-access-and-phishing-resistant-mfa/) | Conditional Access and MFA |
 
 ## Related Solutions
 


### PR DESCRIPTION
## Summary

Weekend docs-accuracy audit (Issue #70) of the **technical documentation** against current Microsoft guidance and the post-audit FSI-AgentGov framework control set. Scope is **technical correctness only** — no regulatory/compliance wording was edited, interpreted, or re-judged.

The framework control set was verified to be **stable at 78 controls** (IDs 1.1–4.9) against `judeper/FSI-AgentGov@origin/main` `assessment/manifest/controls.json`. The audit found that several solution docs link to framework control pages using **outdated slugs / a wrong pillar directory** that now return 404 after framework reorganizations.

## Changes

### 1. Broken framework control links (404 → current canonical pages)

Slug drift — same control ID, link text already names the current control; only the URL slug lagged a framework rename:

| File | Control link fixed |
|------|--------------------|
| `agent-communication-restriction-detector/README.md` | 1.8 `runtime-security-monitoring` → `runtime-protection-and-external-threat-detection` |
| `cross-tenant-external-sharing-governance/README.md` | 1.18, 1.7, 1.11 slugs + `pillar-2-governance/` → `pillar-2-management/` (2.1, 2.8) |
| `generative-ai-config-auditor/README.md` | 2.24 `…-governance` → `…-and-restriction-governance`; 1.8 |
| `session-security-configurator/README.md` | 1.23 `session-security-step-up-authentication` → `step-up-authentication-for-agent-operations`; 1.11 |
| `agent-knowledge-source-scanner/docs/prerequisites.md` | 4.3, 1.4, 1.5 → current canonical slugs (matches manifest-declared IDs) |
| `pipeline-governance-cleanup/docs/automation-guide.md` | 1.5 `data-loss-prevention-enforcement` → `data-loss-prevention-dlp-and-sensitivity-labels` |
| `agent-observability-foundation/governance-mapping.md` | 2.6 → `model-risk-management-sr-26-2` |
| `agent-observability-foundation/queries/governance-queries.md` | 2.12 → `supervision-and-oversight-finra-rule-3110`; 2.6 → `model-risk-management-sr-26-2` |

### 2. Retired control references removed

- `agent-access-monitor/README.md` — removed two stale *Related Controls* rows, **2.5 "Agent Sharing Scope"** and **2.6 "Restrict Team-Created Agent Sharing"**. Those numbers now cover *Testing/QA* (2.5) and *Model Risk Management* (2.6) in the current framework, so the links 404 and the displayed titles are wrong. The solution's canonical mapping (manifest) is **3.8**; valid related rows (1.1, 2.1) are retained.

### 3. Microsoft product terminology

- `audit-compliance-manager/docs/authentication.md` — heading **"Office 365 Security & Compliance Center"** → **"Security & Compliance PowerShell (Microsoft Purview / IPPS)"**, matching the current Microsoft Learn article title and the already-modernized sibling `deployment-guide.md` in the same solution.

## Verification

- `python scripts/build-manifest.py --check` → **OK: all generated artifacts match manifests.**
- Custom full-path link audit against `FSI-AgentGov@origin/main` control filenames → **0 broken control links** remaining.
- Language-rules scan (banned compliance phrases / `Azure AD`) on changed files → clean.
- No `manifest.yaml` or script changes; doc-only diff across 10 files.

## Notes / out-of-scope observations (no change made)

- `agent-knowledge-source-scanner` links now point to the canonical pages for its manifest-declared IDs (4.3/1.4/1.5). The old slugs suggest the solution's *topic* may now align better with **4.8 (Item-Level Permission Scanning for Agent Knowledge Sources)** — a manifest **mapping** decision left for the manifest owner, not changed here.
- `message-center-monitor` Office 365 Connectors retirement dates (May 18–22, 2026) were checked against the live Microsoft devblog and are **already accurate** — no change.

## Sources (Microsoft Learn / official)

- Connect to Security & Compliance PowerShell — https://learn.microsoft.com/powershell/exchange/connect-to-scc-powershell
- Retirement of Office 365 connectors within Microsoft Teams — https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/
- Framework control set (authoritative slugs) — `judeper/FSI-AgentGov@main` `docs/controls/**` and `assessment/manifest/controls.json`

Tracking issue: judeper/OceanSquad#70
