### PR TITLE
fix(audit-compliance-manager): PowerShell 7.4 runtime in deployment guide (tech-accuracy run #2)

### DIFF
--- a/audit-compliance-manager/docs/deployment-guide.md
+++ b/audit-compliance-manager/docs/deployment-guide.md
@@ -31,12 +31,19 @@ This guide covers end-to-end deployment of the ALCA solution in Azure Automation
 ### 1.2 Configure Runtime Environment
 
 1. Navigate to your Automation Account → **Runtime Environments**
-2. Verify the default **PowerShell 7.2** runtime is available
+2. Verify a **PowerShell 7.4** runtime is available
 3. If not present, create a new runtime:
-   - **Name:** `PowerShell-7.2`
+   - **Name:** `PowerShell-7.4`
    - **Language:** PowerShell
-   - **Version:** 7.2
+   - **Version:** 7.4
    - **Description:** ALCA runbook runtime
+
+> **Runtime version:** Use **PowerShell 7.4**, the generally available Azure Automation
+> runtime (GA June 2025). The PowerShell 7.1 and 7.2 Azure Automation runtimes are retired
+> by the parent product and no longer recommended. The ALCA helper module and runbooks
+> declare PowerShell 7.2 only as a *minimum* (`#Requires -Version 7.2` and
+> `PowerShellVersion = '7.2'` in `AuditComplianceHelpers.psd1`), so they run unchanged on
+> 7.4. See [What's new in Azure Automation](https://learn.microsoft.com/azure/automation/whats-new).
 
 ### 1.3 Enable System-Assigned Managed Identity
 
@@ -211,7 +218,7 @@ Send-ComplianceNotification `
 2. Navigate to **Automation Account** → **Modules** → **+ Add a module**
 3. Configure:
    - **Upload module file:** Select `AuditComplianceHelpers.zip`
-   - **Runtime version:** 7.2
+   - **Runtime version:** 7.4
 4. Click **Import**
 5. Wait for status to show **Available**
 
@@ -230,13 +237,13 @@ Import these modules from the PowerShell Gallery:
 2. Select **Browse from gallery**
 3. Search for the module name
 4. Select the module → **Select**
-5. **Runtime version:** 7.2
+5. **Runtime version:** 7.4
 6. Click **Import**
 
 ### 4.3 Verify Module Status
 
 1. Navigate to **Automation Account** → **Modules**
-2. Filter by **Runtime version: 7.2**
+2. Filter by **Runtime version: 7.4**
 3. Confirm all three modules show **Status: Available**:
    - ✅ `AuditComplianceHelpers` — Available
    - ✅ `Microsoft.PowerApps.Administration.PowerShell` — Available
@@ -277,7 +284,7 @@ If you skip this step, runbooks fail with `The term 'New-CanaryEvent' is not rec
 2. Configure:
    - **Name:** `Test-AuditLoggingCompliance`
    - **Runbook type:** PowerShell
-   - **Runtime version:** 7.2
+   - **Runtime version:** 7.4
    - **Description:** Scans all Power Platform environments for Purview unified audit and Dataverse audit compliance
 3. Click **Create**
 4. In the editor, paste the contents of `scripts/Test-AuditLoggingCompliance.ps1`
@@ -289,7 +296,7 @@ If you skip this step, runbooks fail with `The term 'New-CanaryEvent' is not rec
 2. Configure:
    - **Name:** `Enable-AuditLogging`
    - **Runbook type:** PowerShell
-   - **Runtime version:** 7.2
+   - **Runtime version:** 7.4
    - **Description:** Enables org-level and entity-level Dataverse auditing on non-compliant environments
 3. Click **Create**
 4. In the editor, paste the contents of `scripts/Enable-AuditLogging.ps1`
@@ -299,7 +306,7 @@ If you skip this step, runbooks fail with `The term 'New-CanaryEvent' is not rec
 
 Both runbooks should show:
 - **Status:** Published
-- **Runtime version:** 7.2
+- **Runtime version:** 7.4
 - **Type:** PowerShell
 
 ---


### PR DESCRIPTION
## Summary

Run #2 technical-accuracy audit of **presenter/demo materials and deployment guides** (scope: `**/docs/demo-script.md` and `**/deployment-guide.md`), verifying executable content (cmdlets, parameters, module/runtime versions, portal paths, well-known app IDs, API endpoints) against current Microsoft Learn guidance.

Resolves the deployment-guide portion of judeper/OceanSquad#84.

## Change (1 file, surgical)

**`audit-compliance-manager/docs/deployment-guide.md`** — the guide instructed operators to create and select the **PowerShell 7.2** Azure Automation runtime across Phases 1, 4, and 5. Microsoft retired the PowerShell 7.1/7.2 Azure Automation runtimes; **PowerShell 7.4** is the generally available runtime (GA June 2025). Updated all runtime-selection steps to 7.4 and added a short rationale note.

**Version-pin respected (flag-over-rewrite):** the solution's scripts/module declare PowerShell 7.2 only as a *minimum* (`#Requires -Version 7.2`; `PowerShellVersion = '7.2'` in `AuditComplianceHelpers.psd1`). 7.4 satisfies that floor, so the runbooks run unchanged — this is a runtime-selection correction, not a code change.

## Files audited with NO change (verified accurate)

- **`agent-intake/docs/demo-script.md`** — `deploy.ps1` (`-EnvironmentUrl`/`-Teardown`/`-SeedTestData`) and `smoke_test.ps1` (`-IncludeSeededDataChecks`/`-PathScope`) params, and all five seed fixtures, match the scripts. "Microsoft Entra Agent ID" is a current product name.
- **`conditional-access-automation/docs/deployment-guide.md`** — Microsoft Graph cmdlets current; well-known app IDs verified (`7df0a125-d3be-4c96-aa54-591f83ff541c` = *Microsoft Flow Service* on Learn); `enabledForReportingButNotEnforced` correct; the `/beta/identity/conditionalAccess/evaluate` endpoint is already correctly caveated as a preview/beta surface (beta CA What-If APIs confirmed on Learn).

## Out-of-scope follow-up (not in this PR's 2-file scope)

Sibling docs in the same solution still reference the 7.2 runtime and should be aligned in a separate PR: `audit-compliance-manager/docs/prerequisites.md`, `troubleshooting.md`, `testing-scenarios.md`. (`#Requires -Version 7.2` floors in the `.ps1`/`.psd1` remain valid and are intentionally untouched.)

## Sources

- [What's new in Azure Automation](https://learn.microsoft.com/azure/automation/whats-new) — *"PowerShell 7.1 and 7.2 versions … are announced retired … and hence not recommended"*; GA of PowerShell 7.4 runbooks (June 2025).
- [Commonly used Microsoft first-party services and portal apps](https://learn.microsoft.com/power-platform/admin/apps-to-allow) — Microsoft Flow Service app ID confirmation.

## Scope discipline

Technical correctness only; no regulatory/compliance wording changed. No files from the run #1 pending-PR exclusion list were touched. FSI language rules followed in the added note.
