### PR TITLE
docs(lab-validation): fix 6 dead Microsoft Learn links (tech-accuracy audit #83)

### DIFF
--- a/agent-registry-automation/LAB-VALIDATION.md
+++ b/agent-registry-automation/LAB-VALIDATION.md
@@ -36,7 +36,7 @@ in isolation.
 | Dataverse `bot` (Copilot) table — EntitySetName `bots`, PK `botid`, PrimaryName `name`, no `botFrameworkEndpoint` column | https://learn.microsoft.com/power-apps/developer/data-platform/reference/entities/bot |
 | Copilot Studio Agent Inventory (`bot`/`botcomponent` Dataverse tables) | https://learn.microsoft.com/microsoft-copilot-studio/guidance/kit-agent-inventory-data-source |
 | `ILinkedEnvironmentMetadata.instanceUrl` (environment Dataverse org URL) | https://learn.microsoft.com/javascript/api/@microsoft/powerapps/ilinkedenvironmentmetadata |
-| Cross-environment Dataverse connector usage | https://learn.microsoft.com/power-automate/dataverse/connect-other-environments |
+| Cross-environment Dataverse connector usage | https://learn.microsoft.com/power-automate/dataverse/connect-to-other-environments |
 
 ## Gaps found and fixes applied
 

--- a/coi-testing/LAB-VALIDATION.md
+++ b/coi-testing/LAB-VALIDATION.md
@@ -53,8 +53,8 @@ prerequisites, and troubleshooting.
 
 | Claim | Authoritative source |
 |-------|----------------------|
-| Dataverse Web API record create returns **204 No Content** (runner accepts `[201, 204]`) | https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/use-insomnia-web-api · https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/create-entity-web-api |
-| Custom Dataverse Choice (option set) values live in the **100000000+** range | https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/create-update-options-web-api |
+| Dataverse Web API record create returns **204 No Content** (runner accepts `[201, 204]`) | https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/create-entity-web-api |
+| Custom Dataverse Choice (option set) values live in the **100000000+** range | https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/create-update-optionsets |
 | App-only / confidential-client Dataverse token scope is `<environment-url>/.default` (runner uses `f"{environment}/.default"`) | https://learn.microsoft.com/en-us/power-apps/developer/data-platform/authenticate-oauth |
 | `pac admin list` and `pac solution list` support `--json`; `pac connection list` exists but supports only `--environment` (no `--json` flag) | https://learn.microsoft.com/en-us/power-platform/developer/cli/reference/admin · https://learn.microsoft.com/en-us/power-platform/developer/cli/reference/solution · https://learn.microsoft.com/en-us/power-platform/developer/cli/reference/connection |
 | `azure-identity` credential classes used by the runner (`ManagedIdentityCredential`, `WorkloadIdentityCredential`, `CertificateCredential`, `AzureCliCredential`, `DeviceCodeCredential`, `ClientSecretCredential`, `ChainedTokenCredential`) | https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme |

--- a/cross-tenant-external-sharing-governance/LAB-VALIDATION.md
+++ b/cross-tenant-external-sharing-governance/LAB-VALIDATION.md
@@ -49,7 +49,7 @@ Primary framework controls: **1.1, 1.18, 2.1, 2.8, 1.7, 1.11**.
    `bot-authoringSharingDisabled`; values `noLimit` / `ExcludeSharingToSecurityGroups`,
    `-1` = unlimited).
 6. `Get-AzAccessToken` SecureString behavior (Az.Accounts) —
-   https://learn.microsoft.com/powershell/azure/manage-secrets-with-azure-powershell
+   https://learn.microsoft.com/powershell/azure/protect-secrets
    (confirms the `-AsSecureString` pattern already pinned via `#Requires Az.Accounts 2.17.0`).
 
 ## Gaps found and fixes applied

--- a/scope-drift-monitor/LAB-VALIDATION.md
+++ b/scope-drift-monitor/LAB-VALIDATION.md
@@ -43,7 +43,7 @@ GDPR Art. 5(1)(c), GLBA Section 501(b), and CCPA purpose limitation.
    https://learn.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-reference
 3. Microsoft Power Platform CLI command groups (authoritative `pac` group list — there is
    **no** `pac flow` group) —
-   https://learn.microsoft.com/power-platform/developer/cli/reference/group
+   https://learn.microsoft.com/power-platform/developer/cli/reference
 4. Retirement of Office 365 connectors within Microsoft Teams (incoming webhooks;
    progressive rollout completing **May 22, 2026**; new webhook creation blocked since
    August 2024) —

--- a/session-security-configurator/LAB-VALIDATION.md
+++ b/session-security-configurator/LAB-VALIDATION.md
@@ -39,7 +39,7 @@ and SOX 302/404 — it does not by itself satisfy any regulation.
 | `conditionalAccessSessionControls` (v1.0 — no `continuousAccessEvaluation`) | https://learn.microsoft.com/graph/api/resources/conditionalaccesssessioncontrols?view=graph-rest-1.0 |
 | `continuousAccessEvaluationSessionControl` (beta-only; `mode` = strictEnforcement/disabled/…) | https://learn.microsoft.com/graph/api/resources/continuousaccessevaluationsessioncontrol?view=graph-rest-beta |
 | Require reauthentication every time (sign-in frequency `everyTime`) | https://learn.microsoft.com/entra/identity/conditional-access/concept-session-lifetime#require-reauthentication-every-time |
-| `Get-AzAccessToken` SecureString change (Az.Accounts 5.0.0 / Az 14.0.0) | https://learn.microsoft.com/powershell/azure/security-features#transition-from-strings-to-securestrings |
+| `Get-AzAccessToken` SecureString change (Az.Accounts 5.0.0 / Az 14.0.0) | https://learn.microsoft.com/powershell/azure/protect-secrets |
 
 ## Gaps found and fixes applied
 


### PR DESCRIPTION
## Summary

Run #2 technical-accuracy audit (Issue judeper/OceanSquad#83) of the lab-validation guides and lab READMEs — scope `**/LAB-VALIDATION.md` and `**/lab/README.md`, executable-correctness only.

All 36 `LAB-VALIDATION.md` reports plus `agent-intake/lab/README.md` were statically audited against **live** Microsoft Learn. These run-#1 reports proved exceptionally well-sourced: every spot-checked cmdlet, parameter, API surface, and limit verified as **already correct** (see "Verified, no change" below). The one objective defect class found was **dead Microsoft Learn links** — six URLs that now return HTTP 404 — replaced with their current live equivalents (each re-verified `200`, topically unchanged).

**Flag-over-rewrite respected:** no command, parameter, module pin, or prose claim was altered. Only stale documentation links were repointed.

## Changes (6 dead links → live equivalents)

| File | Before (404) | After (200) |
|------|--------------|-------------|
| `coi-testing/LAB-VALIDATION.md` | `webapi/use-insomnia-web-api` | dropped; kept companion `webapi/create-entity-web-api` (documents the 204 create response) |
| `coi-testing/LAB-VALIDATION.md` | `webapi/create-update-options-web-api` | `webapi/create-update-optionsets` |
| `agent-registry-automation/LAB-VALIDATION.md` | `power-automate/dataverse/connect-other-environments` | `power-automate/dataverse/connect-to-other-environments` |
| `cross-tenant-external-sharing-governance/LAB-VALIDATION.md` | `powershell/azure/manage-secrets-with-azure-powershell` | `powershell/azure/protect-secrets` |
| `session-security-configurator/LAB-VALIDATION.md` | `powershell/azure/security-features#transition-from-strings-to-securestrings` | `powershell/azure/protect-secrets` |
| `scope-drift-monitor/LAB-VALIDATION.md` | `power-platform/developer/cli/reference/group` | `power-platform/developer/cli/reference` |

> Note on `scope-drift-monitor`: the surrounding claim is "there is no `pac flow` group." Repointing to the command-groups index keeps the evidence valid, and the absence of a flow group is independently confirmed — `…/cli/reference/flow` also returns 404.

## Verified against live Microsoft Learn, **no change warranted**
- `Get-AzAccessToken` — `-ResourceUrl` is the primary parameter and **`-ResourceUri` is a documented alias** (`Resource`, `ResourceUri`), so files using either form are correct.
- `az keyvault create` — `--enable-soft-delete` is **absent** from the current parameter list (soft delete always on) and `--retention-days` is present; the finra-supervision-workflow report's claim is accurate.
- `serviceAnnouncement` messages — `Prefer: odata.maxpagesize` max is **1000**; message-center-monitor's `500` (with "max 1000" note) is correct.
- Copilot Studio file upload — **15 MB** individual file size, **30,000** chars/file (no limit with code interpreter), XLSX/PPTX experimental; matches file-upload-security & mime-type-restrictions.
- Office 365/Teams connector deprecation — Learn confirms deprecation; exact completion date lives in the cited devblog, left as-is (no confident Learn-sourced re-date).

## Sources (evidence for the link fixes)
- https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/create-entity-web-api
- https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/create-update-optionsets
- https://learn.microsoft.com/power-automate/dataverse/connect-to-other-environments
- https://learn.microsoft.com/powershell/azure/protect-secrets
- https://learn.microsoft.com/power-platform/developer/cli/reference

## Validation
- Edits limited to in-scope `LAB-VALIDATION.md` files (no `*/README.md` from the run-#1 do-not-edit list touched).
- `build-manifest.py` does not read `LAB-VALIDATION.md`; its pre-existing `site-docs/` drift (present on a clean tree) is unrelated to this change.
- URL-only edits — no FSI language-rule surface changed.

Refs judeper/OceanSquad#83
