### PR TITLE
fix(generative-ai-config-auditor): flag deprecated Graph Information Protection labels API (run #2 tech-accuracy audit)

### DIFF
--- a/generative-ai-config-auditor/scripts/Get-PurviewDLPEvidence.ps1
+++ b/generative-ai-config-auditor/scripts/Get-PurviewDLPEvidence.ps1
@@ -100,6 +100,22 @@ function Get-PurviewDLPEvidence {
             # SDK v2.x and reusing a Graph token for Dataverse fails with 401
             # because the audiences differ. Invoke-MgGraphRequest manages the
             # token lifecycle for Graph calls correctly.
+            #
+            # DEPRECATION NOTE (verify before relying on label evidence): the
+            # legacy Information Protection labels API
+            # (informationProtection/policy/labels) is documented as deprecated
+            # on Microsoft Learn and may return no data in some tenants. The
+            # successor list-sensitivityLabels operation lives under the
+            # microsoft.graph.security namespace and returns a DIFFERENT shape
+            # (e.g. displayName instead of name; no color/isActive), so it is
+            # NOT a drop-in URL swap — migrating requires remapping the
+            # properties projected below. Left as v1.0/policy/labels here
+            # pending that property-shape migration. Refs:
+            #   https://learn.microsoft.com/graph/api/informationprotectionpolicy-list-labels
+            #   https://learn.microsoft.com/graph/api/security-informationprotection-list-sensitivitylabels
+            # The call is wrapped in -ErrorAction SilentlyContinue and degrades
+            # to the compliance-cmdlet fallback below, so a deprecated/empty
+            # response does not fail the evidence collection.
             $dlpUri = 'https://graph.microsoft.com/v1.0/informationProtection/policy/labels'
             $dlpResp = Invoke-MgGraphRequest -Uri $dlpUri -Method Get -ErrorAction SilentlyContinue
             $infoLabels = $dlpResp.value


### PR DESCRIPTION
## Run #2 Technical-Accuracy Audit — solution & lab scripts

Static audit of in-scope **executable** content (`**/lab/*.ps1` and solution `*.ps1`/`*.psm1`/`*.py`/`*.kql`) against current Microsoft Learn. Scope was executable correctness only: cmdlet/CLI names, parameters, module/SDK names, Graph/Dataverse/Power Platform API calls, KQL table/column names, and endpoint versions. No regulatory/compliance wording was touched.

### What changed (1 file, surgical, behavior-preserving)
`generative-ai-config-auditor/scripts/Get-PurviewDLPEvidence.ps1` — added a code comment flagging that the queried Graph endpoint `v1.0/informationProtection/policy/labels` is the **deprecated** Information Protection labels API. Per the **flag-over-rewrite** guardrail this was *flagged in-code, not rewritten*, because:
- The documented successor (`microsoft.graph.security` `list sensitivityLabels`) returns a **different resource shape** (`displayName` vs `name`; no `color`/`isActive`) — not a drop-in URL swap; it would require remapping the projected properties.
- The GA v1.0 list path routes through `tenantDataSecurityAndGovernance`; the `security/informationProtection/sensitivityLabels` form is currently beta. Migrating a v1.0 call to a beta path on a guess is out of scope for this run.
- The existing call is wrapped in `-ErrorAction SilentlyContinue` and degrades to a compliance-cmdlet fallback, so a deprecated/empty response does not fail evidence collection. **No runtime behavior change.**

### Verified accurate (left as-is, per flag-over-rewrite)
Everything else audited confirmed correct for its pinned versions:
- **Power Platform:** `pac admin set-governance-config` + `--protection-level`/`--solution-checker-mode`; `Get-AdminPowerAppEnvironment`, `Add-PowerAppsAccount`, `Get-PowerAppTenantIsolationPolicy`.
- **Graph:** `security/auditLog/queries` (v1.0), `security/runHuntingQuery` (v1.0), `applications/microsoft.graph.agentIdentityBlueprint` (v1.0), `admin/serviceAnnouncement/messages` select fields (all serviceUpdateMessage properties exist), `beta/agentRegistry/agentInstances` (still the documented beta form; May 2026 convergence already noted in-code).
- **Exchange/Purview:** `Connect-ExchangeOnline`, `Connect-IPPSSession`, `Search-UnifiedAuditLog`.
- **KQL:** `CloudAppEvents`/`ActionType`/`RawEventData`, `OfficeActivity`, `customEvents`/`AppEvents` dual-table unions.

### Not changed (deliberate, not errors)
Cross-solution Python/PowerShell version-pin differences (`msal`/`requests`/`azure-identity`/`Az.Accounts`) are independent per-solution choices, not technical inaccuracies — and `Az.Accounts 5.3.4` is a real published version. Respected pinned versions per guardrails. Files with open run #1 PRs were skipped.

### CI
PowerShell parse: 0 errors. No new PSScriptAnalyzer findings (pre-existing `Write-Host` warnings untouched). ruff/odata/manifest baselines unaffected (no Python/manifest/schema changes). No FSI-language-rule phrases introduced.

### Sources (Microsoft Learn)
- https://learn.microsoft.com/graph/api/informationprotectionpolicy-list-labels (deprecated labels API)
- https://learn.microsoft.com/graph/api/security-informationprotection-list-sensitivitylabels (beta successor)
- https://learn.microsoft.com/graph/api/tenantdatasecurityandgovernance-list-sensitivitylabels?view=graph-rest-1.0
- https://learn.microsoft.com/power-platform/developer/cli/reference/admin (pac admin set-governance-config)
- https://learn.microsoft.com/graph/api/resources/serviceupdatemessage (select fields)
- https://learn.microsoft.com/graph/api/resources/agentregistry?view=graph-rest-beta (agentInstances)
- https://learn.microsoft.com/graph/api/resources/agentidentityblueprint?view=graph-rest-1.0
- https://learn.microsoft.com/powershell/module/microsoft.powerapps.administration.powershell/get-powerapptenantisolationpolicy

Resolves judeper/OceanSquad#82.
