### PR TITLE
FNF People-Sweep: CAI People-capability detection + audience→UPN expansion

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,7 @@ Deployable Power Platform solutions for the [FSI Agent Governance Framework](htt
 | compliance-dashboard | v1.0.5 | 3.3, 3.1, 3.2, 3.4 | Aggregated compliance reporting across 78 controls with Exchange coverage |
 | conditional-access-automation | v2.0.2 | 1.11, 1.23, 1.18 | CA policy deployment, compliance monitoring, and drift detection |
 | content-moderation-monitor | v1.1.2 | 1.27, 1.8 | Per-agent content moderation validation against zone requirements |
-| copilot-agent-inventory | v0.1.0-preview | 1.2, 1.7, 2.1, 2.13 | Foundation system-of-record for Copilot agents — three-layer tenant-wide discovery feeding a canonical governance store |
+| copilot-agent-inventory | v0.2.0-preview | 1.2, 1.7, 2.1, 2.13 | Foundation system-of-record for Copilot agents — three-layer tenant-wide discovery feeding a canonical governance store |
 | copilot-billing-governance | v0.1.0-preview | 3.5, 1.18, 1.14 | Governance for Copilot consumption billing — PAYG/prepaid credit policies, entitlement engine, per-agent caps, coverage-gap analysis |
 | copilot-studio-analytics | v2.0.2 | 3.2 | Business impact analytics for Copilot Studio agents |
 | credential-oversharing-detector | v2.1.1 | 1.14, 1.4, 1.18 | Configuration-time credential scope governance for agent connectors |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ This file provides guidance for autonomous AI agents working on this repository.
 | compliance-dashboard | v1.0.5 | 3.3, 3.1, 3.2, 3.4 | Aggregated compliance reporting across 78 controls with Exchange coverage |
 | conditional-access-automation | v2.0.2 | 1.11, 1.23, 1.18 | CA policy deployment, compliance monitoring, and drift detection |
 | content-moderation-monitor | v1.1.2 | 1.27, 1.8 | Per-agent content moderation validation against zone requirements |
-| copilot-agent-inventory | v0.1.0-preview | 1.2, 1.7, 2.1, 2.13 | Foundation system-of-record for Copilot agents — three-layer tenant-wide discovery feeding a canonical governance store |
+| copilot-agent-inventory | v0.2.0-preview | 1.2, 1.7, 2.1, 2.13 | Foundation system-of-record for Copilot agents — three-layer tenant-wide discovery feeding a canonical governance store |
 | copilot-billing-governance | v0.1.0-preview | 3.5, 1.18, 1.14 | Governance for Copilot consumption billing — PAYG/prepaid credit policies, entitlement engine, per-agent caps, coverage-gap analysis |
 | copilot-studio-analytics | v2.0.2 | 3.2 | Business impact analytics for Copilot Studio agents |
 | credential-oversharing-detector | v2.1.1 | 1.14, 1.4, 1.18 | Configuration-time credential scope governance for agent connectors |

--- a/copilot-agent-inventory/CHANGELOG.md
+++ b/copilot-agent-inventory/CHANGELOG.md
@@ -51,6 +51,24 @@ sharing-audience-to-UPN expansion.
 - **Unit tests**: `tests/test_detect_people_capability.py` and
   `tests/test_expand_audience_upns.py`.
 
+### Fixed
+
+- **GATE-1 hardening (accuracy is customer-facing).** Org-wide-shared agents no
+  longer resolve to a confidently-empty audience: whole-tenant reach is now a
+  per-agent signal (`fsi_caiauthshare.fsi_sharedwitheveryone`, derived from the
+  bot `accesscontrolpolicy` during discovery) instead of being mis-inferred from
+  the environment-wide `bot-limitSharingMode`; a posture row with no whole-tenant
+  signal and no refs is marked `Partial` (never a silent empty). Provisional
+  manifest detections are now queryable (`fsi_caiagentfeature.fsi_agentrefprovisional`)
+  and no longer collapse on the `(fsi_agentid, fsi_sourceobjectid)` alternate key
+  — provisional rows salt `fsi_sourceobjectid` with a stable per-manifest hash.
+  The Microsoft Graph token now refreshes near expiry (no 401 on long runs),
+  `Retry-After` parsing handles the RFC 7231 HTTP-date format, malformed/unzippable
+  manifests increment a `manifestsFailed` counter that surfaces a `Partial` scan,
+  and the Dataverse write-back `$filter` escapes single quotes. Adds two schema
+  columns (`fsi_sharedwitheveryone`, `fsi_agentrefprovisional`) and a regression
+  test per finding; `docs/dataverse-schema.md` regenerated.
+
 ### Notes
 
 - **Declared ≠ effective** — the People signal is detected as authored/available

--- a/copilot-agent-inventory/CHANGELOG.md
+++ b/copilot-agent-inventory/CHANGELOG.md
@@ -5,6 +5,63 @@ All notable changes to the Copilot Agent Inventory are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0-preview] - 2026-06-12
+
+Adds two FNF-governance extensions that feed the downstream Copilot Billing
+Governance (CBG) solution: declarative-agent "People" capability detection and
+sharing-audience-to-UPN expansion.
+
+### Added
+
+- **People capability detection** (`scripts/detect_people_capability.py`): a
+  manifest-source-agnostic parser that detects the declarative-agent
+  `capabilities[].name == "People"` signal (the "Reference org chart and profile
+  info" toggle) from `declarativeAgent.json`. Case-sensitive literal match, stable
+  across manifest schema v1.5–v1.7, with the optional v1.7 `include_related_content`
+  captured (it does not gate detection). Includes an **acquisition-adapter seam**
+  with two implemented adapters — `local-package` (app-package directory/`.zip`)
+  and `source-repo` (source/CI tree) — plus a clearly-marked `FutureExportAdapter`
+  seam for a scalable tenant-export path. Emits `fsi_caiagentfeature` rows of the
+  new **People (Org Chart & Profile)** feature type with provenance
+  (`fsi_detectionsource`) and a **Declared (Manifest)** confidence marker
+  (`fsi_detectionconfidence`); flags the agent id **provisional** when no
+  `--id-map` binds the manifest to its Dataverse bot GUID.
+- **Audience → UPN expansion** (`scripts/expand_audience_upns.py`): resolves an
+  agent's sharing audience (security groups in `fsi_caiauthshare`) to concrete
+  member UPNs via Microsoft Graph **transitive** membership
+  (`GET /groups/{id}/transitiveMembers`, `GroupMember.Read.All`), flattening nested
+  groups and de-duplicating across viewer/editor groups. Flags
+  **"Everyone in the organization"** sharing as `wholeTenant` **without enumerating
+  the tenant** (configurable `--whole-tenant-cap`), bounds large groups with
+  `--max-members-per-group` (truncation flag), honors HTTP 429 Retry-After backoff,
+  and surfaces per-group resolution errors as `Partial`/`Failed` status. Emits a
+  CBG-shaped `intendedUsers[].upn` artifact and an optional Dataverse write-back of
+  **counts/flags only (no UPNs/PII)**.
+- **Schema additions** (`scripts/create_cai_dataverse_schema.py`): new
+  `fsi_caiagentfeature` columns `fsi_detectionsource`, `fsi_detectionconfidence`
+  (picklists), and `fsi_detectiondetail` (memo); new `fsi_caiauthshare` columns
+  `fsi_audiencewholetenant`, `fsi_audienceupncount`, `fsi_audiencetruncated`,
+  `fsi_audienceresolutionstatus`, and `fsi_audienceresolvedat`. Adds the
+  **People (Org Chart & Profile)** value to the `fsi_cai_featuretype` option set
+  and two new option sets, `fsi_cai_detectionsource` and `fsi_cai_detectionconfidence`.
+  `docs/dataverse-schema.md` regenerated from the schema source of truth.
+- **Sample artifacts**: `templates/people-detection.sample.json`,
+  `templates/audience-input.sample.json`, and
+  `templates/audience-upn-list.sample.json`.
+- **Unit tests**: `tests/test_detect_people_capability.py` and
+  `tests/test_expand_audience_upns.py`.
+
+### Notes
+
+- **Declared ≠ effective** — the People signal is detected as authored/available
+  in the manifest; a v1.7 `user_overrides` block can remove a capability at
+  runtime, so the marker is "Declared (Manifest)", not "effective".
+- **Provisional agent ids** — declarative manifests carry no Dataverse bot GUID;
+  detections without an `--id-map` match are flagged provisional for the
+  orchestrator to reconcile before joining CAI/CBG.
+- **Privacy** — full UPN lists are emitted only as a transient artifact; Dataverse
+  persists audience counts and flags, not member UPNs.
+
 ## [0.1.0-preview] - 2026-06-09
 
 Initial preview scaffold of the tier-1 system-of-record for the FSI Copilot

--- a/copilot-agent-inventory/README.md
+++ b/copilot-agent-inventory/README.md
@@ -7,11 +7,11 @@ coe_function: govern
 ---
 # Copilot Agent Inventory
 
-> **Version:** v0.1.0-preview
+> **Version:** v0.2.0-preview
 > **Status:** Preview
 > **Validated against framework version:** v1.6.0
 > **Upstream Microsoft dependency:** Mixed — ARG Power Platform Inventory GA Mar 31 2026; several agent-specific fields (isManaged, channels, authentication, capabilitiesCounts, powerPlatformConnectors) are still preview.
-> **Last Verified:** 2026-06-09
+> **Last Verified:** 2026-06-12
 
 Tenant-wide discovery and a canonical Dataverse **system-of-record** for every
 Copilot Studio and Microsoft 365 Copilot Agent Builder agent. Copilot Agent
@@ -81,9 +81,14 @@ copilot-agent-inventory/
 ├── scripts/
 │   ├── create_cai_dataverse_schema.py   # 8-entity schema, idempotent, --output-docs
 │   ├── discover_agents.py               # three-layer discovery scanner
+│   ├── detect_people_capability.py      # declarative-agent People capability (manifest)
+│   ├── expand_audience_upns.py          # sharing audience -> member UPNs (Graph transitive)
 │   └── requirements.txt
 └── templates/
-    └── agent-record.sample.json         # sample fsi_copilotagent + feature rows
+    ├── agent-record.sample.json         # sample fsi_copilotagent + feature rows
+    ├── people-detection.sample.json     # sample People-capability detection artifact
+    ├── audience-input.sample.json       # sample sharing posture (expand input)
+    └── audience-upn-list.sample.json    # sample CBG-shaped intendedUsers artifact
 ```
 
 ## Quick Start
@@ -110,7 +115,74 @@ python scripts/discover_agents.py \
 python scripts/discover_agents.py \
     --environment-url https://governance.crm.dynamics.com \
     --tenant-id <your-tenant-id> --auth-mode managed-identity
+
+# 5. Detect the declarative-agent "People" capability from manifests
+#    (source-repo tree or local app-package directory/zip; --dry-run plans only)
+python scripts/detect_people_capability.py \
+    --source source-repo --path ../my-agent-repo \
+    --id-map ./agent-id-map.json --output people.json
+
+# 6. Expand each agent's sharing audience to member UPNs (CBG input)
+#    --dry-run resolves nothing over the network
+python scripts/expand_audience_upns.py \
+    --input authshare.json --auth-mode managed-identity \
+    --output intended-users.json
 ```
+
+## People capability & audience expansion (FNF)
+
+Two FNF-governance extensions augment the core inventory. Both emit transient
+JSON artifacts (the system-of-record stays in Dataverse) and supply input to the
+downstream Copilot Billing Governance (CBG) solution.
+
+**People capability detection (`detect_people_capability.py`).** The "Reference
+org chart and profile info" toggle is the declarative-agent manifest entry
+`capabilities[].name == "People"` (a case-sensitive literal, stable across
+manifest schema v1.5–v1.7; the optional v1.7 `include_related_content` is
+captured but does not gate detection). This signal lives in `declarativeAgent.json`
+inside the agent app package — **not** in the Dataverse `bot`/`botcomponent`
+definition and not in any public API for deployed agents — so it is parsed from
+manifests via a **manifest-source-agnostic** parser behind an acquisition-adapter
+seam:
+
+- `--source local-package` — a local app-package directory or `.zip` (reads
+  `manifest.json` → `copilotAgents.declarativeAgents[]` → `declarativeAgent.json`).
+- `--source source-repo` — a source/CI repository tree (Toolkit-built LOB agents).
+- A clearly-marked `FutureExportAdapter` seam is reserved for a scalable
+  tenant-export path (a sibling spike is resolving whether one exists); it raises
+  `NotImplementedError` rather than silently returning nothing.
+
+Each hit is recorded as a `fsi_caiagentfeature` row of feature type
+**People (Org Chart & Profile)** with provenance (`fsi_detectionsource`) and a
+**Declared (Manifest)** confidence marker (`fsi_detectionconfidence`). "Declared"
+means authored/available in the manifest; a v1.7 `user_overrides` block can remove
+a capability at runtime, so declared does not equate to effective. Declarative
+manifests carry no Dataverse bot GUID, so without an `--id-map` entry the agent id
+is flagged **provisional** and a warning is logged for the orchestrator to
+reconcile before joining CAI/CBG.
+
+**Audience → UPN expansion (`expand_audience_upns.py`).** CBG consumes a per-agent
+`intendedUsers[]` UPN list, but `fsi_caiauthshare` records the sharing audience as
+security-group references. This script expands those groups to member UPNs via
+Microsoft Graph **transitive** membership (`GET /groups/{id}/transitiveMembers`,
+permission `GroupMember.Read.All`), which flattens **nested groups** automatically,
+and de-duplicates across overlapping viewer/editor groups. Defensive handling:
+
+- **"Everyone in the organization"** sharing is flagged `wholeTenant`; the tenant
+  is **never enumerated** (a configurable `--whole-tenant-cap` is recorded for the
+  consumer, default `0`).
+- **`--max-members-per-group`** bounds very large groups and sets a `truncated`
+  flag so a partial list is never mistaken for a complete one.
+- **HTTP 429 throttling** uses Retry-After-aware backoff; a group that cannot be
+  read records a per-group error and the agent status becomes `Partial`/`Failed`
+  rather than silently dropping members.
+- Only `intendedUsers[].upn` is produced (per-user license/cohort flags are
+  separate downstream gaps). The Dataverse write-back carries **counts and flags
+  only — no UPNs/PII** — on the `fsi_caiauthshare` audience columns.
+
+Both scripts are **managed-identity-first**, accept `--dry-run`, and support
+compliance with the audience-scoping and data-minimization expectations the FNF
+deliverable depends on.
 
 ## Configuration Placeholders
 

--- a/copilot-agent-inventory/docs/architecture.md
+++ b/copilot-agent-inventory/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture - Copilot Agent Inventory
 
-> **Status:** `0.1.0-preview`. This document describes the intended architecture
+> **Status:** `0.2.0-preview`. This document describes the intended architecture
 > of the discovery scanner and the canonical Dataverse system-of-record. Several
 > build-time facts are tagged for live verification (see
 > [Assumptions and build-time verifications](#assumptions-and-build-time-verifications));

--- a/copilot-agent-inventory/docs/dataverse-schema.md
+++ b/copilot-agent-inventory/docs/dataverse-schema.md
@@ -4,7 +4,7 @@ Auto-generated schema documentation. Do not edit manually — regenerate with `p
 
 ## Overview
 
-The Copilot Agent Inventory solution uses **8 Dataverse tables**, **11 solution-specific option sets**, and **1 shared option set(s)**, with **96 custom columns** (plus the auto-created primary key and `fsi_Name` on each table). All entities use the `fsi_` publisher prefix.
+The Copilot Agent Inventory solution uses **8 Dataverse tables**, **13 solution-specific option sets**, and **1 shared option set(s)**, with **104 custom columns** (plus the auto-created primary key and `fsi_Name` on each table). All entities use the `fsi_` publisher prefix.
 
 > **Logical-name convention.** Dataverse logical names are the SchemaName lowercased with NO underscores between words (`fsi_CopilotAgent` -> `fsi_copilotagent`, `fsi_AgentId` -> `fsi_agentid`). Always use logical names in OData `$select` / `$filter` / `$orderby`.
 
@@ -25,7 +25,7 @@ The Copilot Agent Inventory solution uses **8 Dataverse tables**, **11 solution-
 | `fsi_cai_createdin` | Copilot Studio (100000000), Microsoft 365 Copilot Agent Builder (100000001), Unknown (100000002) |
 | `fsi_cai_agenttype` | Standard (100000000), Lite / Agent Builder (100000001), Declarative Agent (100000002), Classic V1 (excluded) (100000003), Unknown (100000004) |
 | `fsi_cai_discoverysource` | Azure Resource Graph (100000000), Per-Environment Dataverse Scan (100000001), PPAC Reconciliation (100000002), Reconciled (multi-source) (100000003) |
-| `fsi_cai_featuretype` | Topic (100000000), Skill (100000001), Knowledge Source (100000002), Custom GPT (100000003), Copilot Settings (100000004), External Trigger (100000005), File Attachment (100000006), Bot Variable (100000007), Bot Entity (100000008), Dialog (100000009), Dialog Schema (100000021), Trigger (100000010), Language Understanding (100000011), Language Generation (100000012), Bot Translations (100000013), Test Case (100000014), Tool / Plugin (100000015), Connector (100000016), Power Automate Flow (100000017), Environment Variable (100000018), Dataverse Search Grounding (100000019), AI Builder Model (100000020), Other / Unrecognized (100000099) |
+| `fsi_cai_featuretype` | Topic (100000000), Skill (100000001), Knowledge Source (100000002), Custom GPT (100000003), Copilot Settings (100000004), External Trigger (100000005), File Attachment (100000006), Bot Variable (100000007), Bot Entity (100000008), Dialog (100000009), Dialog Schema (100000021), Trigger (100000010), Language Understanding (100000011), Language Generation (100000012), Bot Translations (100000013), Test Case (100000014), Tool / Plugin (100000015), Connector (100000016), Power Automate Flow (100000017), Environment Variable (100000018), Dataverse Search Grounding (100000019), AI Builder Model (100000020), People (Org Chart & Profile) (100000022), Other / Unrecognized (100000099) |
 | `fsi_cai_componentversion` | V1 (100000000), V2 (100000001), Not Applicable (100000002) |
 | `fsi_cai_policytype` | PAYG Billing Policy (100000000), Prepaid Credit Policy (100000001), None (100000002), Unknown (100000003) |
 | `fsi_cai_spendscope` | Chat (100000000), SharePoint (100000001), All Surfaces (100000002), Unknown (100000003) |
@@ -33,6 +33,8 @@ The Copilot Agent Inventory solution uses **8 Dataverse tables**, **11 solution-
 | `fsi_cai_workiqobserved` | Not Observed (100000000), Invoked (100000001), Configured, Not Invoked (100000002), Unknown (100000003) |
 | `fsi_cai_risklevel` | Low (100000000), Medium (100000001), High (100000002), Critical (100000003), Unknown (100000004) |
 | `fsi_cai_scancompleteness` | Complete (100000000), Incomplete Scan (100000001), Failed (100000002) |
+| `fsi_cai_detectionsource` | Dataverse Botcomponent Scan (100000000), Declarative Manifest (Local App Package) (100000001), Declarative Manifest (Source/CI Repo) (100000002), Declarative Manifest (Export Adapter - Future) (100000003), Unknown (100000099) |
+| `fsi_cai_detectionconfidence` | Declared (Manifest) (100000000), Configured (Dataverse) (100000001), Inferred (100000002), Unknown (100000099) |
 
 ---
 
@@ -116,6 +118,9 @@ The Copilot Agent Inventory solution uses **8 Dataverse tables**, **11 solution-
 | `fsi_SourceObjectName` | `fsi_sourceobjectname` | String(500) | No | Display name of the source component / target |
 | `fsi_IsEnabled` | `fsi_isenabled` | Boolean (default: true) | No | Whether the feature is enabled on the agent |
 | `fsi_RelationshipName` | `fsi_relationshipname` | String(200) | No | botcomponent navigation property the feature was matched through |
+| `fsi_DetectionSource` | `fsi_detectionsource` | Picklist (`fsi_cai_detectionsource`) | No | Acquisition source that produced this row (Dataverse botcomponent scan or a declarative-manifest adapter) |
+| `fsi_DetectionConfidence` | `fsi_detectionconfidence` | Picklist (`fsi_cai_detectionconfidence`) | No | Declared (manifest) vs Configured (Dataverse); declared capabilities may be removed by the user at runtime (v1.7 user_overrides) |
+| `fsi_DetectionDetail` | `fsi_detectiondetail` | Memo(4000) | No | JSON provenance for manifest-derived rows: source locator, manifest schema version, and capability sub-settings such as the v1.7 People include_related_content flag |
 | `fsi_LastScannedAt` | `fsi_lastscannedat` | DateTime | Yes | When this feature row was last refreshed |
 | `fsi_RunId` | `fsi_runid` | String(36) | No | Correlating scan run GUID |
 
@@ -142,6 +147,11 @@ The Copilot Agent Inventory solution uses **8 Dataverse tables**, **11 solution-
 | `fsi_SharedWithViewerCount` | `fsi_sharedwithviewercount` | Integer | No | Count of viewer principals/groups |
 | `fsi_SharedWithEditorCount` | `fsi_sharedwitheditorcount` | Integer | No | Count of editor principals |
 | `fsi_LimitSharingMode` | `fsi_limitsharingmode` | String(100) | No | Managed-environment bot-limitSharingMode value |
+| `fsi_AudienceWholeTenant` | `fsi_audiencewholetenant` | Boolean (default: false) | No | 'Everyone in the organization' sharing detected; members are deliberately NOT enumerated (whole-tenant flag) |
+| `fsi_AudienceUpnCount` | `fsi_audienceupncount` | Integer | No | Distinct member UPNs resolved by Microsoft Graph transitive group expansion (0 when whole-tenant and not enumerated) |
+| `fsi_AudienceTruncated` | `fsi_audiencetruncated` | Boolean (default: false) | No | At least one group exceeded the per-group member cap; the resolved UPN list is partial |
+| `fsi_AudienceResolutionStatus` | `fsi_audienceresolutionstatus` | String(100) | No | Complete / Partial / WholeTenantNotEnumerated / Failed / NotResolved — outcome of the UPN expansion |
+| `fsi_AudienceResolvedAt` | `fsi_audienceresolvedat` | DateTime | No | When the audience-to-UPN expansion last ran for this agent |
 | `fsi_LastScannedAt` | `fsi_lastscannedat` | DateTime | Yes | When this posture was last scanned |
 | `fsi_RunId` | `fsi_runid` | String(36) | No | Correlating scan run GUID |
 

--- a/copilot-agent-inventory/docs/dataverse-schema.md
+++ b/copilot-agent-inventory/docs/dataverse-schema.md
@@ -4,7 +4,7 @@ Auto-generated schema documentation. Do not edit manually — regenerate with `p
 
 ## Overview
 
-The Copilot Agent Inventory solution uses **8 Dataverse tables**, **13 solution-specific option sets**, and **1 shared option set(s)**, with **104 custom columns** (plus the auto-created primary key and `fsi_Name` on each table). All entities use the `fsi_` publisher prefix.
+The Copilot Agent Inventory solution uses **8 Dataverse tables**, **13 solution-specific option sets**, and **1 shared option set(s)**, with **106 custom columns** (plus the auto-created primary key and `fsi_Name` on each table). All entities use the `fsi_` publisher prefix.
 
 > **Logical-name convention.** Dataverse logical names are the SchemaName lowercased with NO underscores between words (`fsi_CopilotAgent` -> `fsi_copilotagent`, `fsi_AgentId` -> `fsi_agentid`). Always use logical names in OData `$select` / `$filter` / `$orderby`.
 
@@ -121,6 +121,7 @@ The Copilot Agent Inventory solution uses **8 Dataverse tables**, **13 solution-
 | `fsi_DetectionSource` | `fsi_detectionsource` | Picklist (`fsi_cai_detectionsource`) | No | Acquisition source that produced this row (Dataverse botcomponent scan or a declarative-manifest adapter) |
 | `fsi_DetectionConfidence` | `fsi_detectionconfidence` | Picklist (`fsi_cai_detectionconfidence`) | No | Declared (manifest) vs Configured (Dataverse); declared capabilities may be removed by the user at runtime (v1.7 user_overrides) |
 | `fsi_DetectionDetail` | `fsi_detectiondetail` | Memo(4000) | No | JSON provenance for manifest-derived rows: source locator, manifest schema version, and capability sub-settings such as the v1.7 People include_related_content flag |
+| `fsi_AgentRefProvisional` | `fsi_agentrefprovisional` | Boolean (default: false) | No | The fsi_agentid is a PROVISIONAL manifest/app id not yet bound to a Dataverse bot GUID (no --id-map match during manifest detection). Downstream joins (Copilot Billing Governance) must reconcile provisional rows before use; queryable so provisional rows can be filtered |
 | `fsi_LastScannedAt` | `fsi_lastscannedat` | DateTime | Yes | When this feature row was last refreshed |
 | `fsi_RunId` | `fsi_runid` | String(36) | No | Correlating scan run GUID |
 
@@ -147,6 +148,7 @@ The Copilot Agent Inventory solution uses **8 Dataverse tables**, **13 solution-
 | `fsi_SharedWithViewerCount` | `fsi_sharedwithviewercount` | Integer | No | Count of viewer principals/groups |
 | `fsi_SharedWithEditorCount` | `fsi_sharedwitheditorcount` | Integer | No | Count of editor principals |
 | `fsi_LimitSharingMode` | `fsi_limitsharingmode` | String(100) | No | Managed-environment bot-limitSharingMode value |
+| `fsi_SharedWithEveryone` | `fsi_sharedwitheveryone` | Boolean (default: false) | No | Per-agent org-wide reach: the agent is shared with 'Everyone in the organization' (derived from the bot accesscontrolpolicy Any / Any-multi-tenant signal during discovery). This is a PER-AGENT posture signal and is NOT the environment-wide bot-limitSharingMode policy; it drives whole-tenant audience handling in expand_audience_upns.py |
 | `fsi_AudienceWholeTenant` | `fsi_audiencewholetenant` | Boolean (default: false) | No | 'Everyone in the organization' sharing detected; members are deliberately NOT enumerated (whole-tenant flag) |
 | `fsi_AudienceUpnCount` | `fsi_audienceupncount` | Integer | No | Distinct member UPNs resolved by Microsoft Graph transitive group expansion (0 when whole-tenant and not enumerated) |
 | `fsi_AudienceTruncated` | `fsi_audiencetruncated` | Boolean (default: false) | No | At least one group exceeded the per-group member cap; the resolved UPN list is partial |

--- a/copilot-agent-inventory/docs/flow-configuration.md
+++ b/copilot-agent-inventory/docs/flow-configuration.md
@@ -228,4 +228,4 @@ Rename action: `Write_Run_Record`.
 
 ---
 
-*Copilot Agent Inventory — Flow Setup Guide v0.1.0-preview*
+*Copilot Agent Inventory — Flow Setup Guide v0.2.0-preview*

--- a/copilot-agent-inventory/docs/governance-platform-composition.md
+++ b/copilot-agent-inventory/docs/governance-platform-composition.md
@@ -203,6 +203,224 @@ brought into the system-of-record between nightly batch runs. This composes with
 governance: when a new environment appears, the listener keeps the inventory
 current without waiting for the next scheduled discovery.
 
+## FNF People-capability sweep — composition lens
+
+> **Context and scope.** This section documents a specialized composition lens built on
+> Pillars 1–3 for a financial services organization running approximately 2,000 Microsoft
+> 365 Copilot declarative agents. The governance question is: *which agents expose the
+> declarative `People` capability to users who lack a paid M365 Copilot license and are
+> not covered by PAYG, and how many such users are shared with that agent?* The lens
+> **supports compliance with** control 1.18 (Application-Level Authorization and RBAC)
+> and **contributes to** control 3.5 (Cost Allocation and Budget Tracking). It does not
+> perform real-time enforcement; it is a detection and reporting composition.
+>
+> **Cloud scope.** US commercial Microsoft 365 only; verify applicability for other
+> cloud environments independently.
+
+### What this lens governs
+
+| Dimension | In scope | Out of scope |
+|-----------|----------|--------------|
+| Capability | Declarative `People` (org chart + profile) | Work IQ; other manifest capabilities |
+| Entitlement | Paid M365 Copilot service-plan; PAYG / Copilot Credits | Guest users; non-M365 workloads |
+| Audience | Sharing groups → expanded UPN list | In-agent AAD group membership at prompt time |
+| Output | Blocked-user count + `coverageStatus` per People-capable agent | Real-time enforcement; auto-remediation |
+
+### The chain: CAI → CBG → engine → FNF report
+
+The sweep composes four existing solutions in a fixed pipeline.
+
+#### Step 1 — Capability detection (`copilot-agent-inventory`)
+
+CAI reads each agent's `declarativeAgent.json` manifest and records an
+`fsi_caiagentfeature` row when `capabilities[].name == "People"` with
+`fsi_isenabled = true`. The detection requires the manifest file to be readable; Work IQ
+telemetry cannot substitute for it (see Architecture facts below).
+
+For agents built with Microsoft 365 Agents Toolkit the manifest is read from
+source-controlled `appPackage/declarativeAgent.json`. For other provenance paths the
+manifest must be supplied via `--source local-package` or a resolved id-map. Agents
+without a readable manifest are not silently dropped; they are flagged as provisional
+coverage gaps (see Coverage model below).
+
+#### Step 2 — Audience expansion (`copilot-agent-inventory`)
+
+For each People-capable agent, `expand_audience_upns.py` resolves the agent's sharing
+groups from `fsi_caiauthshare` and expands them to a UPN list written to the
+`audience-upn-list` artifact. Agents shared with the whole organization
+(`wholeTenant = true`) emit an empty `intendedUsers[]`; the lens handles them as a
+separate `coverageStatus = "Partial"` row — they are not silently assigned "0 blocked"
+(see Integration caveats below).
+
+#### Step 3 — Entitlement scoring (`copilot-billing-governance`)
+
+The CBG resolver (`Get-CopilotEntitlement.ps1`) evaluates each UPN against:
+
+1. A **paid M365 Copilot service-plan allowlist** — checked via
+   `GET /v1.0/users/{id}/licenseDetails` with `provisioningStatus == "Success"`.
+2. **PAYG / Copilot Credits eligibility** — whether the user is in an "All Users" scope
+   or in a security group linked to a connected billing policy.
+
+The resolver is **fail-closed on uncertainty**: users whose license state cannot be
+determined are routed to `needsManualReview`, not silently counted as "allowed."
+
+The entitlement engine (`Invoke-EntitlementEvaluation.ps1`) then classifies each
+(agent, user) pair as `Block`, `Allow`, `Fail-open-Anomaly`, or
+`Fail-closed-ZeroRatingUnresolved` and writes results to
+`fsi_cbgentitlementmaterialized`.
+
+#### Step 4 — FNF report
+
+The lens joins `fsi_caiagentfeature` (People filter), the audience artifact, and the
+engine decisions to produce one report row per People-capable agent:
+
+| Report field | Source |
+|---|---|
+| `agentId`, `agentName` | `fsi_copilotagent` |
+| `audienceMode` | `audience-upn-list.agents[].wholeTenant` → `WholeTenant \| GroupScoped` |
+| `coverageStatus` | Rolled-up from audience `resolutionStatus`, CBG `unresolvedCount`, engine anomalies |
+| `coverageGaps[]` | Named gaps: `manifest-id-unreconciled`, `audience-truncated`, `audience-resolution-errors`, `audience-wholetenant-not-enumerated`, `entitlement-unresolved-users`, `payg-policy-needs-manual-review`, `pathway-unmapped-fail-open` |
+| `blockedUserCount`, `blockedUsers[]` | `fsi_cbgentitlementmaterialized` where `fsi_decision = Block` |
+| `totalAudience` | `audience-upn-list.agents[].audienceSize` (0 / null for whole-tenant) |
+
+`coverageStatus = "Partial"` is emitted whenever any of the named gaps is present.
+A `coverageStatus = "Complete"` row represents a fully scored agent with no audience
+or entitlement gaps — it does not imply the agent's sharing or licensing posture is
+acceptable; it means the data for that agent is complete enough to produce a reliable
+blocked-user count.
+
+---
+
+### Corrected architecture facts
+
+The following facts were adversarially verified (GATE0a, GATE0b, R6) and differ from
+common assumptions that should not be carried into implementations.
+
+#### `People` is a declarative-agent manifest capability — not Work IQ
+
+`People` is expressed as `{ "name": "People" }` inside `declarativeAgent.json`
+(manifest schema v1.5+) and enables grounding on org-chart and profile data for that
+specific agent. It is a per-agent manifest declaration — **distinct from Work IQ** in
+layer, detection surface, and admin governance:
+
+| Attribute | `People` capability | Work IQ |
+|---|---|---|
+| Layer | Per-agent declarative manifest | Tenant-level Copilot intelligence layer |
+| Where defined | `declarativeAgent.json` → `capabilities[].name` | M365 admin center; Copilot and Dataverse settings |
+| How detected | Manifest parse (CAI) | `fsi_wiqstate` four-state model (Pillar 2) |
+| Runtime telemetry signal | **None documented (R6)** | Purview `AISystemPlugin[]` (documented Ids: `BingWebSearch`, `EnterpriseSearch`) |
+
+**Work IQ telemetry does not detect the declarative `People` capability.** Across all
+tested surfaces as of 2026-06-11 — Purview Audit `CopilotInteraction.AISystemPlugin[]`,
+Defender XDR `CloudAppEvents`, Application Insights, and Microsoft Graph `aiInteraction`
+— no documented, distinct, queryable signal fires when People grounding is invoked
+(R6 adversarial research). Build no automated detection on an inferred
+`AISystemPlugin[].Id == "People"` until validated live in a tenant post-GA.
+
+#### License detection is service-plan–based; display names are not contracts
+
+The CBG resolver checks paid entitlement against **service-plan GUIDs** read from
+`GET /v1.0/users/{id}/licenseDetails`. The six service plans that constitute a paid
+M365 Copilot entitlement (GATE0b, Microsoft licensing-service-plan reference):
+
+| `servicePlanName` | `servicePlanId` |
+|---|---|
+| `M365_COPILOT_BUSINESS_CHAT` | `3f30311c-6b1e-48a4-ab79-725b469da960` |
+| `M365_COPILOT_APPS` | `a62f8878-de10-42f3-b68f-6149a25ceb97` |
+| `M365_COPILOT_TEAMS` | `b95945de-b3bd-46db-8437-f2beb6ea2347` |
+| `M365_COPILOT_SHAREPOINT` | `0aedf20c-091d-420b-aadf-30c042609612` |
+| `M365_COPILOT_INTELLIGENT_SEARCH` | `931e4a88-a67f-48b5-814f-16a5f1e6028d` |
+| `M365_COPILOT_CONNECTORS` | `89f1c4c8-0878-40f7-804d-869c9128ab5d` |
+
+`Bing_Chat_Enterprise` (`0d0c0d31-fae7-41f2-b909-eaf4d7f26dba`) — present in M365 E3
+and E5 SKUs — is **explicitly excluded**: its friendly name in Microsoft's reference is
+"RETIRED - Commercial data protection for Microsoft Copilot" and it does not constitute
+a paid M365 Copilot entitlement (GATE0b C2).
+
+Tenant-local labels such as "Microsoft 365 E7" and "Copilot Premium" are not published
+Microsoft SKU names (neither appears in the Microsoft licensing-service-plan reference
+as of 2026-06-11; GATE0b C3). The resolver MUST reconcile against live tenant
+`subscribedSkus` by GUID — never by display name.
+
+---
+
+### Coverage model and honest limits
+
+Automated capability detection is bounded by manifest access. The entitlement and
+sharing join is **fully automated for every agent that is identified**, regardless of
+how the agent was built.
+
+| Tier | Population | Capability detection | Entitlement + sharing join |
+|---|---|---|---|
+| **A — source-controlled** | ~5–20% (Toolkit-built; `declarativeAgent.json` in version control or CI artifact) | ✅ Automated | ✅ Automated |
+| **B — org-catalog, no source** | Published agents without checked-in manifest | ❌ No supported API today | ✅ Automated once identified |
+| **C — Shared by creator (long tail)** | ~60–85% (Agent-Builder self-service agents) | ❌ No supported API today | ✅ Automated once identified |
+
+**No supported, scalable API returns `capabilities[]` for deployed declarative agents
+as of 2026-06-11.** The following surfaces were tested and return metadata only — no
+manifest body or parsed `capabilities[]` array: Microsoft Graph
+`/appCatalogs/teamsApps` (`AppCatalog.Read.All`), the M365 admin-center Agent Registry
+CSV export, Teams Admin Center PowerShell (`Get-TeamsApp`), Purview Audit, Defender XDR
+`CloudAppEvents`, and Microsoft Graph `aiInteraction` (SPIKE adversarial research +
+GATE0a enumeration across all documented surfaces).
+
+For Tier B and C agents, **manual owner attestation is the primary recommended path**:
+the owning team confirms whether the "Reference org chart and profile info" toggle is
+enabled in Agent Builder. The entitlement and sharing join then runs automatically once
+the agent is included in the sweep.
+
+**Future static-API candidates — validate live, do not promise customers today:**
+
+- **M365 Agent Registry Graph API (preview)** — if it returns a parsed
+  `declarativeAgent.json`, Tier B and C agents could be resolved programmatically.
+  Whether `capabilities[]` is exposed is undocumented; must be validated against a live
+  tenant and not relied upon until confirmed.
+- **Defender XDR `AgentsInfo` (preview; rename from `AIAgentsInfo` completes
+  2026-07-01)** — carries a `Capabilities` dynamic column reflecting declared posture.
+  Whether it ingests M365 Copilot declarative agents (vs. Copilot Studio / Foundry
+  agents only) and whether `capabilities[].name = "People"` is captured is unverified
+  as of 2026-06-11. This is a posture (inventory) table, not a runtime invocation
+  signal; even if it resolves the capability-detection gap for some agents, it does not
+  produce a telemetry trace of when People grounding fires.
+
+---
+
+### Integration caveats (GATE-1 seams)
+
+Three seams between CAI and CBG were identified as blocking in the cross-branch
+contract review. Implementations MUST address all three.
+
+1. **SEAM 1 — Agent-id reconciliation.** CAI stamps `fsi_agentrefprovisional = true`
+   on `fsi_caiagentfeature` rows where the manifest was read without a resolved
+   Dataverse bot GUID. Joining these rows to the audience artifact or CBG on
+   `fsi_agentid` without prior reconciliation either joins onto nothing (provisional id
+   ≠ any real GUID) or collapses multiple distinct provisional manifests onto the same
+   stem. The People-capability filter MUST gate on `fsi_agentrefprovisional = false`
+   (or supply `--id-map` and re-query). Unreconciled rows MUST surface as
+   `coverageStatus = "Partial"` with `coverageGap = "manifest-id-unreconciled"` — never
+   silently dropped.
+
+2. **SEAM 2a — Audience artifact shape mismatch.** CAI emits
+   `agents[].intendedUsers[{ "upn": "..." }]` (array of objects). The CBG resolver
+   expects `agents[].intendedUpns: ["..."]` (flat array of strings). Passing the CAI
+   audience artifact directly as the CBG resolver `-InputPath` produces a silent
+   zero-user run: `intendedUpns` is `$null`, the per-user loop iterates nothing, and the
+   report reads "0 blocked." A normalization step is required before invoking the
+   resolver.
+
+3. **SEAM 2c — Whole-tenant audience.** Agents shared with the entire organization emit
+   `wholeTenant = true` with `intendedUsers = []`. The lens MUST NOT report "0 blocked"
+   for these agents; it MUST emit `audienceMode = "WholeTenant"`,
+   `coverageStatus = "Partial"`, and `blockedUsersComputed = false`. Org-wide-shared
+   People-capable agents represent the highest-risk profile in the sweep and must remain
+   visible in the output.
+
+> **Pathway fallback note.** The engine falls back to the `createdIn` field when
+> `configuredTier` (WIQ) is out of scope. Agents with `fsi_createdin ∈ {Unknown, null}`
+> produce `pathway = unmapped → FAIL-OPEN` and under-report blocked users. The lens MUST
+> treat such agents as `coverageStatus = "Partial"` with
+> `coverageGap = "pathway-unmapped-fail-open"`.
+
 ## Composition map
 
 ```mermaid

--- a/copilot-agent-inventory/docs/governance-platform-composition.md
+++ b/copilot-agent-inventory/docs/governance-platform-composition.md
@@ -320,8 +320,9 @@ Defender XDR `CloudAppEvents`, Application Insights, and Microsoft Graph `aiInte
 #### License detection is service-plan–based; display names are not contracts
 
 The CBG resolver checks paid entitlement against **service-plan GUIDs** read from
-`GET /v1.0/users/{id}/licenseDetails`. The six service plans that constitute a paid
-M365 Copilot entitlement (GATE0b, Microsoft licensing-service-plan reference):
+`GET /v1.0/users/{id}/licenseDetails`. The **eight** service plans that constitute a paid
+M365 Copilot entitlement — the six `M365_COPILOT_*` plans plus two sibling plans bundled in
+the same paid SKU (GATE0b 8-GUID allowlist; Microsoft licensing-service-plan reference):
 
 | `servicePlanName` | `servicePlanId` |
 |---|---|
@@ -331,6 +332,8 @@ M365 Copilot entitlement (GATE0b, Microsoft licensing-service-plan reference):
 | `M365_COPILOT_SHAREPOINT` | `0aedf20c-091d-420b-aadf-30c042609612` |
 | `M365_COPILOT_INTELLIGENT_SEARCH` | `931e4a88-a67f-48b5-814f-16a5f1e6028d` |
 | `M365_COPILOT_CONNECTORS` | `89f1c4c8-0878-40f7-804d-869c9128ab5d` |
+| `GRAPH_CONNECTORS_COPILOT` | `82d30987-df9b-4486-b146-198b21d164c7` |
+| `COPILOT_STUDIO_IN_COPILOT_FOR_M365` | `fe6c28b3-d468-44ea-bbd0-a10a5167435c` |
 
 `Bing_Chat_Enterprise` (`0d0c0d31-fae7-41f2-b909-eaf4d7f26dba`) — present in M365 E3
 and E5 SKUs — is **explicitly excluded**: its friendly name in Microsoft's reference is

--- a/copilot-agent-inventory/manifest.yaml
+++ b/copilot-agent-inventory/manifest.yaml
@@ -1,7 +1,7 @@
 id: copilot-agent-inventory
 name: Copilot Agent Inventory
 description: Foundation system-of-record for Copilot Studio and Agent Builder agents — three-layer tenant-wide discovery (Azure Resource Graph, per-environment Dataverse, PPAC reconciliation) feeding a canonical eight-entity governance store keyed on fsi_copilotagent.
-version: 0.1.0-preview
+version: 0.2.0-preview
 status: preview
 domain: monitoring-analytics
 tier: '1'

--- a/copilot-agent-inventory/scripts/create_cai_dataverse_schema.py
+++ b/copilot-agent-inventory/scripts/create_cai_dataverse_schema.py
@@ -133,6 +133,12 @@ CAI_OPTIONSETS = {
             ("Environment Variable", 100000018),
             ("Dataverse Search Grounding", 100000019),
             ("AI Builder Model", 100000020),
+            # Declarative-agent manifest capability (declarativeAgent.json
+            # capabilities[].name == "People"). The "Reference org chart and
+            # profile info" Agent Builder toggle maps to this capability; it is
+            # NOT a botcomponent and NOT exposed by any deployed-agent API, so it
+            # is detected from the manifest by detect_people_capability.py.
+            ("People (Org Chart & Profile)", 100000022),
             ("Other / Unrecognized", 100000099),
         ],
     },
@@ -196,6 +202,35 @@ CAI_OPTIONSETS = {
             ("Complete", 100000000),
             ("Incomplete Scan", 100000001),
             ("Failed", 100000002),
+        ],
+    },
+    # Provenance of a feature row: which acquisition source produced it. Most
+    # rows come from the Dataverse botcomponent scan; manifest-derived rows
+    # (e.g., the People capability) record which manifest-acquisition adapter
+    # supplied the declarativeAgent.json. The export-adapter value is a reserved
+    # seam for a future scalable manifest export (see detect_people_capability.py).
+    "fsi_cai_detectionsource": {
+        "name": "fsi_cai_detectionsource",
+        "options": [
+            ("Dataverse Botcomponent Scan", 100000000),
+            ("Declarative Manifest (Local App Package)", 100000001),
+            ("Declarative Manifest (Source/CI Repo)", 100000002),
+            ("Declarative Manifest (Export Adapter - Future)", 100000003),
+            ("Unknown", 100000099),
+        ],
+    },
+    # Confidence marker for a detected feature. "Declared (Manifest)" means the
+    # capability is authored/available in the declarative-agent manifest; per the
+    # v1.7 user_overrides caveat the consuming user may remove it at runtime, so
+    # declared is NOT the same as effective. Botcomponent rows are read from the
+    # agent's persisted definition and are marked "Configured (Dataverse)".
+    "fsi_cai_detectionconfidence": {
+        "name": "fsi_cai_detectionconfidence",
+        "options": [
+            ("Declared (Manifest)", 100000000),
+            ("Configured (Dataverse)", 100000001),
+            ("Inferred", 100000002),
+            ("Unknown", 100000099),
         ],
     },
 }
@@ -448,6 +483,18 @@ AGENTFEATURE_COLUMNS = [
                  description="Whether the feature is enabled on the agent"),
     _string_col("fsi_RelationshipName", "Relationship Name", 200, required=False,
                 description="botcomponent navigation property the feature was matched through"),
+    _picklist_col("fsi_DetectionSource", "Detection Source",
+                  "fsi_cai_detectionsource", required=False,
+                  description="Acquisition source that produced this row (Dataverse "
+                              "botcomponent scan or a declarative-manifest adapter)"),
+    _picklist_col("fsi_DetectionConfidence", "Detection Confidence",
+                  "fsi_cai_detectionconfidence", required=False,
+                  description="Declared (manifest) vs Configured (Dataverse); declared "
+                              "capabilities may be removed by the user at runtime (v1.7 user_overrides)"),
+    _memo_col("fsi_DetectionDetail", "Detection Detail", 4000,
+              description="JSON provenance for manifest-derived rows: source locator, "
+                          "manifest schema version, and capability sub-settings such as "
+                          "the v1.7 People include_related_content flag"),
     _datetime_col("fsi_LastScannedAt", "Last Scanned At",
                   description="When this feature row was last refreshed"),
     _string_col("fsi_RunId", "Run ID", 36, required=False,
@@ -480,6 +527,21 @@ AUTHSHARE_COLUMNS = [
                  description="Count of editor principals"),
     _string_col("fsi_LimitSharingMode", "Limit Sharing Mode", 100, required=False,
                 description="Managed-environment bot-limitSharingMode value"),
+    _boolean_col("fsi_AudienceWholeTenant", "Audience Whole Tenant", default=False,
+                 description="'Everyone in the organization' sharing detected; members "
+                             "are deliberately NOT enumerated (whole-tenant flag)"),
+    _integer_col("fsi_AudienceUpnCount", "Audience UPN Count", required=False,
+                 description="Distinct member UPNs resolved by Microsoft Graph transitive "
+                             "group expansion (0 when whole-tenant and not enumerated)"),
+    _boolean_col("fsi_AudienceTruncated", "Audience Truncated", default=False,
+                 description="At least one group exceeded the per-group member cap; the "
+                             "resolved UPN list is partial"),
+    _string_col("fsi_AudienceResolutionStatus", "Audience Resolution Status", 100,
+                required=False,
+                description="Complete / Partial / WholeTenantNotEnumerated / Failed / "
+                            "NotResolved — outcome of the UPN expansion"),
+    _datetime_col("fsi_AudienceResolvedAt", "Audience Resolved At", required=False,
+                  description="When the audience-to-UPN expansion last ran for this agent"),
     _datetime_col("fsi_LastScannedAt", "Last Scanned At",
                   description="When this posture was last scanned"),
     _string_col("fsi_RunId", "Run ID", 36, required=False,

--- a/copilot-agent-inventory/scripts/create_cai_dataverse_schema.py
+++ b/copilot-agent-inventory/scripts/create_cai_dataverse_schema.py
@@ -495,6 +495,12 @@ AGENTFEATURE_COLUMNS = [
               description="JSON provenance for manifest-derived rows: source locator, "
                           "manifest schema version, and capability sub-settings such as "
                           "the v1.7 People include_related_content flag"),
+    _boolean_col("fsi_AgentRefProvisional", "Agent Ref Provisional", default=False,
+                 description="The fsi_agentid is a PROVISIONAL manifest/app id not yet "
+                             "bound to a Dataverse bot GUID (no --id-map match during "
+                             "manifest detection). Downstream joins (Copilot Billing "
+                             "Governance) must reconcile provisional rows before use; "
+                             "queryable so provisional rows can be filtered"),
     _datetime_col("fsi_LastScannedAt", "Last Scanned At",
                   description="When this feature row was last refreshed"),
     _string_col("fsi_RunId", "Run ID", 36, required=False,
@@ -527,6 +533,13 @@ AUTHSHARE_COLUMNS = [
                  description="Count of editor principals"),
     _string_col("fsi_LimitSharingMode", "Limit Sharing Mode", 100, required=False,
                 description="Managed-environment bot-limitSharingMode value"),
+    _boolean_col("fsi_SharedWithEveryone", "Shared With Everyone", default=False,
+                 description="Per-agent org-wide reach: the agent is shared with "
+                             "'Everyone in the organization' (derived from the bot "
+                             "accesscontrolpolicy Any / Any-multi-tenant signal during "
+                             "discovery). This is a PER-AGENT posture signal and is NOT "
+                             "the environment-wide bot-limitSharingMode policy; it drives "
+                             "whole-tenant audience handling in expand_audience_upns.py"),
     _boolean_col("fsi_AudienceWholeTenant", "Audience Whole Tenant", default=False,
                  description="'Everyone in the organization' sharing detected; members "
                              "are deliberately NOT enumerated (whole-tenant flag)"),

--- a/copilot-agent-inventory/scripts/detect_people_capability.py
+++ b/copilot-agent-inventory/scripts/detect_people_capability.py
@@ -3,7 +3,8 @@
 
 The Agent Builder toggle *"Reference org chart and profile info"* maps to the
 declarative-agent manifest capability ``{ "name": "People" }`` inside
-``declarativeAgent.json`` (manifest schema v1.5-v1.7). This capability is NOT a
+``declarativeAgent.json`` (manifest schema v1.3+, introduced in schema v1.3;
+unchanged through v1.7). This capability is NOT a
 Copilot Studio ``botcomponent`` and is NOT returned by any public API for a
 *deployed* agent (verified in GATE0a). Capability-level detection therefore
 requires the source manifest itself, obtained from the agent app package or from
@@ -12,7 +13,7 @@ source control. This module:
   * Parses a ``declarativeAgent.json`` (or an app-package ``.zip``, or a
     directory of packages) and extracts ``capabilities[]``.
   * Detects ``name == "People"`` as a **case-sensitive literal**, independent of
-    the manifest ``version`` (the const is unchanged across v1.5-v1.7).
+    the manifest ``version`` (the const is unchanged through v1.7).
   * Captures the optional v1.7 ``include_related_content`` sub-setting.
   * Emits one ``fsi_caiagentfeature`` row (logical column names) per detected
     agent, using the feature type ``People (Org Chart & Profile)``, a
@@ -65,7 +66,7 @@ logger = logging.getLogger("detect_people_capability")
 # =============================================================================
 
 # Case-sensitive const from the declarative-agent manifest JSON Schema; the
-# value is unchanged across schema v1.5, v1.6 and v1.7.
+# value is present since schema v1.3 (introduced in v1.3; unchanged through v1.7).
 PEOPLE_CAPABILITY_NAME = "People"
 
 # fsi_cai_featuretype label for the People capability (see create_cai_dataverse_schema.py).
@@ -170,17 +171,25 @@ def parse_manifest_version(manifest: Any) -> tuple[Optional[str], Optional[str]]
     return (version, schema_url)
 
 
-def detect_people_capability(manifest: Any) -> PeopleDetection:
+def detect_people_capability(manifest: Any, agent_label: str = "") -> PeopleDetection:
     """Test a parsed declarative-agent manifest for the People capability.
 
     Matches ``capabilities[].name == "People"`` as a case-sensitive literal so a
     lowercase ``"people"`` (or any other casing) does NOT match. Returns the
     first matching capability object; the optional v1.7 ``include_related_content``
     boolean is captured but does NOT gate detection (it is a sub-setting).
+
+    A non-fatal WARNING is emitted via the module logger for any capability whose
+    ``name`` differs from ``"People"`` only by case or surrounding whitespace
+    (i.e. ``name.strip().lower() == "people"`` but ``name != "People"``).  The
+    capability is still NOT counted as detected — the warning surfaces a
+    mis-authored manifest rather than silently dropping it.  ``agent_label`` is
+    included in the warning to identify the source.
     """
     version, schema_url = parse_manifest_version(manifest)
     for capability in extract_capabilities(manifest):
-        if capability.get("name") == PEOPLE_CAPABILITY_NAME:
+        name = capability.get("name")
+        if name == PEOPLE_CAPABILITY_NAME:
             irc = capability.get("include_related_content")
             return PeopleDetection(
                 detected=True,
@@ -188,6 +197,15 @@ def detect_people_capability(manifest: Any) -> PeopleDetection:
                 manifest_version=version,
                 schema_url=schema_url,
                 raw_capability=capability,
+            )
+        if isinstance(name, str) and name.strip().lower() == "people":
+            logger.warning(
+                "Manifest capability name %r looks like %r but does not match the "
+                "exact schema const (case/whitespace drift); capability will NOT be "
+                "detected (agent: %s). Correct the manifest to avoid silent omission.",
+                name,
+                PEOPLE_CAPABILITY_NAME,
+                agent_label or "<unknown>",
             )
     return PeopleDetection(detected=False, manifest_version=version, schema_url=schema_url)
 
@@ -587,7 +605,10 @@ def detect_over_adapter(
     run = DetectionRun(run_id=run_id)
     for record in adapter.iter_records():
         run.manifests_scanned += 1
-        detection = detect_people_capability(record.manifest)
+        detection = detect_people_capability(
+            record.manifest,
+            agent_label=record.agent_name or record.agent_id or record.locator,
+        )
         if not detection.detected:
             continue
         run.people_detected += 1

--- a/copilot-agent-inventory/scripts/detect_people_capability.py
+++ b/copilot-agent-inventory/scripts/detect_people_capability.py
@@ -48,6 +48,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import logging
 import zipfile
@@ -85,6 +86,27 @@ PEOPLE_RELATIONSHIP = "declarativeAgent.capabilities"
 # A stable per-agent source-object id so re-detection upserts one People row
 # (the fsi_caiagentfeature alternate key is fsi_agentid + fsi_sourceobjectid).
 PEOPLE_SOURCE_OBJECT_ID = "capability:People"
+
+
+def _people_source_object_id(locator: str, agent_id_provisional: bool) -> str:
+    """Return the fsi_sourceobjectid for a People row, salting provisional rows.
+
+    The fsi_caiagentfeature alternate key is (fsi_agentid, fsi_sourceobjectid).
+    For a resolved (non-provisional) agent the constant ``capability:People`` is
+    correct: re-detection upserts the single People row for that agent.
+
+    For a PROVISIONAL agent the id falls back to the manifest stem, which is the
+    SAME literal (``declarativeAgent``) for every Toolkit
+    ``appPackage/declarativeAgent.json``. With a constant source-object id two
+    distinct provisional manifests would collapse onto one alternate key and one
+    upsert would silently overwrite the other. Salting the source-object id with a
+    stable hash of the manifest locator keeps distinct provisional manifests on
+    distinct alternate keys while remaining deterministic (idempotent re-scans).
+    """
+    if not agent_id_provisional:
+        return PEOPLE_SOURCE_OBJECT_ID
+    digest = hashlib.sha1(str(locator).encode("utf-8")).hexdigest()[:12]
+    return f"{PEOPLE_SOURCE_OBJECT_ID}:{digest}"
 
 # Conventional manifest filenames inside an app package / repo (case-insensitive).
 APP_MANIFEST_NAMES = {"manifest.json"}
@@ -208,12 +230,13 @@ def build_people_feature_record(
         "fsi_featuretype": PEOPLE_FEATURE_TYPE,
         "fsi_componenttype": None,
         "fsi_componentversion": "Not Applicable",
-        "fsi_sourceobjectid": PEOPLE_SOURCE_OBJECT_ID,
+        "fsi_sourceobjectid": _people_source_object_id(locator, agent_id_provisional),
         "fsi_sourceobjectname": PEOPLE_CAPABILITY_NAME,
         "fsi_relationshipname": PEOPLE_RELATIONSHIP,
         "fsi_detectionsource": source_label,
         "fsi_detectionconfidence": CONFIDENCE_DECLARED,
         "fsi_detectiondetail": json.dumps(detail),
+        "fsi_agentrefprovisional": agent_id_provisional,
         "fsi_isenabled": True,
         "fsi_lastscannedat": _utc_now_iso(),
         "fsi_runid": run_id,
@@ -292,13 +315,19 @@ def _read_json_bytes(data: bytes, locator: str) -> Optional[dict]:
 
 
 def load_manifests_from_zip(
-    zip_path: Path, id_map: Optional[dict[str, str]] = None
+    zip_path: Path, id_map: Optional[dict[str, str]] = None,
+    failures: Optional[list] = None,
 ) -> Iterator[ManifestRecord]:
     """Yield ManifestRecords from a Microsoft 365 app-package ``.zip``.
 
     Reads the app ``manifest.json`` to find the ``copilotAgents`` declarative
     agent file refs; falls back to any ``declarativeAgent*.json`` in the package
     when the app manifest is absent or does not reference one.
+
+    A manifest that cannot be opened (``BadZipFile`` / ``OSError``) or whose
+    declarative-agent JSON cannot be parsed (the ``None`` branch) is appended to
+    ``failures`` (when provided) so a corrupt fleet is surfaced as Partial rather
+    than read as "0 detections, all green".
     """
     try:
         with zipfile.ZipFile(zip_path) as archive:
@@ -332,6 +361,8 @@ def load_manifests_from_zip(
                 locator = f"{zip_path}::{da_name}"
                 manifest = _read_json_bytes(archive.read(da_name), locator)
                 if manifest is None:
+                    if failures is not None:
+                        failures.append(locator)
                     continue
                 agent_id, agent_name, provisional = _resolve_agent_identity(
                     manifest, app_manifest, locator, id_map
@@ -343,18 +374,30 @@ def load_manifests_from_zip(
                 )
     except (zipfile.BadZipFile, OSError) as exc:
         logger.warning("Could not open app package %s (fail-open): %s", zip_path, exc)
+        if failures is not None:
+            failures.append(str(zip_path))
 
 
 def load_manifest_from_json_file(
-    json_path: Path, id_map: Optional[dict[str, str]] = None
+    json_path: Path, id_map: Optional[dict[str, str]] = None,
+    failures: Optional[list] = None,
 ) -> Iterator[ManifestRecord]:
-    """Yield a single ManifestRecord from a loose ``declarativeAgent.json`` file."""
+    """Yield a single ManifestRecord from a loose ``declarativeAgent.json`` file.
+
+    An unreadable file (``OSError``) or unparseable JSON (the ``None`` branch) is
+    appended to ``failures`` (when provided) so a corrupt manifest is surfaced as
+    Partial rather than silently skipped.
+    """
     try:
         manifest = _read_json_bytes(json_path.read_bytes(), str(json_path))
     except OSError as exc:
         logger.warning("Could not read manifest %s (fail-open): %s", json_path, exc)
+        if failures is not None:
+            failures.append(str(json_path))
         return
     if manifest is None:
+        if failures is not None:
+            failures.append(str(json_path))
         return
     # An adjacent app manifest (same directory) helps resolve identity if present.
     app_manifest: Optional[dict] = None
@@ -381,28 +424,30 @@ def _is_declarative_agent_json(path: Path) -> bool:
 
 
 def load_manifests_from_dir(
-    root: Path, id_map: Optional[dict[str, str]] = None
+    root: Path, id_map: Optional[dict[str, str]] = None,
+    failures: Optional[list] = None,
 ) -> Iterator[ManifestRecord]:
     """Recursively yield ManifestRecords from app-package zips and loose manifests."""
     for path in sorted(root.rglob("*")):
         if not path.is_file():
             continue
         if path.suffix.lower() == ".zip":
-            yield from load_manifests_from_zip(path, id_map)
+            yield from load_manifests_from_zip(path, id_map, failures)
         elif _is_declarative_agent_json(path):
-            yield from load_manifest_from_json_file(path, id_map)
+            yield from load_manifest_from_json_file(path, id_map, failures)
 
 
 def load_manifests_from_path(
-    path: Path, id_map: Optional[dict[str, str]] = None
+    path: Path, id_map: Optional[dict[str, str]] = None,
+    failures: Optional[list] = None,
 ) -> Iterator[ManifestRecord]:
     """Dispatch on a path that may be a directory, an app-package zip, or a JSON file."""
     if path.is_dir():
-        yield from load_manifests_from_dir(path, id_map)
+        yield from load_manifests_from_dir(path, id_map, failures)
     elif path.suffix.lower() == ".zip":
-        yield from load_manifests_from_zip(path, id_map)
+        yield from load_manifests_from_zip(path, id_map, failures)
     elif path.suffix.lower() == ".json":
-        yield from load_manifest_from_json_file(path, id_map)
+        yield from load_manifest_from_json_file(path, id_map, failures)
     else:
         logger.warning("Unsupported manifest source path: %s", path)
 
@@ -442,9 +487,13 @@ class LocalAppPackageAdapter(ManifestAcquisitionAdapter):
     def __init__(self, root: Path, id_map: Optional[dict[str, str]] = None) -> None:
         self.root = root
         self.id_map = id_map
+        #: Locators of manifests that could not be opened/parsed during the most
+        #: recent iter_records() pass (drives the run's manifests_failed counter).
+        self.failures: list[str] = []
 
     def iter_records(self) -> Iterator[ManifestRecord]:
-        yield from load_manifests_from_path(self.root, self.id_map)
+        self.failures = []
+        yield from load_manifests_from_path(self.root, self.id_map, self.failures)
 
 
 class SourceRepoAdapter(ManifestAcquisitionAdapter):
@@ -460,9 +509,13 @@ class SourceRepoAdapter(ManifestAcquisitionAdapter):
     def __init__(self, root: Path, id_map: Optional[dict[str, str]] = None) -> None:
         self.root = root
         self.id_map = id_map
+        #: Locators of manifests that could not be opened/parsed during the most
+        #: recent iter_records() pass (drives the run's manifests_failed counter).
+        self.failures: list[str] = []
 
     def iter_records(self) -> Iterator[ManifestRecord]:
-        yield from load_manifests_from_dir(self.root, self.id_map)
+        self.failures = []
+        yield from load_manifests_from_dir(self.root, self.id_map, self.failures)
 
 
 class FutureExportAdapter(ManifestAcquisitionAdapter):
@@ -507,14 +560,21 @@ class DetectionRun:
     manifests_scanned: int = 0
     people_detected: int = 0
     provisional_ids: int = 0
+    manifests_failed: int = 0
 
     def summary(self, source_label: str) -> dict:
+        # A non-zero manifests_failed means the fleet was only partially read, so
+        # the scan must NOT be reported as a clean/complete pass: a corrupt or
+        # unzippable manifest is invisible to detection and would otherwise read
+        # as "0 detections, all green".
         return {
             "runId": self.run_id,
             "detectionSource": source_label,
             "manifestsScanned": self.manifests_scanned,
             "peopleDetected": self.people_detected,
             "provisionalAgentIds": self.provisional_ids,
+            "manifestsFailed": self.manifests_failed,
+            "scanStatus": "Partial" if self.manifests_failed else "Complete",
         }
 
 
@@ -557,6 +617,17 @@ def detect_over_adapter(
             "manifestVersion": detection.manifest_version,
             "includeRelatedContent": detection.include_related_content,
         })
+    # Manifests that failed to open/parse are tracked on the adapter (the
+    # iter_records() seam stays argument-free); fold the count into the run so the
+    # summary/artifact can surface a Partial scan.
+    failures = getattr(adapter, "failures", [])
+    run.manifests_failed = len(failures)
+    if failures:
+        logger.warning(
+            "%d manifest(s) could not be read during this scan and were skipped; "
+            "the scan is Partial, not a clean pass: %s",
+            len(failures), ", ".join(str(f) for f in failures[:10]),
+        )
     return run
 
 
@@ -637,6 +708,9 @@ def main() -> None:
     if run.provisional_ids:
         logger.warning("%d detected agent(s) have PROVISIONAL ids - reconcile via --id-map.",
                        run.provisional_ids)
+    if run.manifests_failed:
+        logger.warning("%d manifest(s) could not be read; scan is PARTIAL, not a clean pass.",
+                       run.manifests_failed)
 
     if args.output:
         Path(args.output).write_text(json.dumps(artifact, indent=2), encoding="utf-8")

--- a/copilot-agent-inventory/scripts/detect_people_capability.py
+++ b/copilot-agent-inventory/scripts/detect_people_capability.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+"""Detect the declarative-agent **People** capability from agent manifests.
+
+The Agent Builder toggle *"Reference org chart and profile info"* maps to the
+declarative-agent manifest capability ``{ "name": "People" }`` inside
+``declarativeAgent.json`` (manifest schema v1.5-v1.7). This capability is NOT a
+Copilot Studio ``botcomponent`` and is NOT returned by any public API for a
+*deployed* agent (verified in GATE0a). Capability-level detection therefore
+requires the source manifest itself, obtained from the agent app package or from
+source control. This module:
+
+  * Parses a ``declarativeAgent.json`` (or an app-package ``.zip``, or a
+    directory of packages) and extracts ``capabilities[]``.
+  * Detects ``name == "People"`` as a **case-sensitive literal**, independent of
+    the manifest ``version`` (the const is unchanged across v1.5-v1.7).
+  * Captures the optional v1.7 ``include_related_content`` sub-setting.
+  * Emits one ``fsi_caiagentfeature`` row (logical column names) per detected
+    agent, using the feature type ``People (Org Chart & Profile)``, a
+    provenance marker (``fsi_detectionsource``), and a confidence marker
+    (``fsi_detectionconfidence = "Declared (Manifest)"``).
+
+**Declared is not effective.** A manifest capability is *authored/available*;
+the v1.7 ``user_overrides`` mechanism lets a consuming user remove a capability
+at runtime, and tenant policy may gate grounding. For a governance inventory of
+what an agent is *built with*, the manifest ``capabilities[].name == "People"``
+signal is correct; per-user effective state is a separate, non-queryable concern.
+
+**Agent-id linkage caveat.** A declarative-agent manifest does not contain the
+Dataverse ``bot`` GUID that keys ``fsi_copilotagent``. When no ``--id-map`` is
+supplied, the resolved ``fsi_agentid`` is *provisional* (the manifest/app id) and
+is flagged as such so the orchestrator can reconcile it before the row joins the
+canonical store or feeds Copilot Billing Governance (CBG).
+
+Acquisition-adapter seam: ``ManifestAcquisitionAdapter`` defines the contract;
+``LocalAppPackageAdapter`` and ``SourceRepoAdapter`` are implemented now, and
+``FutureExportAdapter`` is a clearly-marked seam for a future scalable export
+path (a sibling spike is resolving whether a supported one exists).
+
+Usage:
+  # Dry run over a local directory of app packages (logs planned work)
+  python detect_people_capability.py --source local-package --path ./packages --dry-run
+
+  # Scan a source/CI repo tree and write the detection artifact
+  python detect_people_capability.py --source source-repo --path ../my-agent-repo \
+      --id-map ./agent-id-map.json --environment-id <envGuid> --output people.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import zipfile
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+logger = logging.getLogger("detect_people_capability")
+
+# =============================================================================
+# Detection constants (verified against R1 / GATE0a)
+# =============================================================================
+
+# Case-sensitive const from the declarative-agent manifest JSON Schema; the
+# value is unchanged across schema v1.5, v1.6 and v1.7.
+PEOPLE_CAPABILITY_NAME = "People"
+
+# fsi_cai_featuretype label for the People capability (see create_cai_dataverse_schema.py).
+PEOPLE_FEATURE_TYPE = "People (Org Chart & Profile)"
+
+# fsi_cai_detectionconfidence label: manifest capabilities are declared/available.
+CONFIDENCE_DECLARED = "Declared (Manifest)"
+
+# fsi_cai_detectionsource labels - must match the option-set labels exactly.
+SOURCE_LOCAL_PACKAGE = "Declarative Manifest (Local App Package)"
+SOURCE_SOURCE_REPO = "Declarative Manifest (Source/CI Repo)"
+SOURCE_EXPORT_FUTURE = "Declarative Manifest (Export Adapter - Future)"
+
+# The manifest navigation path the feature was matched through (mirrors the
+# botcomponent relationship-name convention used by discover_agents.py).
+PEOPLE_RELATIONSHIP = "declarativeAgent.capabilities"
+
+# A stable per-agent source-object id so re-detection upserts one People row
+# (the fsi_caiagentfeature alternate key is fsi_agentid + fsi_sourceobjectid).
+PEOPLE_SOURCE_OBJECT_ID = "capability:People"
+
+# Conventional manifest filenames inside an app package / repo (case-insensitive).
+APP_MANIFEST_NAMES = {"manifest.json"}
+DECLARATIVE_AGENT_HINT = "declarativeagent"  # matches declarativeAgent*.json
+
+
+# =============================================================================
+# Pure detection helpers (side-effect free; unit-tested)
+# =============================================================================
+
+
+@dataclass
+class PeopleDetection:
+    """Result of testing one manifest for the People capability."""
+
+    detected: bool
+    include_related_content: Optional[bool] = None
+    manifest_version: Optional[str] = None
+    schema_url: Optional[str] = None
+    raw_capability: Optional[dict] = None
+
+
+def extract_capabilities(manifest: Any) -> list[dict]:
+    """Return the manifest ``capabilities[]`` as a list of dicts (fail-open).
+
+    Tolerates a missing array, a non-list value, or non-dict entries - platform
+    drift surfaces as "no capability detected" rather than an exception.
+    """
+    if not isinstance(manifest, dict):
+        logger.warning("Manifest is not a JSON object (fail-open): %r", type(manifest))
+        return []
+    capabilities = manifest.get("capabilities")
+    if capabilities is None:
+        return []
+    if not isinstance(capabilities, list):
+        logger.warning("capabilities is not a list (fail-open): %r", type(capabilities))
+        return []
+    return [c for c in capabilities if isinstance(c, dict)]
+
+
+def parse_manifest_version(manifest: Any) -> tuple[Optional[str], Optional[str]]:
+    """Best-effort (version, schema_url) extraction from a declarative manifest.
+
+    Reads the top-level ``version`` field and/or parses the ``$schema`` URL
+    (e.g. ``.../declarative-agent/v1.7/schema.json`` -> ``1.7``). Detection does
+    NOT depend on either value; they are captured for provenance only.
+    """
+    if not isinstance(manifest, dict):
+        return (None, None)
+    version = manifest.get("version")
+    version = str(version) if version is not None else None
+    schema_url = manifest.get("$schema")
+    schema_url = str(schema_url) if schema_url is not None else None
+    if version is None and schema_url:
+        # Pull the v<major>.<minor> token out of the schema URL path.
+        for part in schema_url.replace("\\", "/").split("/"):
+            token = part.lower()
+            if token.startswith("v") and any(ch.isdigit() for ch in token):
+                version = token[1:]
+                break
+    return (version, schema_url)
+
+
+def detect_people_capability(manifest: Any) -> PeopleDetection:
+    """Test a parsed declarative-agent manifest for the People capability.
+
+    Matches ``capabilities[].name == "People"`` as a case-sensitive literal so a
+    lowercase ``"people"`` (or any other casing) does NOT match. Returns the
+    first matching capability object; the optional v1.7 ``include_related_content``
+    boolean is captured but does NOT gate detection (it is a sub-setting).
+    """
+    version, schema_url = parse_manifest_version(manifest)
+    for capability in extract_capabilities(manifest):
+        if capability.get("name") == PEOPLE_CAPABILITY_NAME:
+            irc = capability.get("include_related_content")
+            return PeopleDetection(
+                detected=True,
+                include_related_content=irc if isinstance(irc, bool) else None,
+                manifest_version=version,
+                schema_url=schema_url,
+                raw_capability=capability,
+            )
+    return PeopleDetection(detected=False, manifest_version=version, schema_url=schema_url)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def build_people_feature_record(
+    run_id: str,
+    agent_id: str,
+    agent_name: Optional[str],
+    environment_id: Optional[str],
+    detection: PeopleDetection,
+    source_label: str,
+    locator: str,
+    agent_id_provisional: bool,
+) -> dict:
+    """Build one ``fsi_caiagentfeature`` row for a detected People capability.
+
+    Field names are Dataverse LOGICAL names. Picklist fields carry the option-set
+    LABEL; the writer resolves the label to the integer value at upsert time
+    (the established CAI convention - see templates/agent-record.sample.json).
+    """
+    detail = {
+        "source": source_label,
+        "locator": locator,
+        "capabilityName": PEOPLE_CAPABILITY_NAME,
+        "manifestVersion": detection.manifest_version,
+        "schema": detection.schema_url,
+        "includeRelatedContent": detection.include_related_content,
+        "agentRefProvisional": agent_id_provisional,
+        "detectedAt": _utc_now_iso(),
+    }
+    display = agent_name or agent_id
+    return {
+        "fsi_name": f"{PEOPLE_FEATURE_TYPE}: {display}",
+        "fsi_agentid": agent_id,
+        "fsi_environmentid": environment_id,
+        "fsi_featuretype": PEOPLE_FEATURE_TYPE,
+        "fsi_componenttype": None,
+        "fsi_componentversion": "Not Applicable",
+        "fsi_sourceobjectid": PEOPLE_SOURCE_OBJECT_ID,
+        "fsi_sourceobjectname": PEOPLE_CAPABILITY_NAME,
+        "fsi_relationshipname": PEOPLE_RELATIONSHIP,
+        "fsi_detectionsource": source_label,
+        "fsi_detectionconfidence": CONFIDENCE_DECLARED,
+        "fsi_detectiondetail": json.dumps(detail),
+        "fsi_isenabled": True,
+        "fsi_lastscannedat": _utc_now_iso(),
+        "fsi_runid": run_id,
+    }
+
+
+# =============================================================================
+# Manifest loading (json file / app-package zip / directory)
+# =============================================================================
+
+
+@dataclass
+class ManifestRecord:
+    """One declarative-agent manifest located by an acquisition adapter."""
+
+    agent_id: str
+    agent_name: Optional[str]
+    locator: str
+    manifest: dict
+    app_manifest: Optional[dict] = None
+    agent_id_provisional: bool = True
+
+
+def _declarative_files_from_app_manifest(app_manifest: dict) -> list[str]:
+    """Return declarativeAgent.json file refs from an app manifest's copilotAgents node."""
+    refs: list[str] = []
+    copilot_agents = app_manifest.get("copilotAgents")
+    if isinstance(copilot_agents, dict):
+        for entry in copilot_agents.get("declarativeAgents", []) or []:
+            if isinstance(entry, dict) and entry.get("file"):
+                refs.append(str(entry["file"]))
+    return refs
+
+
+def _resolve_agent_identity(
+    manifest: dict,
+    app_manifest: Optional[dict],
+    locator: str,
+    id_map: Optional[dict[str, str]],
+) -> tuple[str, Optional[str], bool]:
+    """Resolve (agent_id, agent_name, provisional) for one manifest.
+
+    Prefers an explicit ``--id-map`` entry keyed by app id, declarative-agent id,
+    or the locator's file stem (this is how a caller binds a manifest to the
+    Dataverse bot GUID). With no mapping, the agent id is the best available
+    manifest identifier and is flagged provisional.
+    """
+    app_id = str(app_manifest.get("id")) if isinstance(app_manifest, dict) and app_manifest.get("id") else None
+    da_id = str(manifest.get("id")) if manifest.get("id") else None
+    stem = Path(locator.split("::")[-1]).stem
+    agent_name = (
+        manifest.get("name")
+        or (app_manifest.get("name", {}).get("short") if isinstance(app_manifest, dict)
+            and isinstance(app_manifest.get("name"), dict) else None)
+        or (app_manifest.get("name") if isinstance(app_manifest, dict)
+            and isinstance(app_manifest.get("name"), str) else None)
+    )
+    id_map = id_map or {}
+    for candidate in (app_id, da_id, stem):
+        if candidate and candidate in id_map:
+            return (id_map[candidate], agent_name, False)
+    provisional_id = da_id or app_id or stem
+    return (provisional_id, agent_name, True)
+
+
+def _read_json_bytes(data: bytes, locator: str) -> Optional[dict]:
+    try:
+        parsed = json.loads(data.decode("utf-8-sig"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        logger.warning("Could not parse JSON at %s (fail-open): %s", locator, exc)
+        return None
+    if not isinstance(parsed, dict):
+        logger.warning("JSON at %s is not an object (fail-open)", locator)
+        return None
+    return parsed
+
+
+def load_manifests_from_zip(
+    zip_path: Path, id_map: Optional[dict[str, str]] = None
+) -> Iterator[ManifestRecord]:
+    """Yield ManifestRecords from a Microsoft 365 app-package ``.zip``.
+
+    Reads the app ``manifest.json`` to find the ``copilotAgents`` declarative
+    agent file refs; falls back to any ``declarativeAgent*.json`` in the package
+    when the app manifest is absent or does not reference one.
+    """
+    try:
+        with zipfile.ZipFile(zip_path) as archive:
+            names = archive.namelist()
+            app_manifest: Optional[dict] = None
+            app_manifest_name = next(
+                (n for n in names if Path(n).name.lower() in APP_MANIFEST_NAMES), None
+            )
+            if app_manifest_name:
+                app_manifest = _read_json_bytes(
+                    archive.read(app_manifest_name), f"{zip_path}::{app_manifest_name}"
+                )
+
+            da_files: list[str] = []
+            if app_manifest:
+                for ref in _declarative_files_from_app_manifest(app_manifest):
+                    match = next((n for n in names if Path(n).name == Path(ref).name), None)
+                    if match:
+                        da_files.append(match)
+            if not da_files:
+                da_files = [
+                    n for n in names
+                    if DECLARATIVE_AGENT_HINT in Path(n).name.lower()
+                    and n.lower().endswith(".json")
+                ]
+            if not da_files:
+                logger.warning("No declarativeAgent.json found in package %s", zip_path)
+                return
+
+            for da_name in da_files:
+                locator = f"{zip_path}::{da_name}"
+                manifest = _read_json_bytes(archive.read(da_name), locator)
+                if manifest is None:
+                    continue
+                agent_id, agent_name, provisional = _resolve_agent_identity(
+                    manifest, app_manifest, locator, id_map
+                )
+                yield ManifestRecord(
+                    agent_id=agent_id, agent_name=agent_name, locator=locator,
+                    manifest=manifest, app_manifest=app_manifest,
+                    agent_id_provisional=provisional,
+                )
+    except (zipfile.BadZipFile, OSError) as exc:
+        logger.warning("Could not open app package %s (fail-open): %s", zip_path, exc)
+
+
+def load_manifest_from_json_file(
+    json_path: Path, id_map: Optional[dict[str, str]] = None
+) -> Iterator[ManifestRecord]:
+    """Yield a single ManifestRecord from a loose ``declarativeAgent.json`` file."""
+    try:
+        manifest = _read_json_bytes(json_path.read_bytes(), str(json_path))
+    except OSError as exc:
+        logger.warning("Could not read manifest %s (fail-open): %s", json_path, exc)
+        return
+    if manifest is None:
+        return
+    # An adjacent app manifest (same directory) helps resolve identity if present.
+    app_manifest: Optional[dict] = None
+    sibling = json_path.parent / "manifest.json"
+    if sibling.is_file() and sibling != json_path:
+        try:
+            app_manifest = _read_json_bytes(sibling.read_bytes(), str(sibling))
+        except OSError:
+            app_manifest = None
+    agent_id, agent_name, provisional = _resolve_agent_identity(
+        manifest, app_manifest, str(json_path), id_map
+    )
+    yield ManifestRecord(
+        agent_id=agent_id, agent_name=agent_name, locator=str(json_path),
+        manifest=manifest, app_manifest=app_manifest, agent_id_provisional=provisional,
+    )
+
+
+def _is_declarative_agent_json(path: Path) -> bool:
+    return (
+        path.suffix.lower() == ".json"
+        and DECLARATIVE_AGENT_HINT in path.name.lower()
+    )
+
+
+def load_manifests_from_dir(
+    root: Path, id_map: Optional[dict[str, str]] = None
+) -> Iterator[ManifestRecord]:
+    """Recursively yield ManifestRecords from app-package zips and loose manifests."""
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() == ".zip":
+            yield from load_manifests_from_zip(path, id_map)
+        elif _is_declarative_agent_json(path):
+            yield from load_manifest_from_json_file(path, id_map)
+
+
+def load_manifests_from_path(
+    path: Path, id_map: Optional[dict[str, str]] = None
+) -> Iterator[ManifestRecord]:
+    """Dispatch on a path that may be a directory, an app-package zip, or a JSON file."""
+    if path.is_dir():
+        yield from load_manifests_from_dir(path, id_map)
+    elif path.suffix.lower() == ".zip":
+        yield from load_manifests_from_zip(path, id_map)
+    elif path.suffix.lower() == ".json":
+        yield from load_manifest_from_json_file(path, id_map)
+    else:
+        logger.warning("Unsupported manifest source path: %s", path)
+
+
+# =============================================================================
+# Acquisition-adapter seam
+# =============================================================================
+
+
+class ManifestAcquisitionAdapter(ABC):
+    """Contract for sourcing declarative-agent manifests for People detection.
+
+    The detection logic is manifest-source-agnostic: any adapter that can yield
+    ManifestRecords plugs in here. Two adapters are implemented now; a future
+    scalable export adapter is reserved as a clearly-marked seam.
+    """
+
+    #: fsi_cai_detectionsource label stamped onto rows from this adapter.
+    provenance_label: str = SOURCE_EXPORT_FUTURE
+
+    @abstractmethod
+    def iter_records(self) -> Iterator[ManifestRecord]:
+        """Yield ManifestRecords from the underlying source."""
+        raise NotImplementedError
+
+
+class LocalAppPackageAdapter(ManifestAcquisitionAdapter):
+    """Adapter (a): a local directory of deployed app packages (and/or manifests).
+
+    ``root`` may be a directory of ``.zip`` app packages, a single ``.zip``, or a
+    loose ``declarativeAgent.json``. Suitable for packages exported/downloaded
+    from Teams Admin Center or staged on disk.
+    """
+
+    provenance_label = SOURCE_LOCAL_PACKAGE
+
+    def __init__(self, root: Path, id_map: Optional[dict[str, str]] = None) -> None:
+        self.root = root
+        self.id_map = id_map
+
+    def iter_records(self) -> Iterator[ManifestRecord]:
+        yield from load_manifests_from_path(self.root, self.id_map)
+
+
+class SourceRepoAdapter(ManifestAcquisitionAdapter):
+    """Adapter (b): a source/CI repo tree (Microsoft 365 Agents Toolkit layout).
+
+    Walks the tree for ``appPackage/declarativeAgent.json`` (and any
+    ``declarativeAgent*.json``) checked into source control or produced as a CI
+    build artifact - the highest-fidelity source for org-built LOB agents.
+    """
+
+    provenance_label = SOURCE_SOURCE_REPO
+
+    def __init__(self, root: Path, id_map: Optional[dict[str, str]] = None) -> None:
+        self.root = root
+        self.id_map = id_map
+
+    def iter_records(self) -> Iterator[ManifestRecord]:
+        yield from load_manifests_from_dir(self.root, self.id_map)
+
+
+class FutureExportAdapter(ManifestAcquisitionAdapter):
+    """SEAM (reserved): a future scalable manifest-export source.
+
+    GATE0a found no supported public API that returns the parsed
+    ``capabilities[]`` for a *deployed* agent at fleet scale. A sibling spike is
+    resolving whether a scalable export (e.g., a future Microsoft Agent 365
+    inventory surface) exists. This class is the integration point; do NOT block
+    on it. Wire the real source in here and set ``provenance_label =
+    SOURCE_EXPORT_FUTURE`` once a supported path is confirmed.
+    """
+
+    provenance_label = SOURCE_EXPORT_FUTURE
+
+    def iter_records(self) -> Iterator[ManifestRecord]:
+        raise NotImplementedError(
+            "No supported scalable manifest-export adapter exists yet (GATE0a). "
+            "Use LocalAppPackageAdapter or SourceRepoAdapter; a sibling spike is "
+            "resolving the scalable export path."
+        )
+
+
+ADAPTERS: dict[str, type[ManifestAcquisitionAdapter]] = {
+    "local-package": LocalAppPackageAdapter,
+    "source-repo": SourceRepoAdapter,
+}
+
+
+# =============================================================================
+# Detection over an adapter
+# =============================================================================
+
+
+@dataclass
+class DetectionRun:
+    """Aggregate outcome of a People-capability detection pass."""
+
+    run_id: str
+    features: list[dict] = field(default_factory=list)
+    agents: list[dict] = field(default_factory=list)
+    manifests_scanned: int = 0
+    people_detected: int = 0
+    provisional_ids: int = 0
+
+    def summary(self, source_label: str) -> dict:
+        return {
+            "runId": self.run_id,
+            "detectionSource": source_label,
+            "manifestsScanned": self.manifests_scanned,
+            "peopleDetected": self.people_detected,
+            "provisionalAgentIds": self.provisional_ids,
+        }
+
+
+def detect_over_adapter(
+    adapter: ManifestAcquisitionAdapter,
+    run_id: str,
+    environment_id: Optional[str] = None,
+) -> DetectionRun:
+    """Run People detection over every manifest an adapter yields."""
+    run = DetectionRun(run_id=run_id)
+    for record in adapter.iter_records():
+        run.manifests_scanned += 1
+        detection = detect_people_capability(record.manifest)
+        if not detection.detected:
+            continue
+        run.people_detected += 1
+        if record.agent_id_provisional:
+            run.provisional_ids += 1
+            logger.warning(
+                "People detected for %s but agent id is PROVISIONAL (%s); supply "
+                "--id-map to bind it to the Dataverse bot GUID before joining CAI/CBG.",
+                record.agent_name or record.locator, record.agent_id,
+            )
+        feature = build_people_feature_record(
+            run_id=run_id,
+            agent_id=record.agent_id,
+            agent_name=record.agent_name,
+            environment_id=environment_id,
+            detection=detection,
+            source_label=adapter.provenance_label,
+            locator=record.locator,
+            agent_id_provisional=record.agent_id_provisional,
+        )
+        run.features.append(feature)
+        run.agents.append({
+            "agentId": record.agent_id,
+            "agentName": record.agent_name,
+            "agentIdProvisional": record.agent_id_provisional,
+            "locator": record.locator,
+            "manifestVersion": detection.manifest_version,
+            "includeRelatedContent": detection.include_related_content,
+        })
+    return run
+
+
+def _load_id_map(path: Optional[str]) -> Optional[dict[str, str]]:
+    if not path:
+        return None
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"Could not read --id-map {path}: {exc}")
+    if not isinstance(data, dict):
+        raise SystemExit("--id-map must be a JSON object mapping manifest/app id -> bot GUID")
+    return {str(k): str(v) for k, v in data.items()}
+
+
+# =============================================================================
+# CLI Entry Point
+# =============================================================================
+
+
+def main() -> None:
+    """CLI entry point for People-capability detection."""
+    parser = argparse.ArgumentParser(
+        description="Detect the declarative-agent People capability from manifests",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  # Dry run over a directory of app packages\n"
+            "  python detect_people_capability.py --source local-package "
+            "--path ./packages --dry-run\n\n"
+            "  # Scan a source repo and write the detection artifact\n"
+            "  python detect_people_capability.py --source source-repo "
+            "--path ../agent-repo --id-map ids.json --output people.json\n"
+        ),
+    )
+    parser.add_argument("--source", choices=sorted(ADAPTERS), default="local-package",
+                        help="Manifest-acquisition adapter to use")
+    parser.add_argument("--path", required=True,
+                        help="Path to a directory, an app-package .zip, or a declarativeAgent.json")
+    parser.add_argument("--id-map", default=None,
+                        help="JSON map of app/declarative-agent id (or file stem) -> Dataverse bot GUID")
+    parser.add_argument("--environment-id", default=None,
+                        help="Power Platform environment GUID to stamp on emitted feature rows")
+    parser.add_argument("--run-id", default=None,
+                        help="Scan run correlation id (default: generated)")
+    parser.add_argument("--output", default=None,
+                        help="Write the detection artifact JSON to this path")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Log the planned adapter and source path without scanning")
+    parser.add_argument("--log-level", default="INFO",
+                        help="Logging level (DEBUG, INFO, WARNING, ERROR)")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    run_id = args.run_id or f"cai-people-{int(datetime.now(timezone.utc).timestamp())}"
+    adapter_cls = ADAPTERS[args.source]
+
+    if args.dry_run:
+        logger.info("[DRY RUN] would scan %s via %s (provenance: %s)",
+                    args.path, adapter_cls.__name__, adapter_cls.provenance_label)
+        return
+
+    id_map = _load_id_map(args.id_map)
+    adapter = adapter_cls(Path(args.path), id_map=id_map)
+    run = detect_over_adapter(adapter, run_id, environment_id=args.environment_id)
+
+    artifact = {
+        "schemaVersion": "0.2.0-preview",
+        "summary": run.summary(adapter.provenance_label),
+        "agents": run.agents,
+        "features": run.features,
+    }
+    logger.info("People detection summary: %s", json.dumps(run.summary(adapter.provenance_label)))
+    if run.provisional_ids:
+        logger.warning("%d detected agent(s) have PROVISIONAL ids - reconcile via --id-map.",
+                       run.provisional_ids)
+
+    if args.output:
+        Path(args.output).write_text(json.dumps(artifact, indent=2), encoding="utf-8")
+        logger.info("Wrote detection artifact to %s", args.output)
+    else:
+        print(json.dumps(artifact, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/copilot-agent-inventory/scripts/discover_agents.py
+++ b/copilot-agent-inventory/scripts/discover_agents.py
@@ -524,7 +524,13 @@ def _feature_record(
     component_type: Any,
     relationship: str,
 ) -> dict:
-    """Build one fsi_caiagentfeature row (logical column names)."""
+    """Build one fsi_caiagentfeature row (logical column names).
+
+    Botcomponent-derived rows are stamped with the Dataverse provenance and a
+    "Configured (Dataverse)" confidence marker. Manifest-derived rows (e.g., the
+    People capability detected by detect_people_capability.py) carry their own
+    "Declared (Manifest)" marker — declared is NOT the same as effective.
+    """
     return {
         "fsi_agentid": bot_id,
         "fsi_featuretype": feature_type,
@@ -533,6 +539,8 @@ def _feature_record(
         "fsi_sourceobjectid": source_object_id,
         "fsi_sourceobjectname": source_object_name,
         "fsi_relationshipname": relationship,
+        "fsi_detectionsource": "Dataverse Botcomponent Scan",
+        "fsi_detectionconfidence": "Configured (Dataverse)",
         "fsi_isenabled": True,
         "fsi_runid": ctx.run_id,
     }

--- a/copilot-agent-inventory/scripts/discover_agents.py
+++ b/copilot-agent-inventory/scripts/discover_agents.py
@@ -130,10 +130,12 @@ MM_RELATIONSHIPS: dict[str, tuple[str, str]] = {
 }
 
 # Widened $select on the bot table (the legacy registry scan omitted authMode,
-# createdon, modifiedon — all needed for the canonical Agent record).
+# createdon, modifiedon - all needed for the canonical Agent record). The
+# accesscontrolpolicy + authorizedsecuritygroupids columns carry the per-agent
+# sharing posture used to derive whole-tenant reach (fsi_sharedwitheveryone).
 BOT_SELECT = (
     "botid,name,schemaname,statecode,statuscode,authenticationmode,"
-    "createdon,modifiedon,_ownerid_value"
+    "createdon,modifiedon,_ownerid_value,accesscontrolpolicy,authorizedsecuritygroupids"
 )
 
 
@@ -546,6 +548,68 @@ def _feature_record(
     }
 
 
+# The bot.accesscontrolpolicy option-set: 0 = "Any" (everyone in the org) and
+# 3 = "Any (multi-tenant)" (everyone + external) both mean the agent is reachable
+# org-wide; 2 = specific security groups and 1 = a more restrictive policy are NOT
+# whole-tenant. Values verified against unrestricted-agent-sharing-detector
+# (SOLUTION-DOCUMENTATION.md: accesscontrolpolicy 0=Any, 2=security groups,
+# 3=Any (multi-tenant)).
+ORG_WIDE_ACCESS_POLICIES = frozenset({0, 3})
+RESTRICTED_ACCESS_POLICIES = frozenset({1, 2})
+
+
+def derive_shared_with_everyone(bot: dict) -> Optional[bool]:
+    """Derive per-agent whole-tenant reach from the bot accesscontrolpolicy.
+
+    Returns True for an org-wide policy (Any / Any multi-tenant), False for a
+    restricted policy (security groups / more restrictive), and None when the
+    signal is absent or unparseable. None is deliberate: it must NOT be coerced to
+    False, because expand_audience_upns.py treats an unset fsi_sharedwitheveryone
+    as an unknown whole-tenant signal and marks the audience Partial rather than
+    emitting a confident empty audience for a possibly tenant-reachable agent.
+
+    This is a PER-AGENT signal and must never be confused with the
+    environment-wide bot-limitSharingMode policy.
+    """
+    raw = bot.get("accesscontrolpolicy")
+    if raw is None or isinstance(raw, bool):
+        return None
+    try:
+        policy = int(raw)
+    except (TypeError, ValueError):
+        return None
+    if policy in ORG_WIDE_ACCESS_POLICIES:
+        return True
+    if policy in RESTRICTED_ACCESS_POLICIES:
+        return False
+    return None
+
+
+def _authshare_record(ctx: ScanContext, bot: dict) -> dict:
+    """Build one fsi_caiauthshare row capturing the agent's sharing posture.
+
+    Stamps fsi_sharedwitheveryone from the per-agent accesscontrolpolicy signal.
+    When the signal is unknown (derive_shared_with_everyone returns None) the
+    column is intentionally left OFF the record so the Dataverse value stays unset
+    and the downstream audience expander marks the agent Partial instead of
+    asserting a confident empty audience.
+    """
+    record = {
+        "fsi_agentid": bot.get("botid", ""),
+        "fsi_authmode": bot.get("authenticationmode"),
+        "fsi_runid": ctx.run_id,
+    }
+    groups = bot.get("authorizedsecuritygroupids")
+    if groups:
+        record["fsi_viewergroups"] = json.dumps(
+            [g.strip() for g in str(groups).split(",") if g.strip()]
+        )
+    shared_everyone = derive_shared_with_everyone(bot)
+    if shared_everyone is not None:
+        record["fsi_sharedwitheveryone"] = shared_everyone
+    return record
+
+
 # =============================================================================
 # Mapping + classification
 # =============================================================================
@@ -664,7 +728,7 @@ def _scan_one_environment(
     env_url = environment.get("url") or environment.get("instanceUrl") or ""
     env_id = environment.get("name") or environment.get("id") or ""
     result = {"environmentId": env_id, "agents": [], "features": [],
-              "deltaLink": None}
+              "authShares": [], "deltaLink": None}
     try:
         bots, delta_link = scan_environment_bots(ctx, session, env_url)
         # Thread the delta link into the result instead of discarding it; a
@@ -679,6 +743,11 @@ def _scan_one_environment(
                 result["features"].extend(
                     scan_bot_features(ctx, session, env_url, bot_id)
                 )
+                authshare = _authshare_record(ctx, bot)
+                authshare["fsi_environmentid"] = (
+                    authshare.get("fsi_environmentid") or env_id
+                )
+                result["authShares"].append(authshare)
     except Exception as exc:  # one bad env must not abort the tenant scan
         logger.warning("Environment %s scan failed (fail-open): %s", env_id, exc)
     return result
@@ -737,6 +806,7 @@ def scan_all(ctx: ScanContext) -> dict:
     environments = enumerate_environments(ctx, session)
     scanned_agents: list[dict] = []
     features: list[dict] = []
+    auth_shares: list[dict] = []
 
     # Throttled concurrent per-environment fan-out (~10 workers, 429 backoff).
     with ThreadPoolExecutor(max_workers=ctx.max_workers) as pool:
@@ -748,6 +818,7 @@ def scan_all(ctx: ScanContext) -> dict:
             outcome = future.result()
             scanned_agents.extend(outcome["agents"])
             features.extend(outcome["features"])
+            auth_shares.extend(outcome.get("authShares", []))
 
     reconciliation = reconcile_sources(arg_agents, scanned_agents)
     summary = {
@@ -755,6 +826,7 @@ def scan_all(ctx: ScanContext) -> dict:
         "argAgentCount": len(arg_agents),
         "scannedAgentCount": len(scanned_agents),
         "featureCount": len(features),
+        "authShareCount": len(auth_shares),
         "environmentCount": len(environments),
         "reconciliation": reconciliation,
     }
@@ -763,6 +835,7 @@ def scan_all(ctx: ScanContext) -> dict:
         "summary": summary,
         "agents": arg_agents or scanned_agents,
         "features": features,
+        "authShares": auth_shares,
     }
 
 

--- a/copilot-agent-inventory/scripts/expand_audience_upns.py
+++ b/copilot-agent-inventory/scripts/expand_audience_upns.py
@@ -57,6 +57,12 @@ GRAPH_SCOPE = "https://graph.microsoft.com/.default"
 GRAPH_PAGE_SIZE = 999
 MAX_BACKOFF_SECONDS = 60
 
+# Refresh the Graph access token when it is within this window of expiry. A long
+# audience-expansion run can exceed the ~60-minute token lifetime, so the token
+# is re-acquired per request once it nears expiry rather than cached for the
+# whole resolver lifetime (which previously caused 401s on late agents).
+TOKEN_REFRESH_SKEW_SECONDS = 300
+
 DEFAULT_MAX_MEMBERS_PER_GROUP = 1000
 DEFAULT_WHOLE_TENANT_CAP = 0  # 0 = never enumerate the tenant for whole-tenant shares
 
@@ -76,6 +82,54 @@ STATUS_PARTIAL = "Partial"
 STATUS_WHOLE_TENANT = "WholeTenantNotEnumerated"
 STATUS_FAILED = "Failed"
 STATUS_NOT_RESOLVED = "NotResolved"
+
+
+# =============================================================================
+# Pure HTTP / OData helpers
+# =============================================================================
+
+
+def _parse_retry_after(value: Optional[str], fallback: float) -> float:
+    """Parse an HTTP ``Retry-After`` header into a delay in seconds.
+
+    ``Retry-After`` is either a non-negative number of seconds or an RFC 7231
+    HTTP-date (e.g. ``Wed, 21 Oct 2026 07:28:00 GMT``). A naive ``float(value)``
+    crashes on the date form; this helper tries int/float first, then falls back
+    to date parsing, and finally to ``fallback`` for missing/garbage values so a
+    throttled request never raises while computing its backoff.
+    """
+    if value is None:
+        return fallback
+    text = value.strip()
+    if not text:
+        return fallback
+    try:
+        seconds = float(text)
+        return seconds if seconds >= 0 else fallback
+    except ValueError:
+        pass
+    try:
+        from email.utils import parsedate_to_datetime
+
+        retry_at = parsedate_to_datetime(text)
+    except (TypeError, ValueError, IndexError):
+        return fallback
+    if retry_at is None:
+        return fallback
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=timezone.utc)
+    delta = (retry_at - datetime.now(timezone.utc)).total_seconds()
+    return delta if delta > 0 else fallback
+
+
+def _odata_escape(value: Any) -> str:
+    """Escape a string literal for an OData ``$filter`` (single quote -> doubled).
+
+    OData string literals are single-quoted; an unescaped quote in the value
+    breaks the query (and is an injection vector). Per the OData spec a literal
+    single quote is escaped by doubling it.
+    """
+    return str(value).replace("'", "''")
 
 
 # =============================================================================
@@ -217,10 +271,16 @@ def _derive_status(
     upn_count: int,
     truncated: bool,
     errors: list[dict],
+    tenant_signal_known: bool = True,
 ) -> str:
     if whole_tenant:
         return STATUS_WHOLE_TENANT
     if not had_refs:
+        if not tenant_signal_known:
+            # No sharing refs AND no per-agent whole-tenant signal: the posture is
+            # incomplete, so an empty audience cannot be asserted for a possibly
+            # tenant-reachable agent. Never emit a confident empty here.
+            return STATUS_PARTIAL
         # No groups or principals shared -> a cleanly empty audience.
         return STATUS_COMPLETE
     if errors and upn_count == 0:
@@ -228,6 +288,24 @@ def _derive_status(
     if errors or truncated:
         return STATUS_PARTIAL
     return STATUS_COMPLETE
+
+
+def _has_tenant_signal(agent: dict, had_refs: bool) -> bool:
+    """Return True when the posture carries a usable whole-tenant determination.
+
+    An explicit per-agent ``sharedWithEveryone`` / ``wholeTenant`` boolean, or any
+    viewer/editor refs to resolve, constitute a usable signal. A posture with none
+    of these (e.g. a Dataverse row whose ``fsi_sharedwitheveryone`` column is unset,
+    flagged via ``wholeTenantSignalKnown=False``) cannot be asserted as a confident
+    empty audience.
+    """
+    if isinstance(agent.get("sharedWithEveryone"), bool):
+        return True
+    if isinstance(agent.get("wholeTenant"), bool):
+        return True
+    if had_refs:
+        return True
+    return bool(agent.get("wholeTenantSignalKnown", True))
 
 
 def expand_agent_audience(
@@ -285,7 +363,17 @@ def expand_agent_audience(
                 errors.append({"ref": ref.display, "error": "unrecognized sharing reference"})
 
     upn_list = sorted(upns)
-    status = _derive_status(whole_tenant, had_refs, len(upn_list), any_truncated, errors)
+    tenant_signal_known = _has_tenant_signal(agent, had_refs)
+    if not whole_tenant and not had_refs and not tenant_signal_known:
+        logger.warning(
+            "Agent %s sharing posture has no whole-tenant signal "
+            "(fsi_sharedwitheveryone unset) and no viewer/editor refs; the audience "
+            "cannot be confirmed empty and is marked Partial. Populate "
+            "fsi_sharedwitheveryone during discovery to resolve.",
+            agent_id or "<unknown>",
+        )
+    status = _derive_status(whole_tenant, had_refs, len(upn_list), any_truncated,
+                            errors, tenant_signal_known)
 
     return {
         "agentId": agent_id,
@@ -372,7 +460,11 @@ class GraphMemberResolver:
         self.tenant_id = tenant_id
         self.client_id = client_id
         self.auth_mode = auth_mode
-        self._token: Optional[str] = None
+        # Hold the credential (not just a bearer string) for the resolver lifetime
+        # so the token can be refreshed per request; _access_token caches the most
+        # recent azure-identity AccessToken (token + expires_on epoch seconds).
+        self._credential_obj: Any = None
+        self._access_token: Any = None
         session = requests.Session()
         retry = Retry(total=5, backoff_factor=2,
                       status_forcelist=[429, 500, 502, 503, 504],
@@ -381,20 +473,37 @@ class GraphMemberResolver:
         self._session = session
 
     def _credential(self) -> Any:
-        import azure.identity as azid  # type: ignore
-        if self.auth_mode == "managed-identity":
-            return (azid.ManagedIdentityCredential(client_id=self.client_id)
-                    if self.client_id else azid.ManagedIdentityCredential())
-        if self.auth_mode == "workload-identity":
-            return azid.WorkloadIdentityCredential(tenant_id=self.tenant_id, client_id=self.client_id)
-        if self.auth_mode == "interactive":
-            return azid.InteractiveBrowserCredential(tenant_id=self.tenant_id, client_id=self.client_id)
-        return azid.DefaultAzureCredential()
+        if self._credential_obj is None:
+            import azure.identity as azid  # type: ignore
+            if self.auth_mode == "managed-identity":
+                self._credential_obj = (
+                    azid.ManagedIdentityCredential(client_id=self.client_id)
+                    if self.client_id else azid.ManagedIdentityCredential()
+                )
+            elif self.auth_mode == "workload-identity":
+                self._credential_obj = azid.WorkloadIdentityCredential(
+                    tenant_id=self.tenant_id, client_id=self.client_id)
+            elif self.auth_mode == "interactive":
+                self._credential_obj = azid.InteractiveBrowserCredential(
+                    tenant_id=self.tenant_id, client_id=self.client_id)
+            else:
+                self._credential_obj = azid.DefaultAzureCredential()
+        return self._credential_obj
+
+    def _bearer_token(self) -> str:
+        """Return a valid Graph bearer token, refreshing it as it nears expiry.
+
+        A long run can outlive the ~60-minute token lifetime; re-acquiring within
+        TOKEN_REFRESH_SKEW_SECONDS of expiry avoids the 401s that a lifetime-cached
+        token caused on late agents.
+        """
+        token = self._access_token
+        if token is None or (token.expires_on - time.time()) < TOKEN_REFRESH_SKEW_SECONDS:
+            self._access_token = self._credential().get_token(GRAPH_SCOPE)
+        return self._access_token.token
 
     def _headers(self) -> dict:
-        if self._token is None:
-            self._token = self._credential().get_token(GRAPH_SCOPE).token
-        return {"Authorization": f"Bearer {self._token}", "Accept": "application/json"}
+        return {"Authorization": f"Bearer {self._bearer_token()}", "Accept": "application/json"}
 
     def _get_with_backoff(self, url: str) -> Any:
         """GET with explicit 429-aware backoff that honors Retry-After.
@@ -413,7 +522,8 @@ class GraphMemberResolver:
             resp = self._session.get(url, headers=self._headers(), timeout=120)
             if resp.status_code != 429:
                 return resp
-            wait = float(resp.headers.get("Retry-After") or min(delay, MAX_BACKOFF_SECONDS))
+            wait = _parse_retry_after(resp.headers.get("Retry-After"),
+                                      min(delay, MAX_BACKOFF_SECONDS))
             logger.warning("429 throttled on %s; backing off %.1fs (attempt %d)",
                            url, wait, attempt + 1)
             time.sleep(wait)
@@ -489,7 +599,9 @@ def load_agents_from_dataverse(environment_url: str, tenant_id: str,
     """Read fsi_caiauthshare rows from Dataverse and map to the input shape.
 
     Uses the shared DataverseClient. fsi_viewergroups / fsi_editorprincipals are
-    stored as JSON memo columns; they are parsed back into lists here.
+    stored as JSON memo columns; they are parsed back into lists here. Whole-tenant
+    reach is read from the per-agent fsi_sharedwitheveryone boolean (NOT inferred
+    from the environment-wide fsi_limitsharingmode policy).
     """
     import sys
     shared_dir = Path(__file__).resolve().parent.parent.parent / "scripts" / "shared"
@@ -504,7 +616,7 @@ def load_agents_from_dataverse(environment_url: str, tenant_id: str,
     rows = client.query(
         "fsi_caiauthshares",
         select=["fsi_agentid", "fsi_environmentid", "fsi_viewergroups",
-                "fsi_editorprincipals", "fsi_limitsharingmode"],
+                "fsi_editorprincipals", "fsi_sharedwitheveryone"],
     ) or []
 
     def _parse(value: Any) -> list:
@@ -518,14 +630,23 @@ def load_agents_from_dataverse(environment_url: str, tenant_id: str,
 
     agents: list[dict] = []
     for row in rows:
-        agents.append({
+        agent: dict = {
             "fsi_agentid": row.get("fsi_agentid"),
             "fsi_environmentid": row.get("fsi_environmentid"),
             "viewerGroups": _parse(row.get("fsi_viewergroups")),
             "editorPrincipals": _parse(row.get("fsi_editorprincipals")),
-            "sharedWithEveryone": str(row.get("fsi_limitsharingmode") or "").lower() in
-            ("everyone", "noscope", "none"),
-        })
+        }
+        # Whole-tenant reach is a PER-AGENT signal read from fsi_sharedwitheveryone
+        # (populated during discovery from the bot accesscontrolpolicy). It is NOT
+        # inferred from the environment-wide fsi_limitsharingmode policy. When the
+        # column is unset, leave the signal unknown so a refless row is marked
+        # Partial rather than emitted as a confident empty audience.
+        shared_everyone = row.get("fsi_sharedwitheveryone")
+        if isinstance(shared_everyone, bool):
+            agent["sharedWithEveryone"] = shared_everyone
+        else:
+            agent["wholeTenantSignalKnown"] = False
+        agents.append(agent)
     return agents
 
 
@@ -640,7 +761,7 @@ def _write_back_authshare(updates: list[dict], args: argparse.Namespace) -> None
         existing = client.query(
             "fsi_caiauthshares",
             select=["fsi_caiauthshareid"],
-            filter_expr=f"fsi_agentid eq '{update['fsi_agentid']}'",
+            filter_expr=f"fsi_agentid eq '{_odata_escape(update['fsi_agentid'])}'",
             top=1,
         ) or []
         payload = {k: v for k, v in update.items() if k != "fsi_agentid"}

--- a/copilot-agent-inventory/scripts/expand_audience_upns.py
+++ b/copilot-agent-inventory/scripts/expand_audience_upns.py
@@ -1,0 +1,655 @@
+#!/usr/bin/env python3
+"""Expand an agent's sharing audience to concrete member UPNs (CBG input).
+
+Copilot Billing Governance (CBG) consumes a per-agent ``intendedUsers[]`` list of
+UPNs. The Copilot Agent Inventory ``fsi_caiauthshare`` row records the sharing
+*audience* as security-group references (``fsi_viewergroups`` /
+``fsi_editorprincipals`` / authorized security group ids), NOT enumerated users.
+This module bridges that gap: it expands each shared security group to its member
+UPNs via Microsoft Graph **transitive** membership
+(``GET /groups/{id}/transitiveMembers``, permission ``GroupMember.Read.All``),
+which flattens **nested groups** automatically.
+
+Defensive behaviours (accuracy is customer-facing):
+
+  * **"Everyone in the organization"** sharing is detected and marked with a
+    ``wholeTenant`` flag; the tenant is **never enumerated**. A configurable
+    ``--whole-tenant-cap`` is recorded for the downstream consumer but the
+    expansion emits an empty UPN list for whole-tenant audiences.
+  * **Per-group cap** (``--max-members-per-group``) bounds very large groups; the
+    audience is flagged ``truncated`` when a cap is hit so a partial list is never
+    mistaken for a complete one.
+  * **Throttling** (HTTP 429) uses Retry-After-aware exponential backoff; a group
+    that cannot be resolved records a per-group ``error`` rather than silently
+    dropping members.
+  * **De-duplication** across overlapping viewer/editor groups.
+  * **Agents with no sharing** resolve cleanly to an empty audience.
+
+Scope note: only the ``intendedUsers[].upn`` list is produced here (R5 gap #1).
+The per-user ``hasCopilotLicense`` / cohort flags are separate downstream gaps and
+are intentionally not populated by this module.
+
+The network-touching work lives in ``GraphMemberResolver``; the orchestration
+(``expand_agent_audience``) takes any resolver, so it is unit-tested without a
+live tenant. ``--dry-run`` logs planned work and contacts nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional, Protocol
+
+logger = logging.getLogger("expand_audience_upns")
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+GRAPH_PAGE_SIZE = 999
+MAX_BACKOFF_SECONDS = 60
+
+DEFAULT_MAX_MEMBERS_PER_GROUP = 1000
+DEFAULT_WHOLE_TENANT_CAP = 0  # 0 = never enumerate the tenant for whole-tenant shares
+
+# Strong "Everyone in the organization" sentinels (lowercased). Conservative on
+# purpose: a generic name like "All Users" can be a real distribution group, so
+# the preferred signal is an explicit marker (sharedWithEveryone / type=Everyone)
+# captured upstream. Override with --whole-tenant-sentinels.
+DEFAULT_WHOLE_TENANT_SENTINELS = (
+    "everyone",
+    "everyone in the organization",
+    "everyone except external users",
+)
+
+# fsi_audienceresolutionstatus values.
+STATUS_COMPLETE = "Complete"
+STATUS_PARTIAL = "Partial"
+STATUS_WHOLE_TENANT = "WholeTenantNotEnumerated"
+STATUS_FAILED = "Failed"
+STATUS_NOT_RESOLVED = "NotResolved"
+
+
+# =============================================================================
+# Reference normalization (pure)
+# =============================================================================
+
+
+@dataclass
+class NormalizedRef:
+    """A normalized sharing reference resolved from heterogeneous input."""
+
+    kind: str  # "group" | "user_upn" | "user_id" | "whole_tenant" | "unknown"
+    value: Optional[str] = None
+    display: Optional[str] = None
+
+
+def _looks_like_upn(text: str) -> bool:
+    return "@" in text
+
+
+def _whole_tenant_match(text: Optional[str], sentinels: tuple[str, ...]) -> bool:
+    return bool(text) and text.strip().lower() in sentinels
+
+
+def _ref_id(raw: dict) -> Optional[str]:
+    for key in ("id", "groupId", "objectId", "principalId", "value"):
+        if raw.get(key):
+            return str(raw[key])
+    return None
+
+
+def _ref_type(raw: dict) -> str:
+    return str(raw.get("type") or raw.get("principalType") or raw.get("@odata.type") or "").lower()
+
+
+def normalize_group_ref(raw: Any, sentinels: tuple[str, ...]) -> NormalizedRef:
+    """Normalize a viewer/authorized-security-group reference to a NormalizedRef.
+
+    In this context a bare GUID is a group id (these are security-group ids).
+    """
+    if isinstance(raw, str):
+        text = raw.strip()
+        if _whole_tenant_match(text, sentinels):
+            return NormalizedRef("whole_tenant", display=text)
+        return NormalizedRef("group", value=text, display=text)
+    if isinstance(raw, dict):
+        display = raw.get("displayName") or raw.get("name")
+        if raw.get("wholeTenant") is True or "everyone" in _ref_type(raw):
+            return NormalizedRef("whole_tenant", display=display)
+        if _whole_tenant_match(display, sentinels):
+            return NormalizedRef("whole_tenant", display=display)
+        gid = _ref_id(raw)
+        if gid:
+            return NormalizedRef("group", value=gid, display=display)
+    return NormalizedRef("unknown", display=str(raw)[:200])
+
+
+def normalize_editor_ref(raw: Any, sentinels: tuple[str, ...]) -> NormalizedRef:
+    """Normalize an editor principal (individual user OR group) to a NormalizedRef."""
+    if isinstance(raw, str):
+        text = raw.strip()
+        if _whole_tenant_match(text, sentinels):
+            return NormalizedRef("whole_tenant", display=text)
+        if _looks_like_upn(text):
+            return NormalizedRef("user_upn", value=text, display=text)
+        # A bare GUID editor ref is ambiguous; treat as a group id and expand
+        # (Copilot Studio editor shares commonly target security groups). A
+        # failed expansion is reported as a per-ref error rather than dropped.
+        return NormalizedRef("group", value=text, display=text)
+    if isinstance(raw, dict):
+        display = raw.get("displayName") or raw.get("name")
+        upn = raw.get("upn") or raw.get("userPrincipalName")
+        if upn:
+            return NormalizedRef("user_upn", value=str(upn), display=display or str(upn))
+        rtype = _ref_type(raw)
+        if raw.get("wholeTenant") is True or "everyone" in rtype:
+            return NormalizedRef("whole_tenant", display=display)
+        rid = _ref_id(raw)
+        if rid and ("group" in rtype or raw.get("securityEnabled") is True):
+            return NormalizedRef("group", value=rid, display=display)
+        if rid and ("user" in rtype or "member" in rtype):
+            return NormalizedRef("user_id", value=rid, display=display)
+        if rid:
+            # Unknown principal type -> attempt group expansion (best effort).
+            return NormalizedRef("group", value=rid, display=display)
+    return NormalizedRef("unknown", display=str(raw)[:200])
+
+
+def detect_whole_tenant(agent: dict, sentinels: tuple[str, ...]) -> bool:
+    """Return True when the agent is shared with 'Everyone in the organization'."""
+    if agent.get("sharedWithEveryone") is True or agent.get("wholeTenant") is True:
+        return True
+    for raw in list(agent.get("viewerGroups") or []) + list(agent.get("editorPrincipals") or []):
+        ref = normalize_group_ref(raw, sentinels)
+        if ref.kind == "whole_tenant":
+            return True
+    return False
+
+
+# =============================================================================
+# Resolver protocol + result types
+# =============================================================================
+
+
+@dataclass
+class ResolveResult:
+    """Outcome of resolving a single group's transitive members."""
+
+    upns: list[str] = field(default_factory=list)
+    truncated: bool = False
+    error: Optional[str] = None
+
+
+class MemberResolver(Protocol):
+    """Protocol for resolving group members / user UPNs (real or fake)."""
+
+    def transitive_member_upns(self, group_id: str) -> ResolveResult: ...
+
+    def user_upn(self, user_id: str) -> Optional[str]: ...
+
+
+@dataclass
+class ExpandConfig:
+    """Tunables for an audience-expansion pass."""
+
+    max_members_per_group: int = DEFAULT_MAX_MEMBERS_PER_GROUP
+    whole_tenant_cap: int = DEFAULT_WHOLE_TENANT_CAP
+    sentinels: tuple[str, ...] = DEFAULT_WHOLE_TENANT_SENTINELS
+
+
+# =============================================================================
+# Core orchestration (pure given a resolver)
+# =============================================================================
+
+
+def _derive_status(
+    whole_tenant: bool,
+    had_refs: bool,
+    upn_count: int,
+    truncated: bool,
+    errors: list[dict],
+) -> str:
+    if whole_tenant:
+        return STATUS_WHOLE_TENANT
+    if not had_refs:
+        # No groups or principals shared -> a cleanly empty audience.
+        return STATUS_COMPLETE
+    if errors and upn_count == 0:
+        return STATUS_FAILED
+    if errors or truncated:
+        return STATUS_PARTIAL
+    return STATUS_COMPLETE
+
+
+def expand_agent_audience(
+    agent: dict, resolver: MemberResolver, config: ExpandConfig
+) -> dict:
+    """Expand one agent's sharing audience to a de-duplicated UPN list.
+
+    Honors the whole-tenant rule (no enumeration), the per-group cap (truncation
+    flag), nested groups (via the resolver's transitive expansion), and overlap
+    de-duplication. Returns a CBG-shaped per-agent object plus governance flags.
+    """
+    agent_id = agent.get("fsi_agentid") or agent.get("agentId") or ""
+    agent_name = agent.get("fsi_agentname") or agent.get("agentName")
+    environment_id = agent.get("fsi_environmentid") or agent.get("environmentId")
+
+    whole_tenant = detect_whole_tenant(agent, config.sentinels)
+
+    upns: dict[str, None] = {}  # ordered de-dup set
+    source_groups: list[dict] = []
+    errors: list[dict] = []
+    any_truncated = False
+
+    viewer_refs = [normalize_group_ref(r, config.sentinels)
+                   for r in (agent.get("viewerGroups") or [])]
+    editor_refs = [normalize_editor_ref(r, config.sentinels)
+                   for r in (agent.get("editorPrincipals") or [])]
+    all_refs = viewer_refs + editor_refs
+    had_refs = bool(all_refs)
+
+    if not whole_tenant:
+        for ref in all_refs:
+            if ref.kind == "user_upn" and ref.value:
+                upns.setdefault(ref.value, None)
+            elif ref.kind == "user_id" and ref.value:
+                resolved = resolver.user_upn(ref.value)
+                if resolved:
+                    upns.setdefault(resolved, None)
+                else:
+                    errors.append({"ref": ref.value, "error": "user UPN not resolved"})
+            elif ref.kind == "group" and ref.value:
+                result = resolver.transitive_member_upns(ref.value)
+                for upn in result.upns:
+                    upns.setdefault(upn, None)
+                any_truncated = any_truncated or result.truncated
+                source_groups.append({
+                    "id": ref.value,
+                    "displayName": ref.display,
+                    "memberCount": len(result.upns),
+                    "truncated": result.truncated,
+                    "error": result.error,
+                })
+                if result.error:
+                    errors.append({"ref": ref.value, "error": result.error})
+            elif ref.kind == "unknown":
+                errors.append({"ref": ref.display, "error": "unrecognized sharing reference"})
+
+    upn_list = sorted(upns)
+    status = _derive_status(whole_tenant, had_refs, len(upn_list), any_truncated, errors)
+
+    return {
+        "agentId": agent_id,
+        "agentName": agent_name,
+        "environmentId": environment_id,
+        "wholeTenant": whole_tenant,
+        "wholeTenantCap": config.whole_tenant_cap,
+        "audienceSize": 0 if whole_tenant else len(upn_list),
+        "truncated": any_truncated,
+        "resolutionStatus": status,
+        "resolutionErrors": errors,
+        "sourceGroups": source_groups,
+        # CBG -InputPath shape: intendedUsers[].upn (per-user license/cohort flags
+        # are downstream gaps per R5 and are intentionally not populated here).
+        "intendedUsers": [{"upn": upn} for upn in upn_list],
+    }
+
+
+def build_authshare_update(result: dict, run_id: str) -> dict:
+    """Project an expansion result onto fsi_caiauthshare audience columns (no PII)."""
+    return {
+        "fsi_agentid": result["agentId"],
+        "fsi_environmentid": result.get("environmentId"),
+        "fsi_audiencewholetenant": result["wholeTenant"],
+        "fsi_audienceupncount": result["audienceSize"],
+        "fsi_audiencetruncated": result["truncated"],
+        "fsi_audienceresolutionstatus": result["resolutionStatus"],
+        "fsi_audienceresolvedat": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "fsi_runid": run_id,
+    }
+
+
+def expand_all(agents: list[dict], resolver: MemberResolver, config: ExpandConfig,
+               run_id: str) -> dict:
+    """Expand every agent's audience and assemble the artifact + summary."""
+    expanded: list[dict] = []
+    authshare_updates: list[dict] = []
+    whole_tenant_count = 0
+    error_agent_count = 0
+    for agent in agents:
+        result = expand_agent_audience(agent, resolver, config)
+        expanded.append(result)
+        authshare_updates.append(build_authshare_update(result, run_id))
+        if result["wholeTenant"]:
+            whole_tenant_count += 1
+        if result["resolutionErrors"]:
+            error_agent_count += 1
+    summary = {
+        "runId": run_id,
+        "agentCount": len(agents),
+        "wholeTenantAgentCount": whole_tenant_count,
+        "agentsWithResolutionErrors": error_agent_count,
+        "maxMembersPerGroup": config.max_members_per_group,
+        "wholeTenantCap": config.whole_tenant_cap,
+    }
+    return {
+        "schemaVersion": "0.2.0-preview",
+        "summary": summary,
+        "agents": expanded,
+        "authShareUpdates": authshare_updates,
+    }
+
+
+# =============================================================================
+# Microsoft Graph resolver (managed-identity-first)
+# =============================================================================
+
+
+class GraphMemberResolver:
+    """Resolve group transitive members and user UPNs via Microsoft Graph.
+
+    Requires the ``GroupMember.Read.All`` permission (plus ``User.Read.All`` to
+    resolve a bare user object id). Authentication is managed-identity-first via
+    azure-identity, lazily imported so ``--dry-run`` and unit tests need no
+    credential or network.
+    """
+
+    def __init__(self, config: ExpandConfig, tenant_id: Optional[str] = None,
+                 client_id: Optional[str] = None, auth_mode: str = "managed-identity") -> None:
+        import requests  # local import: only needed for live runs
+        from requests.adapters import HTTPAdapter, Retry
+
+        self.config = config
+        self.tenant_id = tenant_id
+        self.client_id = client_id
+        self.auth_mode = auth_mode
+        self._token: Optional[str] = None
+        session = requests.Session()
+        retry = Retry(total=5, backoff_factor=2,
+                      status_forcelist=[429, 500, 502, 503, 504],
+                      allowed_methods=["GET"], respect_retry_after_header=True)
+        session.mount("https://", HTTPAdapter(max_retries=retry))
+        self._session = session
+
+    def _credential(self) -> Any:
+        import azure.identity as azid  # type: ignore
+        if self.auth_mode == "managed-identity":
+            return (azid.ManagedIdentityCredential(client_id=self.client_id)
+                    if self.client_id else azid.ManagedIdentityCredential())
+        if self.auth_mode == "workload-identity":
+            return azid.WorkloadIdentityCredential(tenant_id=self.tenant_id, client_id=self.client_id)
+        if self.auth_mode == "interactive":
+            return azid.InteractiveBrowserCredential(tenant_id=self.tenant_id, client_id=self.client_id)
+        return azid.DefaultAzureCredential()
+
+    def _headers(self) -> dict:
+        if self._token is None:
+            self._token = self._credential().get_token(GRAPH_SCOPE).token
+        return {"Authorization": f"Bearer {self._token}", "Accept": "application/json"}
+
+    def _get_with_backoff(self, url: str) -> Any:
+        """GET with explicit 429-aware backoff that honors Retry-After.
+
+        Mirrors discover_agents._request_with_backoff: the session adapter
+        already retries transient failures, and this outer guard adds the
+        Retry-After-honoring loop for the longer throttling windows Graph can
+        return at scale. Unlike the discovery scanner (which raises so a paging
+        loop never mistakes a persistent 429 for end-of-data), this returns the
+        final 429 response so the caller records it as a per-group resolution
+        error: in a multi-agent batch one throttled group should be flagged
+        Partial/Failed, never silently treated as an empty/complete group.
+        """
+        delay = 1.0
+        for attempt in range(6):
+            resp = self._session.get(url, headers=self._headers(), timeout=120)
+            if resp.status_code != 429:
+                return resp
+            wait = float(resp.headers.get("Retry-After") or min(delay, MAX_BACKOFF_SECONDS))
+            logger.warning("429 throttled on %s; backing off %.1fs (attempt %d)",
+                           url, wait, attempt + 1)
+            time.sleep(wait)
+            delay = min(delay * 2, MAX_BACKOFF_SECONDS)
+        return resp  # last (still-429) response; caller records it as an error
+
+    def transitive_member_upns(self, group_id: str) -> ResolveResult:
+        cap = self.config.max_members_per_group
+        url = (f"{GRAPH_BASE}/groups/{group_id}/transitiveMembers"
+               f"?$select=id,userPrincipalName&$top={GRAPH_PAGE_SIZE}")
+        upns: list[str] = []
+        while url:
+            resp = self._get_with_backoff(url)
+            if resp.status_code == 404:
+                return ResolveResult(upns=upns, error="group not found (404)")
+            if resp.status_code != 200:
+                return ResolveResult(upns=upns, error=f"HTTP {resp.status_code}")
+            payload = resp.json()
+            for obj in payload.get("value", []):
+                upn = obj.get("userPrincipalName")
+                if upn:
+                    upns.append(upn)
+                    if len(upns) >= cap:
+                        return ResolveResult(upns=upns, truncated=True)
+            url = payload.get("@odata.nextLink")
+        return ResolveResult(upns=upns)
+
+    def user_upn(self, user_id: str) -> Optional[str]:
+        resp = self._get_with_backoff(
+            f"{GRAPH_BASE}/users/{user_id}?$select=userPrincipalName")
+        if resp.status_code == 200:
+            return resp.json().get("userPrincipalName")
+        logger.warning("Could not resolve user %s (HTTP %s)", user_id, resp.status_code)
+        return None
+
+
+class DryRunResolver:
+    """No-network resolver used by --dry-run: resolves nothing, flags it."""
+
+    def transitive_member_upns(self, group_id: str) -> ResolveResult:
+        return ResolveResult(error="dry-run: not resolved")
+
+    def user_upn(self, user_id: str) -> Optional[str]:
+        return None
+
+
+# =============================================================================
+# Input loading
+# =============================================================================
+
+
+def load_agents_from_input(path: str) -> list[dict]:
+    """Load the per-agent sharing posture from a JSON file.
+
+    Accepts either a top-level ``{"agents": [...]}`` object or a bare ``[...]``
+    list. Each element mirrors fsi_caiauthshare: ``viewerGroups`` /
+    ``editorPrincipals`` (+ optional ``sharedWithEveryone``).
+    """
+    data = json.loads(Path(path).read_text(encoding="utf-8-sig"))
+    if isinstance(data, dict):
+        agents = data.get("agents", [])
+    elif isinstance(data, list):
+        agents = data
+    else:
+        raise SystemExit("--input must be a JSON object with 'agents' or a JSON array")
+    if not isinstance(agents, list):
+        raise SystemExit("'agents' must be a JSON array")
+    return agents
+
+
+def load_agents_from_dataverse(environment_url: str, tenant_id: str,
+                               auth_mode: str) -> list[dict]:
+    """Read fsi_caiauthshare rows from Dataverse and map to the input shape.
+
+    Uses the shared DataverseClient. fsi_viewergroups / fsi_editorprincipals are
+    stored as JSON memo columns; they are parsed back into lists here.
+    """
+    import sys
+    shared_dir = Path(__file__).resolve().parent.parent.parent / "scripts" / "shared"
+    if str(shared_dir) not in sys.path:
+        sys.path.insert(0, str(shared_dir))
+    from dataverse_client import DataverseClient  # noqa: E402
+
+    client = DataverseClient(
+        tenant_id=tenant_id, environment_url=environment_url,
+        interactive=(auth_mode == "interactive"), auth_mode=auth_mode,
+    )
+    rows = client.query(
+        "fsi_caiauthshares",
+        select=["fsi_agentid", "fsi_environmentid", "fsi_viewergroups",
+                "fsi_editorprincipals", "fsi_limitsharingmode"],
+    ) or []
+
+    def _parse(value: Any) -> list:
+        if not value:
+            return []
+        try:
+            parsed = json.loads(value) if isinstance(value, str) else value
+        except json.JSONDecodeError:
+            return []
+        return parsed if isinstance(parsed, list) else []
+
+    agents: list[dict] = []
+    for row in rows:
+        agents.append({
+            "fsi_agentid": row.get("fsi_agentid"),
+            "fsi_environmentid": row.get("fsi_environmentid"),
+            "viewerGroups": _parse(row.get("fsi_viewergroups")),
+            "editorPrincipals": _parse(row.get("fsi_editorprincipals")),
+            "sharedWithEveryone": str(row.get("fsi_limitsharingmode") or "").lower() in
+            ("everyone", "noscope", "none"),
+        })
+    return agents
+
+
+# =============================================================================
+# CLI Entry Point
+# =============================================================================
+
+
+def main() -> None:
+    """CLI entry point for audience-to-UPN expansion."""
+    parser = argparse.ArgumentParser(
+        description="Expand agent sharing audiences to member UPNs (CBG input)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  # Dry run from a captured auth-share JSON (no network)\n"
+            "  python expand_audience_upns.py --input authshare.json --dry-run\n\n"
+            "  # Live expansion via Microsoft Graph (managed identity)\n"
+            "  python expand_audience_upns.py --input authshare.json "
+            "--auth-mode managed-identity --output intended-users.json\n"
+        ),
+    )
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--input", help="JSON file of per-agent sharing posture (fsi_caiauthshare shape)")
+    src.add_argument("--from-dataverse", action="store_true",
+                     help="Read fsi_caiauthshare rows from Dataverse (needs --environment-url/--tenant-id)")
+    parser.add_argument("--environment-url", default=os.environ.get("CAI_ENVIRONMENT_URL"),
+                        help="Governance Dataverse URL (with --from-dataverse / --write-back)")
+    parser.add_argument("--tenant-id", default=os.environ.get("CAI_TENANT_ID"),
+                        help="Microsoft Entra ID tenant ID")
+    parser.add_argument("--client-id", default=os.environ.get("CAI_CLIENT_ID"),
+                        help="Service principal / managed identity client ID")
+    parser.add_argument("--auth-mode",
+                        choices=["managed-identity", "workload-identity", "interactive", "default"],
+                        default=os.environ.get("CAI_AUTH_MODE", "managed-identity"),
+                        help="Graph/Dataverse auth mode; prefer managed-identity for automation")
+    parser.add_argument("--max-members-per-group", type=int, default=DEFAULT_MAX_MEMBERS_PER_GROUP,
+                        help="Per-group member cap (bounds very large groups; sets the truncated flag)")
+    parser.add_argument("--whole-tenant-cap", type=int, default=DEFAULT_WHOLE_TENANT_CAP,
+                        help="Recorded cap for 'Everyone in org' shares; the tenant is never enumerated")
+    parser.add_argument("--whole-tenant-sentinels", default=None,
+                        help="Comma-separated display-name sentinels treated as whole-tenant")
+    parser.add_argument("--run-id", default=None, help="Scan run correlation id (default: generated)")
+    parser.add_argument("--output", default=None, help="Write the CBG-input artifact JSON to this path")
+    parser.add_argument("--write-back", action="store_true",
+                        help="Update fsi_caiauthshare audience summary columns (needs Dataverse conn)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Resolve nothing over the network; log planned work")
+    parser.add_argument("--log-level", default="INFO", help="Logging level")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    sentinels = (tuple(s.strip().lower() for s in args.whole_tenant_sentinels.split(",") if s.strip())
+                 if args.whole_tenant_sentinels else DEFAULT_WHOLE_TENANT_SENTINELS)
+    config = ExpandConfig(
+        max_members_per_group=max(1, args.max_members_per_group),
+        whole_tenant_cap=max(0, args.whole_tenant_cap),
+        sentinels=sentinels,
+    )
+    run_id = args.run_id or f"cai-audience-{int(datetime.now(timezone.utc).timestamp())}"
+
+    # Load the per-agent sharing posture.
+    if args.from_dataverse:
+        if not (args.environment_url and args.tenant_id):
+            parser.error("--from-dataverse requires --environment-url and --tenant-id")
+        agents = load_agents_from_dataverse(args.environment_url, args.tenant_id, args.auth_mode)
+    else:
+        agents = load_agents_from_input(args.input)
+    logger.info("Loaded %d agent sharing postures", len(agents))
+
+    # Choose the resolver.
+    if args.dry_run:
+        logger.info("[DRY RUN] resolving nothing over Graph; whole-tenant shares are flagged only.")
+        resolver: MemberResolver = DryRunResolver()
+    else:
+        resolver = GraphMemberResolver(config, tenant_id=args.tenant_id,
+                                       client_id=args.client_id, auth_mode=args.auth_mode)
+
+    artifact = expand_all(agents, resolver, config, run_id)
+    logger.info("Audience expansion summary: %s", json.dumps(artifact["summary"]))
+
+    if args.write_back and not args.dry_run:
+        _write_back_authshare(artifact["authShareUpdates"], args)
+
+    if args.output:
+        Path(args.output).write_text(json.dumps(artifact, indent=2), encoding="utf-8")
+        logger.info("Wrote CBG-input artifact to %s", args.output)
+    else:
+        print(json.dumps(artifact, indent=2))
+
+
+def _write_back_authshare(updates: list[dict], args: argparse.Namespace) -> None:
+    """Update fsi_caiauthshare audience-summary columns (counts/flags only; no PII)."""
+    if not (args.environment_url and args.tenant_id):
+        logger.error("--write-back requires --environment-url and --tenant-id; skipping write-back")
+        return
+    import sys
+    shared_dir = Path(__file__).resolve().parent.parent.parent / "scripts" / "shared"
+    if str(shared_dir) not in sys.path:
+        sys.path.insert(0, str(shared_dir))
+    from dataverse_client import DataverseClient  # noqa: E402
+
+    client = DataverseClient(
+        tenant_id=args.tenant_id, environment_url=args.environment_url,
+        interactive=(args.auth_mode == "interactive"), auth_mode=args.auth_mode,
+    )
+    for update in updates:
+        existing = client.query(
+            "fsi_caiauthshares",
+            select=["fsi_caiauthshareid"],
+            filter_expr=f"fsi_agentid eq '{update['fsi_agentid']}'",
+            top=1,
+        ) or []
+        payload = {k: v for k, v in update.items() if k != "fsi_agentid"}
+        if existing:
+            client.update_record("fsi_caiauthshares", existing[0]["fsi_caiauthshareid"], payload)
+        else:
+            logger.warning("No fsi_caiauthshare row for agent %s; skipping write-back",
+                           update["fsi_agentid"])
+
+
+if __name__ == "__main__":
+    main()

--- a/copilot-agent-inventory/templates/agent-record.sample.json
+++ b/copilot-agent-inventory/templates/agent-record.sample.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Sample fsi_copilotagent record plus its fsi_caiagentfeature rows produced by discover_agents.py. Field names are Dataverse LOGICAL names (SchemaName lowercased, no underscores between words). Picklist fields show the label; the scanner resolves the label to the option-set integer value at write time. This is illustrative sample data, NOT an exported Power Platform artifact.",
-  "schemaVersion": "0.1.0-preview",
+  "schemaVersion": "0.2.0-preview",
   "runId": "cai-1781029367",
   "fsi_copilotagent": {
     "fsi_name": "Wealth Advisory Assistant (Z2)",
@@ -39,6 +39,8 @@
       "fsi_sourceobjectname": "Account Balance Inquiry",
       "fsi_isenabled": true,
       "fsi_relationshipname": "botcomponent",
+      "fsi_detectionsource": "Dataverse Botcomponent Scan",
+      "fsi_detectionconfidence": "Configured (Dataverse)",
       "fsi_lastscannedat": "2026-06-09T14:00:00Z",
       "fsi_runid": "cai-1781029367"
     },
@@ -53,6 +55,8 @@
       "fsi_sourceobjectname": "Product Disclosures Library",
       "fsi_isenabled": true,
       "fsi_relationshipname": "botcomponent",
+      "fsi_detectionsource": "Dataverse Botcomponent Scan",
+      "fsi_detectionconfidence": "Configured (Dataverse)",
       "fsi_lastscannedat": "2026-06-09T14:00:00Z",
       "fsi_runid": "cai-1781029367"
     },
@@ -67,6 +71,8 @@
       "fsi_sourceobjectname": "Advisory Tone GPT",
       "fsi_isenabled": true,
       "fsi_relationshipname": "botcomponent",
+      "fsi_detectionsource": "Dataverse Botcomponent Scan",
+      "fsi_detectionconfidence": "Configured (Dataverse)",
       "fsi_lastscannedat": "2026-06-09T14:00:00Z",
       "fsi_runid": "cai-1781029367"
     },
@@ -81,6 +87,8 @@
       "fsi_sourceobjectname": "CRM Account Lookup",
       "fsi_isenabled": true,
       "fsi_relationshipname": "botcomponent_aipluginoperation",
+      "fsi_detectionsource": "Dataverse Botcomponent Scan",
+      "fsi_detectionconfidence": "Configured (Dataverse)",
       "fsi_lastscannedat": "2026-06-09T14:00:00Z",
       "fsi_runid": "cai-1781029367"
     },
@@ -95,6 +103,8 @@
       "fsi_sourceobjectname": "Holdings",
       "fsi_isenabled": true,
       "fsi_relationshipname": "botcomponent_dvtablesearch",
+      "fsi_detectionsource": "Dataverse Botcomponent Scan",
+      "fsi_detectionconfidence": "Configured (Dataverse)",
       "fsi_lastscannedat": "2026-06-09T14:00:00Z",
       "fsi_runid": "cai-1781029367"
     }

--- a/copilot-agent-inventory/templates/audience-input.sample.json
+++ b/copilot-agent-inventory/templates/audience-input.sample.json
@@ -1,0 +1,37 @@
+{
+  "_comment": "Sample INPUT for expand_audience_upns.py: a per-agent sharing posture mirroring fsi_caiauthshare. 'viewerGroups' mirrors fsi_viewergroups (security groups granted chat viewer access); 'editorPrincipals' mirrors fsi_editorprincipals (individual editors AND/OR security groups). Each ref may be a bare GUID string, a UPN string (editors), or an object with id/displayName/type. Set 'sharedWithEveryone': true (or include a group whose displayName is an 'Everyone in the organization' sentinel) to mark whole-tenant sharing; the tenant is NEVER enumerated. Pass this file to: python expand_audience_upns.py --input audience-input.sample.json --dry-run",
+  "agents": [
+    {
+      "fsi_agentid": "f3a8c1d2-4b5e-4f6a-9c7d-1e2f3a4b5c6d",
+      "fsi_agentname": "Wealth Advisory Assistant",
+      "fsi_environmentid": "Default-2c9e1a77-3b4d-4e5f-8a90-1b2c3d4e5f60",
+      "viewerGroups": [
+        { "id": "11111111-1111-1111-1111-111111111111", "displayName": "Wealth Advisors", "type": "SecurityGroup" },
+        { "id": "22222222-2222-2222-2222-222222222222", "displayName": "Relationship Managers", "type": "SecurityGroup" }
+      ],
+      "editorPrincipals": [
+        { "upn": "ada.lovelace@contoso.com", "displayName": "Ada Lovelace", "type": "User" }
+      ],
+      "sharedWithEveryone": false
+    },
+    {
+      "fsi_agentid": "a1b2c3d4-5566-7788-99aa-bbccddeeff00",
+      "fsi_agentname": "Company Concierge",
+      "fsi_environmentid": "Default-2c9e1a77-3b4d-4e5f-8a90-1b2c3d4e5f60",
+      "viewerGroups": [],
+      "editorPrincipals": [],
+      "sharedWithEveryone": true
+    },
+    {
+      "fsi_agentid": "c0ffee00-1234-5678-9abc-def012345678",
+      "fsi_agentname": "Loan Ops Helper",
+      "fsi_environmentid": "Default-2c9e1a77-3b4d-4e5f-8a90-1b2c3d4e5f60",
+      "viewerGroups": [
+        "33333333-3333-3333-3333-333333333333"
+      ],
+      "editorPrincipals": [
+        { "id": "44444444-4444-4444-4444-444444444444", "displayName": "Loan Ops Leads", "type": "Group" }
+      ]
+    }
+  ]
+}

--- a/copilot-agent-inventory/templates/audience-upn-list.sample.json
+++ b/copilot-agent-inventory/templates/audience-upn-list.sample.json
@@ -1,0 +1,101 @@
+{
+  "_comment": "Sample OUTPUT artifact emitted by expand_audience_upns.py. It resolves each agent's sharing audience (security groups in fsi_caiauthshare) to concrete member UPNs via Microsoft Graph TRANSITIVE membership (GET /groups/{id}/transitiveMembers, permission GroupMember.Read.All), which flattens nested groups automatically. The 'agents[]' objects are Copilot Billing Governance (CBG) -InputPath shaped: each carries intendedUsers[].upn. Per-user license/cohort flags (e.g. hasCopilotLicense) are separate downstream gaps per R5 and are intentionally NOT populated here. 'Everyone in the organization' shares are flagged wholeTenant and the tenant is deliberately NOT enumerated. 'authShareUpdates[]' carries counts/flags ONLY (no UPNs / no PII) for write-back to fsi_caiauthshare audience columns. This is illustrative sample data, NOT an exported Power Platform artifact.",
+  "schemaVersion": "0.2.0-preview",
+  "summary": {
+    "runId": "cai-audience-1781290500",
+    "agentCount": 3,
+    "wholeTenantAgentCount": 1,
+    "agentsWithResolutionErrors": 1,
+    "maxMembersPerGroup": 1000,
+    "wholeTenantCap": 0
+  },
+  "agents": [
+    {
+      "agentId": "f3a8c1d2-4b5e-4f6a-9c7d-1e2f3a4b5c6d",
+      "agentName": "Wealth Advisory Assistant",
+      "environmentId": "Default-2c9e1a77-3b4d-4e5f-8a90-1b2c3d4e5f60",
+      "wholeTenant": false,
+      "wholeTenantCap": 0,
+      "audienceSize": 3,
+      "truncated": false,
+      "resolutionStatus": "Complete",
+      "resolutionErrors": [],
+      "sourceGroups": [
+        { "id": "11111111-1111-1111-1111-111111111111", "displayName": "Wealth Advisors", "memberCount": 2, "truncated": false, "error": null },
+        { "id": "22222222-2222-2222-2222-222222222222", "displayName": "Relationship Managers", "memberCount": 1, "truncated": false, "error": null }
+      ],
+      "intendedUsers": [
+        { "upn": "ada.lovelace@contoso.com" },
+        { "upn": "alan.turing@contoso.com" },
+        { "upn": "grace.hopper@contoso.com" }
+      ]
+    },
+    {
+      "_comment": "Whole-tenant ('Everyone in the organization'): the tenant is NOT enumerated. intendedUsers is empty, audienceSize is 0, and resolutionStatus is WholeTenantNotEnumerated. CBG treats wholeTenant as the audience-size signal instead of the UPN list.",
+      "agentId": "a1b2c3d4-5566-7788-99aa-bbccddeeff00",
+      "agentName": "Company Concierge",
+      "environmentId": "Default-2c9e1a77-3b4d-4e5f-8a90-1b2c3d4e5f60",
+      "wholeTenant": true,
+      "wholeTenantCap": 0,
+      "audienceSize": 0,
+      "truncated": false,
+      "resolutionStatus": "WholeTenantNotEnumerated",
+      "resolutionErrors": [],
+      "sourceGroups": [],
+      "intendedUsers": []
+    },
+    {
+      "_comment": "Partial resolution: one group resolved, another could not be read (e.g. deleted group -> 404). The resolved members are still emitted; the failure is surfaced in resolutionErrors and the status is Partial so a partial list is never mistaken for complete.",
+      "agentId": "c0ffee00-1234-5678-9abc-def012345678",
+      "agentName": "Loan Ops Helper",
+      "environmentId": "Default-2c9e1a77-3b4d-4e5f-8a90-1b2c3d4e5f60",
+      "wholeTenant": false,
+      "wholeTenantCap": 0,
+      "audienceSize": 1,
+      "truncated": false,
+      "resolutionStatus": "Partial",
+      "resolutionErrors": [
+        { "ref": "44444444-4444-4444-4444-444444444444", "error": "group not found (404)" }
+      ],
+      "sourceGroups": [
+        { "id": "33333333-3333-3333-3333-333333333333", "displayName": null, "memberCount": 1, "truncated": false, "error": null },
+        { "id": "44444444-4444-4444-4444-444444444444", "displayName": "Loan Ops Leads", "memberCount": 0, "truncated": false, "error": "group not found (404)" }
+      ],
+      "intendedUsers": [
+        { "upn": "katherine.johnson@contoso.com" }
+      ]
+    }
+  ],
+  "authShareUpdates": [
+    {
+      "fsi_agentid": "f3a8c1d2-4b5e-4f6a-9c7d-1e2f3a4b5c6d",
+      "fsi_environmentid": "Default-2c9e1a77-3b4d-4e5f-8a90-1b2c3d4e5f60",
+      "fsi_audiencewholetenant": false,
+      "fsi_audienceupncount": 3,
+      "fsi_audiencetruncated": false,
+      "fsi_audienceresolutionstatus": "Complete",
+      "fsi_audienceresolvedat": "2026-06-12T14:05:00Z",
+      "fsi_runid": "cai-audience-1781290500"
+    },
+    {
+      "fsi_agentid": "a1b2c3d4-5566-7788-99aa-bbccddeeff00",
+      "fsi_environmentid": "Default-2c9e1a77-3b4d-4e5f-8a90-1b2c3d4e5f60",
+      "fsi_audiencewholetenant": true,
+      "fsi_audienceupncount": 0,
+      "fsi_audiencetruncated": false,
+      "fsi_audienceresolutionstatus": "WholeTenantNotEnumerated",
+      "fsi_audienceresolvedat": "2026-06-12T14:05:00Z",
+      "fsi_runid": "cai-audience-1781290500"
+    },
+    {
+      "fsi_agentid": "c0ffee00-1234-5678-9abc-def012345678",
+      "fsi_environmentid": "Default-2c9e1a77-3b4d-4e5f-8a90-1b2c3d4e5f60",
+      "fsi_audiencewholetenant": false,
+      "fsi_audienceupncount": 1,
+      "fsi_audiencetruncated": false,
+      "fsi_audienceresolutionstatus": "Partial",
+      "fsi_audienceresolvedat": "2026-06-12T14:05:00Z",
+      "fsi_runid": "cai-audience-1781290500"
+    }
+  ]
+}

--- a/copilot-agent-inventory/templates/people-detection.sample.json
+++ b/copilot-agent-inventory/templates/people-detection.sample.json
@@ -1,0 +1,66 @@
+{
+  "_comment": "Sample artifact emitted by detect_people_capability.py. It records the declarative-agent 'People' capability (capabilities[].name == 'People', the 'Reference org chart and profile info' toggle) detected from declarativeAgent.json manifests. Field names under 'features' are Dataverse LOGICAL names for fsi_caiagentfeature rows; picklist fields (fsi_featuretype, fsi_detectionsource, fsi_detectionconfidence) carry the option-set LABEL and the writer resolves the label to its integer value at upsert time. This is illustrative sample data, NOT an exported Power Platform artifact. The People signal is DECLARED (authored/available in the manifest); a v1.7 user_overrides block can remove it at runtime, so 'declared' does not guarantee 'effective'.",
+  "schemaVersion": "0.2.0-preview",
+  "summary": {
+    "runId": "cai-people-1781290000",
+    "detectionSource": "Declarative Manifest (Source/CI Repo)",
+    "manifestsScanned": 3,
+    "peopleDetected": 2,
+    "provisionalAgentIds": 1
+  },
+  "agents": [
+    {
+      "agentId": "f3a8c1d2-4b5e-4f6a-9c7d-1e2f3a4b5c6d",
+      "agentName": "Wealth Advisory Assistant",
+      "agentIdProvisional": false,
+      "locator": "packages/wealth-advisory/declarativeAgent.json",
+      "manifestVersion": "v1.5",
+      "includeRelatedContent": null
+    },
+    {
+      "agentId": "people-org-concierge",
+      "agentName": "Org Concierge",
+      "agentIdProvisional": true,
+      "locator": "packages/org-concierge.zip!declarativeAgent.json",
+      "manifestVersion": "v1.7",
+      "includeRelatedContent": true
+    }
+  ],
+  "features": [
+    {
+      "fsi_name": "People (Org Chart & Profile): Wealth Advisory Assistant",
+      "fsi_agentid": "f3a8c1d2-4b5e-4f6a-9c7d-1e2f3a4b5c6d",
+      "fsi_environmentid": "Default-2c9e1a77-3b4d-4e5f-8a90-1b2c3d4e5f60",
+      "fsi_featuretype": "People (Org Chart & Profile)",
+      "fsi_componenttype": null,
+      "fsi_componentversion": "Not Applicable",
+      "fsi_sourceobjectid": "capability:People",
+      "fsi_sourceobjectname": "People",
+      "fsi_relationshipname": "declarativeAgent.capabilities",
+      "fsi_detectionsource": "Declarative Manifest (Source/CI Repo)",
+      "fsi_detectionconfidence": "Declared (Manifest)",
+      "fsi_detectiondetail": "{\"source\": \"Declarative Manifest (Source/CI Repo)\", \"locator\": \"packages/wealth-advisory/declarativeAgent.json\", \"capabilityName\": \"People\", \"manifestVersion\": \"v1.5\", \"schema\": \"https://developer.microsoft.com/json-schemas/copilot/declarative-agent/v1.5/schema.json\", \"includeRelatedContent\": null, \"agentRefProvisional\": false, \"detectedAt\": \"2026-06-12T14:00:00Z\"}",
+      "fsi_isenabled": true,
+      "fsi_lastscannedat": "2026-06-12T14:00:00Z",
+      "fsi_runid": "cai-people-1781290000"
+    },
+    {
+      "_comment": "Provisional agent id: the manifest had no Dataverse bot GUID and no --id-map entry resolved it, so fsi_agentid carries the declarative-agent id as a placeholder and agentRefProvisional is true. The orchestrator must reconcile this to the bot GUID before joining CAI/CBG. include_related_content (v1.7) is captured but does NOT gate detection.",
+      "fsi_name": "People (Org Chart & Profile): Org Concierge",
+      "fsi_agentid": "people-org-concierge",
+      "fsi_environmentid": "Default-2c9e1a77-3b4d-4e5f-8a90-1b2c3d4e5f60",
+      "fsi_featuretype": "People (Org Chart & Profile)",
+      "fsi_componenttype": null,
+      "fsi_componentversion": "Not Applicable",
+      "fsi_sourceobjectid": "capability:People",
+      "fsi_sourceobjectname": "People",
+      "fsi_relationshipname": "declarativeAgent.capabilities",
+      "fsi_detectionsource": "Declarative Manifest (Source/CI Repo)",
+      "fsi_detectionconfidence": "Declared (Manifest)",
+      "fsi_detectiondetail": "{\"source\": \"Declarative Manifest (Source/CI Repo)\", \"locator\": \"packages/org-concierge.zip!declarativeAgent.json\", \"capabilityName\": \"People\", \"manifestVersion\": \"v1.7\", \"schema\": \"https://developer.microsoft.com/json-schemas/copilot/declarative-agent/v1.7/schema.json\", \"includeRelatedContent\": true, \"agentRefProvisional\": true, \"detectedAt\": \"2026-06-12T14:00:00Z\"}",
+      "fsi_isenabled": true,
+      "fsi_lastscannedat": "2026-06-12T14:00:00Z",
+      "fsi_runid": "cai-people-1781290000"
+    }
+  ]
+}

--- a/copilot-agent-inventory/tests/test_detect_people_capability.py
+++ b/copilot-agent-inventory/tests/test_detect_people_capability.py
@@ -5,7 +5,7 @@ adapters in ``scripts/detect_people_capability.py``:
 
   * ``detect_people_capability`` matches ``capabilities[].name == "People"`` as a
     CASE-SENSITIVE literal, independent of the manifest ``version`` (the const is
-    unchanged across schema v1.5-v1.7), and captures the optional v1.7
+    unchanged through v1.7), and captures the optional v1.7
     ``include_related_content`` sub-setting without letting it gate detection.
   * ``extract_capabilities`` / ``parse_manifest_version`` fail open on missing or
     malformed manifests (platform drift surfaces as "not detected", not an error).
@@ -72,6 +72,38 @@ def test_people_match_is_case_sensitive() -> None:
     for name in ("people", "PEOPLE", "PeoplE", "people "):
         manifest = {"capabilities": [{"name": name}]}
         assert dp.detect_people_capability(manifest).detected is False, name
+
+
+def test_case_drift_warns_not_detected_and_exact_people_has_no_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Near-miss casing must NOT be detected but MUST emit a WARNING; the exact
+    schema const "People" must be detected with NO warning emitted."""
+    import logging
+
+    # Near-miss: "people" (lowercase) → not detected, warning contains offending
+    # value and agent identity.
+    with caplog.at_level(logging.WARNING, logger="detect_people_capability"):
+        result = dp.detect_people_capability(
+            {"capabilities": [{"name": "people"}]},
+            agent_label="test-agent-drift",
+        )
+    assert result.detected is False
+    assert len(caplog.records) >= 1
+    warning_text = caplog.text
+    assert "'people'" in warning_text   # offending value (%r format)
+    assert "test-agent-drift" in warning_text  # agent identity
+
+    caplog.clear()
+
+    # Exact match: "People" → detected, no warning emitted.
+    with caplog.at_level(logging.WARNING, logger="detect_people_capability"):
+        result_exact = dp.detect_people_capability(
+            {"capabilities": [{"name": "People"}]},
+            agent_label="test-agent-exact",
+        )
+    assert result_exact.detected is True
+    assert caplog.records == [], [r.getMessage() for r in caplog.records]
 
 
 def test_no_capabilities_array_is_not_detected() -> None:

--- a/copilot-agent-inventory/tests/test_detect_people_capability.py
+++ b/copilot-agent-inventory/tests/test_detect_people_capability.py
@@ -226,3 +226,114 @@ def test_detect_over_adapter_ignores_agents_without_people(tmp_path: Path) -> No
     run = dp.detect_over_adapter(dp.LocalAppPackageAdapter(tmp_path), "run-z")
     assert run.manifests_scanned == 2
     assert run.people_detected == 1
+
+
+# ===========================================================================
+# Regression tests for GATE-1 findings (H2, M3)
+# ===========================================================================
+
+# --- H2: provisional rows must not collapse on the alt-key ------------------
+
+def test_people_source_object_id_is_deterministic_and_salted_only_when_provisional() -> None:
+    # Non-provisional rows keep the clean constant so re-detection upserts the one
+    # People row for a resolved agent.
+    assert dp._people_source_object_id("anything", False) == dp.PEOPLE_SOURCE_OBJECT_ID
+    # Provisional rows are salted by locator, deterministically (idempotent rescans)
+    # and distinctly (different manifests do not collapse).
+    a1 = dp._people_source_object_id("repo/x/declarativeAgent.json", True)
+    a2 = dp._people_source_object_id("repo/x/declarativeAgent.json", True)
+    b = dp._people_source_object_id("repo/y/declarativeAgent.json", True)
+    assert a1 == a2
+    assert a1 != b
+    assert a1.startswith(dp.PEOPLE_SOURCE_OBJECT_ID + ":")
+
+
+def test_provisional_manifests_with_identical_stem_avoid_altkey_collapse(
+    tmp_path: Path,
+) -> None:
+    # Two Toolkit packages each carry appPackage/declarativeAgent.json (the SAME
+    # file stem) with no --id-map, so both resolve to the identical provisional
+    # agent id "declarativeAgent". With a constant fsi_sourceobjectid the
+    # (fsi_agentid, fsi_sourceobjectid) alt-key would collapse and one upsert would
+    # silently overwrite the other.
+    for sub in ("agent-a", "agent-b"):
+        pkg = tmp_path / sub / "appPackage"
+        pkg.mkdir(parents=True)
+        _write_json(pkg / "declarativeAgent.json",
+                    {"capabilities": [{"name": "People"}]})
+
+    run = dp.detect_over_adapter(dp.SourceRepoAdapter(tmp_path), "run-collapse")
+
+    assert run.people_detected == 2
+    features = run.features
+    # The provisional ids genuinely collide on the stem (the collapse RISK)...
+    assert {f["fsi_agentid"] for f in features} == {"declarativeAgent"}
+    # ...but the salted source-object id keeps the two alt-keys distinct.
+    altkeys = {(f["fsi_agentid"], f["fsi_sourceobjectid"]) for f in features}
+    assert len(altkeys) == 2
+    assert len({f["fsi_sourceobjectid"] for f in features}) == 2
+    # fsi_agentrefprovisional is a queryable top-level column (CBG-join filter).
+    assert all(f["fsi_agentrefprovisional"] is True for f in features)
+
+
+def test_non_provisional_row_keeps_clean_source_object_id_and_flag(
+    tmp_path: Path,
+) -> None:
+    da = tmp_path / "declarativeAgent.json"
+    _write_json(da, {"id": "da-77", "capabilities": [{"name": "People"}]})
+    id_map = {"da-77": "99999999-9999-9999-9999-999999999999"}
+    run = dp.detect_over_adapter(dp.LocalAppPackageAdapter(tmp_path, id_map), "run-clean")
+    feature = run.features[0]
+    assert feature["fsi_sourceobjectid"] == dp.PEOPLE_SOURCE_OBJECT_ID
+    assert feature["fsi_agentrefprovisional"] is False
+
+
+# --- M3: malformed/unzippable manifests must surface as a Partial scan -------
+
+def test_corrupt_zip_is_counted_as_failed_manifest(tmp_path: Path) -> None:
+    (tmp_path / "broken.zip").write_bytes(b"not a real zip file")
+    _write_json(tmp_path / "declarativeAgent.json",
+                {"capabilities": [{"name": "People"}]})
+
+    run = dp.detect_over_adapter(dp.LocalAppPackageAdapter(tmp_path), "run-m3")
+
+    assert run.people_detected == 1
+    assert run.manifests_failed == 1
+    summary = run.summary(dp.SOURCE_LOCAL_PACKAGE)
+    assert summary["manifestsFailed"] == 1
+    assert summary["scanStatus"] == "Partial"
+
+
+def test_unparseable_manifest_json_is_counted_as_failed(tmp_path: Path) -> None:
+    (tmp_path / "declarativeAgent.json").write_text(
+        "{ this is not valid json", encoding="utf-8")
+
+    run = dp.detect_over_adapter(dp.LocalAppPackageAdapter(tmp_path), "run-m3b")
+
+    # A corrupt fleet must NOT read as "0 detections, all green".
+    assert run.manifests_scanned == 0
+    assert run.people_detected == 0
+    assert run.manifests_failed == 1
+    assert run.summary(dp.SOURCE_LOCAL_PACKAGE)["scanStatus"] == "Partial"
+
+
+def test_clean_scan_status_is_complete(tmp_path: Path) -> None:
+    _write_json(tmp_path / "declarativeAgent.json",
+                {"capabilities": [{"name": "People"}]})
+    run = dp.detect_over_adapter(dp.LocalAppPackageAdapter(tmp_path), "run-ok")
+    assert run.manifests_failed == 0
+    assert run.summary(dp.SOURCE_LOCAL_PACKAGE)["scanStatus"] == "Complete"
+
+
+def test_zip_without_declarative_agent_is_not_a_failure(tmp_path: Path) -> None:
+    # A package that genuinely contains no declarativeAgent.json is a valid
+    # "no capability" outcome, NOT a read failure (M3 scope is malformed/unzippable).
+    zip_path = tmp_path / "no-da.zip"
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        archive.writestr("manifest.json", json.dumps({"name": {"short": "X"}}))
+        archive.writestr("color.png", b"not-json")
+
+    run = dp.detect_over_adapter(dp.LocalAppPackageAdapter(zip_path), "run-noda")
+
+    assert run.manifests_failed == 0
+    assert run.summary(dp.SOURCE_LOCAL_PACKAGE)["scanStatus"] == "Complete"

--- a/copilot-agent-inventory/tests/test_detect_people_capability.py
+++ b/copilot-agent-inventory/tests/test_detect_people_capability.py
@@ -1,0 +1,228 @@
+"""Unit tests for People-capability detection in copilot-agent-inventory.
+
+Exercises the side-effect-free detection logic and the manifest-acquisition
+adapters in ``scripts/detect_people_capability.py``:
+
+  * ``detect_people_capability`` matches ``capabilities[].name == "People"`` as a
+    CASE-SENSITIVE literal, independent of the manifest ``version`` (the const is
+    unchanged across schema v1.5-v1.7), and captures the optional v1.7
+    ``include_related_content`` sub-setting without letting it gate detection.
+  * ``extract_capabilities`` / ``parse_manifest_version`` fail open on missing or
+    malformed manifests (platform drift surfaces as "not detected", not an error).
+  * ``build_people_feature_record`` emits Dataverse LOGICAL column names, the new
+    ``People (Org Chart & Profile)`` feature type, and a ``Declared (Manifest)``
+    confidence marker.
+  * ``LocalAppPackageAdapter`` / ``SourceRepoAdapter`` read loose manifests and
+    app-package zips; ``--id-map`` binds a manifest to a bot GUID (else the id is
+    flagged provisional); ``FutureExportAdapter`` is an unimplemented seam.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import detect_people_capability as dp  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# detect_people_capability — the core signal
+# ---------------------------------------------------------------------------
+
+def test_detects_people_v17_with_include_related_content() -> None:
+    manifest = {
+        "$schema": "https://developer.microsoft.com/json-schemas/copilot/"
+                   "declarative-agent/v1.7/schema.json",
+        "version": "1.7",
+        "capabilities": [
+            {"name": "WebSearch"},
+            {"name": "People", "include_related_content": True},
+        ],
+    }
+    result = dp.detect_people_capability(manifest)
+    assert result.detected is True
+    assert result.include_related_content is True
+    assert result.manifest_version == "1.7"
+    assert result.raw_capability == {"name": "People", "include_related_content": True}
+
+
+def test_detects_people_v15_without_include_related_content() -> None:
+    manifest = {
+        "$schema": "https://developer.microsoft.com/json-schemas/copilot/"
+                   "declarative-agent/v1.5/schema.json",
+        "capabilities": [{"name": "People"}],
+    }
+    result = dp.detect_people_capability(manifest)
+    assert result.detected is True
+    # Absent sub-setting must be None, never a fabricated default.
+    assert result.include_related_content is None
+    assert result.manifest_version == "1.5"
+
+
+def test_people_match_is_case_sensitive() -> None:
+    # The schema const is exactly "People"; any other casing must NOT match.
+    for name in ("people", "PEOPLE", "PeoplE", "people "):
+        manifest = {"capabilities": [{"name": name}]}
+        assert dp.detect_people_capability(manifest).detected is False, name
+
+
+def test_no_capabilities_array_is_not_detected() -> None:
+    assert dp.detect_people_capability({}).detected is False
+    assert dp.detect_people_capability({"capabilities": []}).detected is False
+
+
+@pytest.mark.parametrize("bad_manifest", [
+    None,
+    "not-a-dict",
+    {"capabilities": "WebSearch"},      # capabilities not a list
+    {"capabilities": [None, 7, "x"]},   # entries not dicts
+    {"capabilities": [{"noname": 1}]},  # capability missing name
+])
+def test_malformed_manifests_fail_open(bad_manifest: object) -> None:
+    assert dp.detect_people_capability(bad_manifest).detected is False
+
+
+def test_include_related_content_non_bool_is_ignored() -> None:
+    manifest = {"capabilities": [{"name": "People", "include_related_content": "yes"}]}
+    result = dp.detect_people_capability(manifest)
+    assert result.detected is True
+    assert result.include_related_content is None
+
+
+def test_extract_capabilities_filters_non_dicts() -> None:
+    caps = dp.extract_capabilities({"capabilities": [{"name": "People"}, None, 5, "x"]})
+    assert caps == [{"name": "People"}]
+
+
+def test_parse_manifest_version_from_schema_url_when_no_version_field() -> None:
+    manifest = {"$schema": ".../declarative-agent/v1.6/schema.json"}
+    version, schema_url = dp.parse_manifest_version(manifest)
+    assert version == "1.6"
+    assert schema_url.endswith("v1.6/schema.json")
+
+
+# ---------------------------------------------------------------------------
+# build_people_feature_record — Dataverse logical-name row
+# ---------------------------------------------------------------------------
+
+def test_feature_record_uses_logical_names_and_declared_confidence() -> None:
+    detection = dp.PeopleDetection(
+        detected=True, include_related_content=True, manifest_version="1.7",
+        schema_url="schema-url", raw_capability={"name": "People"},
+    )
+    record = dp.build_people_feature_record(
+        run_id="run-1", agent_id="bot-guid", agent_name="CoS Agent",
+        environment_id="env-guid", detection=detection,
+        source_label=dp.SOURCE_SOURCE_REPO, locator="appPackage/declarativeAgent.json",
+        agent_id_provisional=False,
+    )
+    assert record["fsi_featuretype"] == "People (Org Chart & Profile)"
+    assert record["fsi_detectionconfidence"] == "Declared (Manifest)"
+    assert record["fsi_detectionsource"] == dp.SOURCE_SOURCE_REPO
+    assert record["fsi_sourceobjectid"] == dp.PEOPLE_SOURCE_OBJECT_ID
+    assert record["fsi_agentid"] == "bot-guid"
+    # Every emitted key is a Dataverse logical name (fsi_ prefix, no inter-word _).
+    for key in record:
+        assert key.startswith("fsi_"), key
+        assert "_" not in key[len("fsi_"):], key
+    detail = json.loads(record["fsi_detectiondetail"])
+    assert detail["includeRelatedContent"] is True
+    assert detail["manifestVersion"] == "1.7"
+    assert detail["agentRefProvisional"] is False
+
+
+# ---------------------------------------------------------------------------
+# Manifest loading: loose JSON, directory, app-package zip
+# ---------------------------------------------------------------------------
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_local_package_adapter_reads_loose_manifest(tmp_path: Path) -> None:
+    da = tmp_path / "declarativeAgent.json"
+    _write_json(da, {"version": "1.7", "name": "Loose Agent",
+                     "capabilities": [{"name": "People"}]})
+    adapter = dp.LocalAppPackageAdapter(tmp_path)
+    run = dp.detect_over_adapter(adapter, "run-x")
+    assert run.manifests_scanned == 1
+    assert run.people_detected == 1
+    assert run.features[0]["fsi_detectionsource"] == dp.SOURCE_LOCAL_PACKAGE
+    # No id-map supplied -> id is provisional and surfaced in the count.
+    assert run.provisional_ids == 1
+
+
+def test_zip_app_package_detects_via_copilot_agents_node(tmp_path: Path) -> None:
+    zip_path = tmp_path / "agent.zip"
+    app_manifest = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "name": {"short": "Packaged Agent"},
+        "copilotAgents": {"declarativeAgents": [{"id": "da1", "file": "declarativeAgent.json"}]},
+    }
+    da_manifest = {"version": "1.7", "capabilities": [{"name": "People"},
+                                                      {"name": "WebSearch"}]}
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        archive.writestr("manifest.json", json.dumps(app_manifest))
+        archive.writestr("declarativeAgent.json", json.dumps(da_manifest))
+        archive.writestr("color.png", b"not-json")
+    records = list(dp.load_manifests_from_zip(zip_path))
+    assert len(records) == 1
+    assert records[0].agent_name == "Packaged Agent"
+    assert dp.detect_people_capability(records[0].manifest).detected is True
+
+
+def test_zip_without_app_manifest_falls_back_to_filename(tmp_path: Path) -> None:
+    zip_path = tmp_path / "loose.zip"
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        archive.writestr("declarativeAgent.json",
+                         json.dumps({"capabilities": [{"name": "People"}]}))
+    records = list(dp.load_manifests_from_zip(zip_path))
+    assert len(records) == 1
+    assert dp.detect_people_capability(records[0].manifest).detected is True
+
+
+def test_id_map_resolves_provisional_to_bot_guid(tmp_path: Path) -> None:
+    da = tmp_path / "declarativeAgent.json"
+    _write_json(da, {"id": "da-77", "capabilities": [{"name": "People"}]})
+    id_map = {"da-77": "99999999-9999-9999-9999-999999999999"}
+    records = list(dp.load_manifest_from_json_file(da, id_map))
+    assert records[0].agent_id == "99999999-9999-9999-9999-999999999999"
+    assert records[0].agent_id_provisional is False
+
+
+def test_source_repo_adapter_walks_tree(tmp_path: Path) -> None:
+    pkg = tmp_path / "myagent" / "appPackage"
+    pkg.mkdir(parents=True)
+    _write_json(pkg / "declarativeAgent.json", {"capabilities": [{"name": "People"}]})
+    # A non-manifest JSON file must be ignored (only declarativeAgent*.json counts).
+    other = tmp_path / "other"
+    other.mkdir(parents=True)
+    _write_json(other / "notes.json", {"capabilities": [{"name": "People"}]})
+    adapter = dp.SourceRepoAdapter(tmp_path)
+    run = dp.detect_over_adapter(adapter, "run-r")
+    assert run.manifests_scanned == 1
+    assert run.people_detected == 1
+    assert run.features[0]["fsi_detectionsource"] == dp.SOURCE_SOURCE_REPO
+
+
+def test_future_export_adapter_is_unimplemented_seam() -> None:
+    with pytest.raises(NotImplementedError):
+        list(dp.FutureExportAdapter().iter_records())
+
+
+def test_detect_over_adapter_ignores_agents_without_people(tmp_path: Path) -> None:
+    _write_json(tmp_path / "a.declarativeAgent.json",
+                {"capabilities": [{"name": "WebSearch"}]})
+    _write_json(tmp_path / "b.declarativeAgent.json",
+                {"capabilities": [{"name": "People"}]})
+    run = dp.detect_over_adapter(dp.LocalAppPackageAdapter(tmp_path), "run-z")
+    assert run.manifests_scanned == 2
+    assert run.people_detected == 1

--- a/copilot-agent-inventory/tests/test_discover_agents.py
+++ b/copilot-agent-inventory/tests/test_discover_agents.py
@@ -177,3 +177,54 @@ def test_reconcile_sources_disjoint_id_spaces_warns(
     assert any(
         "id-space check FAILED" in record.getMessage() for record in caplog.records
     ), "expected the H-3 id-space-split warning to be emitted"
+
+
+# ---------------------------------------------------------------------------
+# derive_shared_with_everyone / _authshare_record (finding H1 - population side)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "policy,expected",
+    [
+        (0, True), (3, True),        # Any / Any (multi-tenant) -> org-wide reach
+        ("0", True), ("3", True),    # string codes parse too
+        (1, False), (2, False),      # more restrictive / security groups
+        ("2", False),
+    ],
+)
+def test_derive_shared_with_everyone_known_policies(
+    policy: object, expected: bool
+) -> None:
+    assert da.derive_shared_with_everyone({"accesscontrolpolicy": policy}) is expected
+
+
+@pytest.mark.parametrize(
+    "bot",
+    [
+        {},                                # signal absent
+        {"accesscontrolpolicy": None},     # explicit null
+        {"accesscontrolpolicy": "weird"},  # unparseable
+        {"accesscontrolpolicy": 99},       # unknown / drifted code
+        {"accesscontrolpolicy": True},     # a bool is not a policy code
+    ],
+)
+def test_derive_shared_with_everyone_unknown_is_none(bot: dict) -> None:
+    # An unknown signal must be None (NOT coerced to False) so the audience expander
+    # marks the agent Partial rather than emitting a confident empty audience.
+    assert da.derive_shared_with_everyone(bot) is None
+
+
+def test_authshare_record_stamps_shared_with_everyone_for_org_wide() -> None:
+    ctx = da.ScanContext(run_id="run-1", dry_run=True)
+    rec = da._authshare_record(ctx, {"botid": "bot-1", "accesscontrolpolicy": 0})
+    assert rec["fsi_agentid"] == "bot-1"
+    assert rec["fsi_sharedwitheveryone"] is True
+
+
+def test_authshare_record_omits_column_when_signal_unknown() -> None:
+    ctx = da.ScanContext(run_id="run-1", dry_run=True)
+    rec = da._authshare_record(ctx, {"botid": "bot-2"})
+    # The column is left OFF the record so the Dataverse value stays unset and the
+    # expander treats whole-tenant reach as unknown (Partial), not a confident empty.
+    assert "fsi_sharedwitheveryone" not in rec
+    assert rec["fsi_agentid"] == "bot-2"

--- a/copilot-agent-inventory/tests/test_expand_audience_upns.py
+++ b/copilot-agent-inventory/tests/test_expand_audience_upns.py
@@ -1,0 +1,359 @@
+"""Unit tests for the pure audience-to-UPN expansion logic.
+
+Imports ``scripts/expand_audience_upns.py``. That module has no third-party
+imports at load time (Microsoft Graph / azure-identity / requests are imported
+lazily inside ``GraphMemberResolver`` only), so it imports cleanly here and the
+orchestration is exercised against an injected ``FakeResolver`` — no network, no
+credential, no live tenant.
+
+Coverage focuses on the defensive behaviours that make the audience list safe to
+feed Copilot Billing Governance:
+
+  * reference normalization across heterogeneous shapes (bare GUID, dict, UPN
+    string, typed user/group),
+  * "Everyone in the organization" detection — the tenant is NOT enumerated,
+  * nested-group flattening (trusted to Graph transitiveMembers) and overlap
+    de-duplication,
+  * per-group cap / truncation flagging,
+  * partial vs failed vs complete resolution status derivation,
+  * agents with no sharing resolving to a clean empty audience,
+  * the Dataverse write-back projection carrying counts/flags only (no PII).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import expand_audience_upns as eau  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Test double: an in-memory resolver implementing the MemberResolver protocol.
+# ---------------------------------------------------------------------------
+
+
+class FakeResolver:
+    """In-memory MemberResolver. transitiveMembers output is assumed already
+    flattened (as real Graph transitiveMembers is), so nested groups are modeled
+    by simply listing every transitive member for a group id."""
+
+    def __init__(self, group_map=None, user_map=None,
+                 truncated_groups=None, error_groups=None):
+        self.group_map = group_map or {}
+        self.user_map = user_map or {}
+        self.truncated_groups = set(truncated_groups or ())
+        self.error_groups = error_groups or {}
+        self.group_calls: list[str] = []
+        self.user_calls: list[str] = []
+
+    def transitive_member_upns(self, group_id: str) -> "eau.ResolveResult":
+        self.group_calls.append(group_id)
+        if group_id in self.error_groups:
+            return eau.ResolveResult(error=self.error_groups[group_id])
+        return eau.ResolveResult(
+            upns=list(self.group_map.get(group_id, [])),
+            truncated=group_id in self.truncated_groups,
+        )
+
+    def user_upn(self, user_id: str):
+        self.user_calls.append(user_id)
+        return self.user_map.get(user_id)
+
+
+SENT = eau.DEFAULT_WHOLE_TENANT_SENTINELS
+CFG = eau.ExpandConfig()
+
+
+# ---------------------------------------------------------------------------
+# Reference normalization
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_group_ref_bare_guid_is_group():
+    ref = eau.normalize_group_ref("11111111-1111-1111-1111-111111111111", SENT)
+    assert ref.kind == "group"
+    assert ref.value == "11111111-1111-1111-1111-111111111111"
+
+
+def test_normalize_group_ref_dict_id_variants():
+    for key in ("id", "groupId", "objectId"):
+        ref = eau.normalize_group_ref({key: "gid-1", "displayName": "Sales"}, SENT)
+        assert ref.kind == "group"
+        assert ref.value == "gid-1"
+        assert ref.display == "Sales"
+
+
+def test_normalize_group_ref_whole_tenant_by_display_name():
+    ref = eau.normalize_group_ref({"displayName": "Everyone in the organization"}, SENT)
+    assert ref.kind == "whole_tenant"
+
+
+def test_normalize_group_ref_whole_tenant_by_explicit_marker():
+    assert eau.normalize_group_ref({"wholeTenant": True}, SENT).kind == "whole_tenant"
+    assert eau.normalize_group_ref({"type": "Everyone"}, SENT).kind == "whole_tenant"
+
+
+def test_normalize_group_ref_unrecognized_is_unknown():
+    assert eau.normalize_group_ref(12345, SENT).kind == "unknown"
+    assert eau.normalize_group_ref({"foo": "bar"}, SENT).kind == "unknown"
+
+
+def test_normalize_editor_ref_upn_string_and_dict():
+    assert eau.normalize_editor_ref("alice@contoso.com", SENT).kind == "user_upn"
+    r = eau.normalize_editor_ref({"upn": "bob@contoso.com"}, SENT)
+    assert r.kind == "user_upn" and r.value == "bob@contoso.com"
+    r2 = eau.normalize_editor_ref({"userPrincipalName": "carol@contoso.com"}, SENT)
+    assert r2.kind == "user_upn" and r2.value == "carol@contoso.com"
+
+
+def test_normalize_editor_ref_typed_user_id_and_group():
+    u = eau.normalize_editor_ref({"id": "uid-9", "type": "User"}, SENT)
+    assert u.kind == "user_id" and u.value == "uid-9"
+    g = eau.normalize_editor_ref({"id": "gid-9", "type": "Group"}, SENT)
+    assert g.kind == "group" and g.value == "gid-9"
+
+
+def test_normalize_editor_ref_bare_guid_treated_as_group():
+    # Ambiguous bare GUID in editor context -> attempt group expansion.
+    r = eau.normalize_editor_ref("22222222-2222-2222-2222-222222222222", SENT)
+    assert r.kind == "group"
+
+
+# ---------------------------------------------------------------------------
+# Whole-tenant detection
+# ---------------------------------------------------------------------------
+
+
+def test_detect_whole_tenant_explicit_flag():
+    assert eau.detect_whole_tenant({"sharedWithEveryone": True}, SENT) is True
+    assert eau.detect_whole_tenant({"wholeTenant": True}, SENT) is True
+
+
+def test_detect_whole_tenant_via_group_sentinel():
+    agent = {"viewerGroups": [{"displayName": "Everyone except external users"}]}
+    assert eau.detect_whole_tenant(agent, SENT) is True
+
+
+def test_detect_whole_tenant_false_for_named_groups():
+    agent = {"viewerGroups": ["gid-1"], "editorPrincipals": ["alice@contoso.com"]}
+    assert eau.detect_whole_tenant(agent, SENT) is False
+
+
+# ---------------------------------------------------------------------------
+# expand_agent_audience — core behaviours
+# ---------------------------------------------------------------------------
+
+
+def test_expand_basic_dedup_and_sorted():
+    resolver = FakeResolver(group_map={
+        "g1": ["alice@contoso.com", "bob@contoso.com"],
+        "g2": ["bob@contoso.com", "carol@contoso.com"],  # bob overlaps
+    })
+    agent = {"fsi_agentid": "bot-1", "fsi_agentname": "Helpdesk",
+             "viewerGroups": ["g1", "g2"]}
+    out = eau.expand_agent_audience(agent, resolver, CFG)
+    upns = [u["upn"] for u in out["intendedUsers"]]
+    assert upns == ["alice@contoso.com", "bob@contoso.com", "carol@contoso.com"]
+    assert out["audienceSize"] == 3
+    assert out["resolutionStatus"] == eau.STATUS_COMPLETE
+    assert out["wholeTenant"] is False
+    assert out["truncated"] is False
+
+
+def test_expand_nested_group_members_flattened():
+    # transitiveMembers flattens nested groups; the resolver returns the full set.
+    resolver = FakeResolver(group_map={
+        "parent": ["a@contoso.com", "b@contoso.com", "c@contoso.com"],
+    })
+    agent = {"fsi_agentid": "bot-2", "viewerGroups": ["parent"]}
+    out = eau.expand_agent_audience(agent, resolver, CFG)
+    assert out["audienceSize"] == 3
+    assert out["sourceGroups"][0]["memberCount"] == 3
+
+
+def test_expand_whole_tenant_not_enumerated():
+    resolver = FakeResolver(group_map={"g1": ["x@contoso.com"]})
+    agent = {"fsi_agentid": "bot-3", "sharedWithEveryone": True,
+             "viewerGroups": ["g1"]}
+    out = eau.expand_agent_audience(agent, resolver, CFG)
+    assert out["wholeTenant"] is True
+    assert out["intendedUsers"] == []
+    assert out["audienceSize"] == 0
+    assert out["resolutionStatus"] == eau.STATUS_WHOLE_TENANT
+    # Crucially: the tenant was NOT enumerated.
+    assert resolver.group_calls == []
+
+
+def test_expand_truncation_sets_partial():
+    resolver = FakeResolver(
+        group_map={"big": ["u1@contoso.com", "u2@contoso.com"]},
+        truncated_groups={"big"},
+    )
+    agent = {"fsi_agentid": "bot-4", "viewerGroups": ["big"]}
+    out = eau.expand_agent_audience(agent, resolver, CFG)
+    assert out["truncated"] is True
+    assert out["resolutionStatus"] == eau.STATUS_PARTIAL
+    assert out["sourceGroups"][0]["truncated"] is True
+
+
+def test_expand_group_error_partial_when_other_members():
+    resolver = FakeResolver(
+        group_map={"ok": ["good@contoso.com"]},
+        error_groups={"bad": "group not found (404)"},
+    )
+    agent = {"fsi_agentid": "bot-5", "viewerGroups": ["ok", "bad"]}
+    out = eau.expand_agent_audience(agent, resolver, CFG)
+    assert out["audienceSize"] == 1
+    assert out["resolutionStatus"] == eau.STATUS_PARTIAL
+    assert any(e["ref"] == "bad" for e in out["resolutionErrors"])
+
+
+def test_expand_all_errors_no_members_is_failed():
+    resolver = FakeResolver(error_groups={"bad": "HTTP 403"})
+    agent = {"fsi_agentid": "bot-6", "viewerGroups": ["bad"]}
+    out = eau.expand_agent_audience(agent, resolver, CFG)
+    assert out["audienceSize"] == 0
+    assert out["resolutionStatus"] == eau.STATUS_FAILED
+
+
+def test_expand_no_sharing_is_clean_empty():
+    resolver = FakeResolver()
+    agent = {"fsi_agentid": "bot-7", "viewerGroups": [], "editorPrincipals": []}
+    out = eau.expand_agent_audience(agent, resolver, CFG)
+    assert out["audienceSize"] == 0
+    assert out["intendedUsers"] == []
+    assert out["resolutionStatus"] == eau.STATUS_COMPLETE
+    assert out["resolutionErrors"] == []
+
+
+def test_expand_editor_mix_user_group_and_userid():
+    resolver = FakeResolver(
+        group_map={"eg": ["team1@contoso.com", "alice@contoso.com"]},
+        user_map={"uid-1": "dan@contoso.com"},
+    )
+    agent = {
+        "fsi_agentid": "bot-8",
+        "viewerGroups": [],
+        "editorPrincipals": [
+            {"upn": "alice@contoso.com"},            # direct user (also in eg -> dedup)
+            {"id": "eg", "type": "Group"},            # group expansion
+            {"id": "uid-1", "type": "User"},          # user id -> resolve UPN
+        ],
+    }
+    out = eau.expand_agent_audience(agent, resolver, CFG)
+    upns = {u["upn"] for u in out["intendedUsers"]}
+    assert upns == {"alice@contoso.com", "team1@contoso.com", "dan@contoso.com"}
+    assert "uid-1" in resolver.user_calls
+
+
+def test_expand_unresolvable_user_id_records_error():
+    resolver = FakeResolver()  # user_map empty -> cannot resolve
+    agent = {"fsi_agentid": "bot-9",
+             "editorPrincipals": [{"id": "ghost", "type": "User"}]}
+    out = eau.expand_agent_audience(agent, resolver, CFG)
+    assert out["audienceSize"] == 0
+    assert any(e["ref"] == "ghost" for e in out["resolutionErrors"])
+    assert out["resolutionStatus"] == eau.STATUS_FAILED
+
+
+def test_expand_unknown_ref_records_error():
+    resolver = FakeResolver()
+    agent = {"fsi_agentid": "bot-10", "viewerGroups": [12345]}
+    out = eau.expand_agent_audience(agent, resolver, CFG)
+    assert any(e["error"] == "unrecognized sharing reference"
+               for e in out["resolutionErrors"])
+
+
+# ---------------------------------------------------------------------------
+# Dataverse write-back projection — counts/flags only, no PII
+# ---------------------------------------------------------------------------
+
+
+def test_build_authshare_update_logical_names_and_no_pii():
+    resolver = FakeResolver(group_map={"g1": ["a@contoso.com", "b@contoso.com"]})
+    out = eau.expand_agent_audience(
+        {"fsi_agentid": "bot-11", "fsi_environmentid": "env-1", "viewerGroups": ["g1"]},
+        resolver, CFG)
+    upd = eau.build_authshare_update(out, run_id="run-xyz")
+    assert set(upd.keys()) == {
+        "fsi_agentid", "fsi_environmentid", "fsi_audiencewholetenant",
+        "fsi_audienceupncount", "fsi_audiencetruncated",
+        "fsi_audienceresolutionstatus", "fsi_audienceresolvedat", "fsi_runid",
+    }
+    # Logical-name convention: lowercase, no inter-word underscore after the
+    # fsi_ prefix.
+    for key in upd:
+        assert key == key.lower()
+        assert "_" not in key[len("fsi_"):]
+    # No UPNs / PII leaked into the Dataverse projection.
+    blob = json.dumps(upd)
+    assert "@contoso.com" not in blob
+    assert "intendedUsers" not in upd
+    assert upd["fsi_audienceupncount"] == 2
+    assert upd["fsi_audienceresolvedat"].endswith("Z")
+
+
+# ---------------------------------------------------------------------------
+# expand_all summary + artifact
+# ---------------------------------------------------------------------------
+
+
+def test_expand_all_summary_counts():
+    resolver = FakeResolver(
+        group_map={"g1": ["a@contoso.com"]},
+        error_groups={"bad": "HTTP 500"},
+    )
+    agents = [
+        {"fsi_agentid": "a1", "viewerGroups": ["g1"]},
+        {"fsi_agentid": "a2", "sharedWithEveryone": True},
+        {"fsi_agentid": "a3", "viewerGroups": ["bad"]},
+    ]
+    art = eau.expand_all(agents, resolver, CFG, run_id="run-1")
+    assert art["summary"]["agentCount"] == 3
+    assert art["summary"]["wholeTenantAgentCount"] == 1
+    assert art["summary"]["agentsWithResolutionErrors"] == 1
+    assert art["schemaVersion"]
+    assert len(art["agents"]) == 3
+    assert len(art["authShareUpdates"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Input loading + dry-run resolver
+# ---------------------------------------------------------------------------
+
+
+def test_load_agents_from_input_object_and_array(tmp_path):
+    obj = tmp_path / "obj.json"
+    obj.write_text(json.dumps({"agents": [{"fsi_agentid": "x"}]}), encoding="utf-8")
+    assert eau.load_agents_from_input(str(obj)) == [{"fsi_agentid": "x"}]
+
+    arr = tmp_path / "arr.json"
+    arr.write_text(json.dumps([{"fsi_agentid": "y"}]), encoding="utf-8")
+    assert eau.load_agents_from_input(str(arr)) == [{"fsi_agentid": "y"}]
+
+
+def test_load_agents_from_input_utf8_bom(tmp_path):
+    p = tmp_path / "bom.json"
+    p.write_text(json.dumps({"agents": []}), encoding="utf-8-sig")
+    assert eau.load_agents_from_input(str(p)) == []
+
+
+def test_dry_run_resolver_resolves_nothing():
+    resolver = eau.DryRunResolver()
+    assert resolver.user_upn("anything") is None
+    res = resolver.transitive_member_upns("g1")
+    assert res.upns == [] and res.error and "dry-run" in res.error
+
+
+def test_dry_run_whole_tenant_still_flagged():
+    resolver = eau.DryRunResolver()
+    out = eau.expand_agent_audience({"fsi_agentid": "z", "sharedWithEveryone": True},
+                                    resolver, CFG)
+    assert out["wholeTenant"] is True
+    assert out["resolutionStatus"] == eau.STATUS_WHOLE_TENANT

--- a/copilot-agent-inventory/tests/test_expand_audience_upns.py
+++ b/copilot-agent-inventory/tests/test_expand_audience_upns.py
@@ -23,8 +23,11 @@ feed Copilot Billing Governance:
 from __future__ import annotations
 
 import json
+import logging
 import sys
+import time
 from pathlib import Path
+from types import SimpleNamespace
 
 SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
@@ -357,3 +360,206 @@ def test_dry_run_whole_tenant_still_flagged():
                                     resolver, CFG)
     assert out["wholeTenant"] is True
     assert out["resolutionStatus"] == eau.STATUS_WHOLE_TENANT
+
+
+# ===========================================================================
+# Regression tests for GATE-1 findings (H1, M1, M2, M4)
+# ===========================================================================
+
+
+def _install_fake_dataverse(monkeypatch, rows):
+    """Inject a fake ``dataverse_client`` module so the Dataverse-backed paths
+    (load_agents_from_dataverse / _write_back_authshare) can be exercised with no
+    network or credential. Returns a ``captured`` dict recording init kwargs,
+    queries (entity_set/select/filter_expr/top) and update_record calls.
+    """
+    import types
+
+    captured: dict = {"queries": [], "updates": [], "init_kwargs": None}
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            captured["init_kwargs"] = kwargs
+
+        def query(self, entity_set, select=None, filter_expr=None,
+                  orderby=None, top=None):
+            captured["queries"].append({
+                "entity_set": entity_set, "select": select,
+                "filter_expr": filter_expr, "top": top,
+            })
+            return [dict(r) for r in rows]
+
+        def update_record(self, entity_set, record_id, payload):
+            captured["updates"].append({
+                "entity_set": entity_set, "id": record_id, "payload": payload,
+            })
+
+    module = types.ModuleType("dataverse_client")
+    module.DataverseClient = _FakeClient  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "dataverse_client", module)
+    return captured
+
+
+# --- H1: org-wide-shared agent must NOT become a confident empty audience ----
+
+def test_dataverse_org_wide_agent_is_not_confident_empty(monkeypatch):
+    # An agent shared org-wide (fsi_sharedwitheveryone=True) with no group refs.
+    # The pre-fix loader inferred sharing from fsi_limitsharingmode (fake values)
+    # and produced sharedWithEveryone=False -> an empty audience asserted Complete
+    # for a tenant-reachable agent (the exact silent-success the design forbids).
+    rows = [{
+        "fsi_agentid": "org-wide-bot",
+        "fsi_environmentid": "env-1",
+        "fsi_sharedwitheveryone": True,
+    }]
+    captured = _install_fake_dataverse(monkeypatch, rows)
+
+    agents = eau.load_agents_from_dataverse("https://x.crm.dynamics.com", "t", "default")
+
+    # The loader reads the per-agent column and never the env-wide policy.
+    select = captured["queries"][0]["select"]
+    assert "fsi_sharedwitheveryone" in select
+    assert "fsi_limitsharingmode" not in select
+    assert agents[0].get("sharedWithEveryone") is True
+
+    out = eau.expand_agent_audience(agents[0], FakeResolver(), CFG)
+    assert out["wholeTenant"] is True
+    assert out["resolutionStatus"] == eau.STATUS_WHOLE_TENANT
+    assert out["resolutionStatus"] != eau.STATUS_COMPLETE
+
+
+def test_dataverse_unknown_signal_refless_is_partial_not_confident_empty(
+    monkeypatch, caplog
+):
+    # A posture row with NO whole-tenant signal and NO viewer/editor refs must be
+    # marked Partial (signal unknown), never a confident empty Complete audience.
+    rows = [{"fsi_agentid": "unknown-bot", "fsi_environmentid": "env-1"}]
+    _install_fake_dataverse(monkeypatch, rows)
+
+    agents = eau.load_agents_from_dataverse("https://x.crm.dynamics.com", "t", "default")
+    assert agents[0].get("wholeTenantSignalKnown") is False
+    assert "sharedWithEveryone" not in agents[0]
+
+    with caplog.at_level(logging.WARNING, logger=eau.logger.name):
+        out = eau.expand_agent_audience(agents[0], FakeResolver(), CFG)
+
+    assert out["resolutionStatus"] == eau.STATUS_PARTIAL
+    assert out["resolutionStatus"] != eau.STATUS_COMPLETE
+    assert any("no whole-tenant signal" in r.getMessage() for r in caplog.records)
+
+
+def test_dataverse_explicit_not_shared_with_everyone_stays_clean_empty(monkeypatch):
+    # A genuine restricted agent (fsi_sharedwitheveryone=False, no refs) is a KNOWN
+    # signal: a clean empty audience (Complete) is correct here.
+    rows = [{"fsi_agentid": "restricted-bot", "fsi_sharedwitheveryone": False}]
+    _install_fake_dataverse(monkeypatch, rows)
+
+    agents = eau.load_agents_from_dataverse("https://x.crm.dynamics.com", "t", "default")
+    assert agents[0].get("sharedWithEveryone") is False
+
+    out = eau.expand_agent_audience(agents[0], FakeResolver(), CFG)
+    assert out["wholeTenant"] is False
+    assert out["resolutionStatus"] == eau.STATUS_COMPLETE
+
+
+# --- M1: Graph token must refresh as it nears expiry (no 401 on long runs) ---
+
+class _FakeAccessToken:
+    def __init__(self, token, expires_on):
+        self.token = token
+        self.expires_on = expires_on
+
+
+class _FakeCredential:
+    def __init__(self, expires_on_seq):
+        self._seq = list(expires_on_seq)
+        self.calls = 0
+
+    def get_token(self, *scopes, **kwargs):
+        self.calls += 1
+        exp = self._seq.pop(0) if self._seq else (time.time() + 3600)
+        return _FakeAccessToken(f"token-{self.calls}", exp)
+
+
+def _resolver_without_init():
+    # Bypass __init__ (which imports requests) so the token-refresh logic is tested
+    # hermetically with an injected fake credential.
+    resolver = eau.GraphMemberResolver.__new__(eau.GraphMemberResolver)
+    resolver.auth_mode = "managed-identity"
+    resolver._access_token = None
+    return resolver
+
+
+def test_graph_resolver_refreshes_token_before_expiry():
+    resolver = _resolver_without_init()
+    now = time.time()
+    # First token expires within the refresh skew (300s); second is long-lived.
+    cred = _FakeCredential([now + 30, now + 3600])
+    resolver._credential_obj = cred
+
+    assert resolver._bearer_token() == "token-1"
+    assert cred.calls == 1
+    # Near-expiry token must be refreshed on the next request (the 401 fix).
+    assert resolver._bearer_token() == "token-2"
+    assert cred.calls == 2
+    # Long-lived token is reused (no needless refetch).
+    assert resolver._bearer_token() == "token-2"
+    assert cred.calls == 2
+
+
+def test_graph_resolver_headers_use_refreshed_token():
+    resolver = _resolver_without_init()
+    cred = _FakeCredential([time.time() + 3600])
+    resolver._credential_obj = cred
+    headers = resolver._headers()
+    assert headers["Authorization"] == "Bearer token-1"
+
+
+# --- M2: Retry-After parsing must survive the RFC 7231 HTTP-date format ------
+
+def test_parse_retry_after_numeric_seconds():
+    assert eau._parse_retry_after("5", 1.0) == 5.0
+    assert eau._parse_retry_after("0", 1.0) == 0.0
+
+
+def test_parse_retry_after_http_date_returns_delta():
+    from datetime import datetime, timedelta, timezone
+    from email.utils import format_datetime
+
+    future = datetime.now(timezone.utc) + timedelta(seconds=120)
+    delta = eau._parse_retry_after(format_datetime(future), 1.0)
+    # ~120s minus a little execution time; never the fallback.
+    assert 90.0 <= delta <= 121.0
+
+
+def test_parse_retry_after_garbage_and_missing_fall_back():
+    assert eau._parse_retry_after("not-a-date", 7.0) == 7.0
+    assert eau._parse_retry_after(None, 9.0) == 9.0
+    assert eau._parse_retry_after("", 3.0) == 3.0
+    # A negative number is nonsensical -> fall back rather than sleep(-n).
+    assert eau._parse_retry_after("-5", 2.0) == 2.0
+
+
+# --- M4: OData write-back filter must escape single quotes --------------------
+
+def test_odata_escape_doubles_single_quotes():
+    assert eau._odata_escape("o'brien") == "o''brien"
+    assert eau._odata_escape("plain") == "plain"
+    assert eau._odata_escape("a'b'c") == "a''b''c"
+
+
+def test_write_back_escapes_agent_id_in_filter(monkeypatch):
+    captured = _install_fake_dataverse(monkeypatch, [{"fsi_caiauthshareid": "row-1"}])
+    args = SimpleNamespace(
+        environment_url="https://x.crm.dynamics.com",
+        tenant_id="t", auth_mode="default",
+    )
+    updates = [{"fsi_agentid": "o'brien-bot", "fsi_audienceupncount": 3}]
+
+    eau._write_back_authshare(updates, args)
+
+    # The single quote in the agent id is doubled per the OData spec, so the
+    # $filter is well-formed (and not an injection vector).
+    assert captured["queries"][0]["filter_expr"] == "fsi_agentid eq 'o''brien-bot'"
+    # fsi_agentid is stripped from the update payload (it is the lookup key).
+    assert captured["updates"][0]["payload"] == {"fsi_audienceupncount": 3}


### PR DESCRIPTION
## FNF People-Sweep — CAI People-capability detection + audience→UPN

Part of the FNF People-Sweep back-port. Answers (the discovery half of) FNF Director Britton Hall's question: which declarative agents have the **"Reference org chart and profile info"** (declarative-manifest `People`) capability, and who are they shared with.

### What's here (`copilot-agent-inventory`)
- `detect_people_capability.py` — static detector for `capabilities[].name == "People"` (schema v1.3+); `--id-map` de-provisionalizes manifest stems → bot GUIDs; non-fatal case-drift warning.
- `expand_audience_upns.py` — share-group → transitive-member UPNs via Microsoft Graph.
- Schema: `fsi_caiagentfeature` "People (Org Chart & Profile)" type + provisional / shared-with-everyone flags.

### Verification
Pytest green; `py_compile` clean; live-validated on autojude as part of the chain. Lab-validation record: judep_microsoft/FSI-AgentGov-Lab#4.