### PR TITLE
fix(agent-intake): remove out-of-scope gov-cloud mentions (commercial-scope CI)

### DIFF
--- a/agent-intake/README.md
+++ b/agent-intake/README.md
@@ -171,7 +171,7 @@ See [`docs/pilot-deployment-runbook.md`](docs/pilot-deployment-runbook.md) for t
 Express, Standard, and Full paths all ship in v1.0.0-preview. Forward-looking items:
 
 - **v1.1** — Convert `fsi_appealofid` to a self-lookup; live-tenant verification of the Microsoft Entra Agent ID `fsiReviewerAttestations` open-type field; Power Pages multistep form-binding automation once PAC CLI supports it.
-- **Post-v1.0** — M365 Copilot declarative agent surface (conversational intake); sovereign cloud adaptation guide (GCC / GCC-High / DoD); localization beyond en-US.
+- **Post-v1.0** — M365 Copilot declarative agent surface (conversational intake); localization beyond en-US.
 - **v1.0 (live)** — Promote from preview after pilot-firm validation feedback is incorporated.
 
 ## Changelog

--- a/agent-intake/docs/decisions.md
+++ b/agent-intake/docs/decisions.md
@@ -60,7 +60,7 @@ This ADR consolidates the locked product-owner decisions that shape agent-intake
 
 **Decision:** If the maker's working country (from Entra ID profile) differs from the declared data residency country of any data source the agent will use, the request defaults to **denied** with reason "cross-border data routing requires Privacy review". A Privacy reviewer can override.
 
-**Why:** Cross-border data flows are a primary GDPR / Schrems II / sovereign-cloud risk surface. A conservative default protects customers who have not yet built a Privacy review function; those that have can override per request.
+**Why:** Cross-border data flows are a primary GDPR / Schrems II / data-residency risk surface. A conservative default protects customers who have not yet built a Privacy review function; those that have can override per request.
 
 **Override:** `cross_border.default_action` (`deny` | `flag_for_review` | `allow`); `cross_border.privacy_override_role`.
 


### PR DESCRIPTION
## Clear pre-existing `commercial-scope` CI failure

Two forward-facing `agent-intake` docs (pre-existing on `main`) tripped the commercial-cloud-scope gate:
- `agent-intake/README.md` — Post-v1.0 roadmap promised a "sovereign cloud adaptation guide (GCC / GCC-High / DoD)", which is out of this repo's US-commercial-cloud scope. Removed the clause.
- `agent-intake/docs/decisions.md` (ADR-005) — used "sovereign-cloud" as a risk-surface adjective; reworded to "data-residency" (same meaning, no banned term).

Verified locally: `python scripts/verify_commercial_scope.py` → ✅ 0 violations across 477 files.

This unblocks the repo-wide `commercial-scope` check, including the FNF People-Sweep back-port PRs #323 and #324 (which inherit this pre-existing failure via the whole-repo scan).