### PR TITLE
feat: #1390 Purview audit records-fetch, pagination, CopilotInteraction mapping

### DIFF
--- a/agent-cost-reporting/docs/api-surface-matrix.md
+++ b/agent-cost-reporting/docs/api-surface-matrix.md
@@ -13,6 +13,7 @@ during deployment. Status reflects research as of 2026-06-16.
 | Power Platform API | Policy → environments | `GET .../licensing/billingPolicies/{id}/environments` | 2024-10-01 | SP + Power Platform RBAC | **No** | GA |
 | Power Platform API | Capacity allocations | `GET .../licensing/capacityAllocations` | 2024-10-01 | SP + Power Platform RBAC | **No** | **Preview — "do not use in production"** |
 | Purview audit (Graph) | Copilot interactions | `POST graph.microsoft.com/beta/security/auditLog/queries` | beta | AuditLogsQuery.Read.All | Yes | **Beta; not in US Gov/China** |
+| Purview audit (Graph) | Copilot interaction records | `GET graph.microsoft.com/beta/security/auditLog/queries/{id}/records` | beta | AuditLogsQuery.Read.All | Yes | **Beta; `@odata.nextLink` paging; `auditData` mapping unverified** |
 | Manual export | Per-agent credit consumption | M365 admin / PPAC CSV | n/a | Admin portal | No | **UI only (the gap)** |
 
 ## What is and is not attributable

--- a/agent-cost-reporting/docs/known-gaps.md
+++ b/agent-cost-reporting/docs/known-gaps.md
@@ -22,7 +22,7 @@ architecture; they affect specific collectors or mappings.
 | Exact Azure meter names/IDs for Power Platform / Copilot Studio / Agent 365 | `normalize_cost_facts.py` meter filtering | Run a Cost Management query grouped by MeterId/Meter over a subscription with known usage |
 | Whether `capacityAllocations` returns consumed vs allocated | preview PP collector | Live call with nonzero usage; inspect payload |
 | Agent 365 `skuPartNumber` values ($15 standalone, E7 bundle) | license mapping | `GET /subscribedSkus` from a tenant with the SKUs assigned |
-| Purview audit records-fetch endpoint + `CopilotInteraction` schema | beta audit collector | Run a query to completion; enumerate records and agent-identifying fields |
+| Purview audit records-fetch endpoint + `CopilotInteraction` schema | beta audit collector | Records-fetch + `@odata.nextLink` paging + field mapping are now implemented; the `auditData` field names/casing/availability when surfaced through Graph beta remain unverified — run a query to completion, enumerate records, and confirm the agent-identifying fields |
 | Whether Agent 365 ACU consumption is a distinct Azure meter | cost coverage | Export Cost Management while generating known Agent 365 activity |
 | Current GA api-version for PP licensing + Azure Cost Management | all collectors | Confirm against the published REST references at build time |
 

--- a/agent-cost-reporting/scripts/collectors/collect_purview_audit_queries_beta.py
+++ b/agent-cost-reporting/scripts/collectors/collect_purview_audit_queries_beta.py
@@ -14,9 +14,15 @@ Constraints (must be respected):
     record retrieval is not yet wired.
 
 Endpoints:
-  POST {GRAPH_BETA_HOST}/security/auditLog/queries
-  GET  {GRAPH_BETA_HOST}/security/auditLog/queries/{queryId}
+  POST {GRAPH_BETA_HOST}/security/auditLog/queries                    (create query)
+  GET  {GRAPH_BETA_HOST}/security/auditLog/queries/{queryId}          (poll status)
+  GET  {GRAPH_BETA_HOST}/security/auditLog/queries/{queryId}/records  (fetch records, paged)
 Auth: Graph token with AuditLogsQuery.Read.All.
+
+The records endpoint returns a collection of auditLogRecord objects using the standard
+Microsoft Graph @odata.nextLink paging model; each CopilotInteraction is mapped to the
+supplementary reporting shape (see map_copilot_interaction). Field mapping is UNVERIFIED
+against a live tenant -- see docs/known-gaps.md.
 """
 
 from __future__ import annotations
@@ -76,6 +82,123 @@ def poll_query(query_id: str, token: str) -> str:
     return "running"
 
 
+# ---------------------------------------------------------------------------
+# Records fetch + CopilotInteraction field mapping.
+#
+# The records endpoint returns a collection of auditLogRecord objects using the
+# standard Microsoft Graph @odata.nextLink paging model. The Copilot-specific
+# detail lives in the opaque `auditData` blob; the copilotInteractionAuditRecord
+# beta resource documents no explicit properties, so the auditData field names
+# used below follow the Office 365 Management Activity API "CopilotInteraction"
+# schema (AppHost, Contexts, ThreadId, MessageIds, AccessedResources, AgentId, ...).
+# Casing and availability of these fields when surfaced through Graph beta are
+# UNVERIFIED against a live tenant, so extraction is case-insensitive and every
+# Copilot-specific field is optional. See docs/known-gaps.md.
+# ---------------------------------------------------------------------------
+
+# Hard stop so a misbehaving @odata.nextLink cannot page forever.
+RECORDS_MAX_PAGES = 1000
+
+
+def _default_get_json(url: str, headers: dict) -> dict:
+    """Default transport: authenticated GET returning parsed JSON."""
+    import requests
+
+    resp = requests.get(url, headers=headers, timeout=120)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_query_records(query_id: str, token: str, get_json=None) -> list:
+    """Fetch all auditLogRecord objects for a completed query, following @odata.nextLink.
+
+    Handles the empty result set, a single page (no nextLink), and multi-page responses,
+    and guards against a server that echoes an identical nextLink. `get_json` is injectable
+    so the pagination logic can be unit-tested with mocked payloads and no network access.
+    """
+    get_json = get_json or _default_get_json
+    headers = {"Authorization": f"Bearer {token}"}
+    url = f"{lib.GRAPH_BETA_HOST}/security/auditLog/queries/{query_id}/records"
+    records: list = []
+    seen_links: set = set()
+    pages = 0
+    while url and pages < RECORDS_MAX_PAGES:
+        payload = get_json(url, headers)
+        pages += 1
+        records.extend(payload.get("value") or [])
+        next_link = payload.get("@odata.nextLink")
+        if next_link and next_link in seen_links:
+            logger.warning("Audit records nextLink repeated; stopping to avoid an infinite loop.")
+            break
+        if next_link:
+            seen_links.add(next_link)
+        url = next_link
+    if url and pages >= RECORDS_MAX_PAGES:
+        logger.warning("Stopped after %d record page(s); more records may remain.", pages)
+    logger.info("Fetched %d Copilot audit record(s) across %d page(s).", len(records), pages)
+    return records
+
+
+def _audit_data_dict(record: dict) -> dict:
+    """Return a record's auditData as a dict.
+
+    Graph may return auditData as a nested JSON object or, for some workloads, as a
+    JSON-encoded string. Both are handled; anything else yields an empty dict.
+    """
+    data = record.get("auditData")
+    if isinstance(data, dict):
+        return data
+    if isinstance(data, str):
+        try:
+            parsed = json.loads(data)
+        except (ValueError, TypeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _ci_get(data: dict, *names: str):
+    """Case-insensitive lookup: return the first present key among `names`, else None."""
+    lowered = {str(k).lower(): v for k, v in data.items()}
+    for name in names:
+        if name.lower() in lowered:
+            return lowered[name.lower()]
+    return None
+
+
+def map_copilot_interaction(record: dict) -> dict:
+    """Map one auditLogRecord to the supplementary Copilot-interaction reporting shape.
+
+    Envelope fields come from the auditLogRecord itself; Copilot detail is pulled from the
+    auditData blob (see the module note on schema uncertainty). This is USAGE evidence only
+    and is never folded into authoritative cost totals.
+    """
+    audit_data = _audit_data_dict(record)
+    return {
+        "source_surface": lib.SURFACE_PURVIEW_AUDIT,
+        "record_id": lib.stable_record_id(record.get("id"), record),
+        "created_utc": record.get("createdDateTime"),
+        "operation": record.get("operation"),
+        "record_type": record.get("auditLogRecordType"),
+        "organization_id": record.get("organizationId"),
+        "service": record.get("service"),
+        "user_id": record.get("userId"),
+        "user_principal_name": record.get("userPrincipalName"),
+        "user_type": record.get("userType"),
+        "client_ip": record.get("clientIp"),
+        # Copilot-specific detail from auditData (all optional; casing UNVERIFIED).
+        "app_host": _ci_get(audit_data, "AppHost"),
+        "app_identity": _ci_get(audit_data, "AppIdentity"),
+        "agent_id": _ci_get(audit_data, "AgentId"),
+        "ai_system_plugin": _ci_get(audit_data, "AISystemPlugin"),
+        "contexts": _ci_get(audit_data, "Contexts"),
+        "thread_id": _ci_get(audit_data, "ThreadId", "ThreadID"),
+        "message_ids": _ci_get(audit_data, "MessageIds", "MessageIDs"),
+        "accessed_resources": _ci_get(audit_data, "AccessedResources"),
+        "model_transparency_details": _ci_get(audit_data, "ModelTransparencyDetails"),
+    }
+
+
 def _main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--start-utc", required=True)
@@ -111,20 +234,37 @@ def _main() -> int:
     query = create_audit_query(args.start_utc, args.end_utc, token)
     query_id = query.get("id")
     status = poll_query(query_id, token) if query_id else "unknown"
-    # Records-fetch endpoint + CopilotInteraction schema are unverified at scaffold time.
-    # Persist the query metadata and degrade gracefully until record retrieval is wired.
-    result.extract_path = lib.write_raw_extract(
-        args.out_dir, lib.SURFACE_PURVIEW_AUDIT, args.snapshot_id, [{"query": query, "status": status}]
-    )
-    result.rows = 0
-    result.data_freshness_utc = lib.utc_now_iso()
-    if status == "succeeded":
-        result.note = "Query succeeded; records-fetch not yet implemented -- verify the records endpoint on a live tenant."
-        result.finish("partial")
+    # When the query has completed, fetch its records (with @odata.nextLink paging) and
+    # map each CopilotInteraction to the supplementary reporting shape. The auditData schema
+    # is UNVERIFIED against a live tenant, so mapping is defensive and the surface stays
+    # supplementary (usage evidence, never authoritative cost).
+    if query_id and status == "succeeded":
+        raw_records = fetch_query_records(query_id, token)
+        mapped = [map_copilot_interaction(r) for r in raw_records]
+        result.extract_path = lib.write_raw_extract(
+            args.out_dir, lib.SURFACE_PURVIEW_AUDIT, args.snapshot_id, mapped
+        )
+        result.rows = len(mapped)
+        result.data_freshness_utc = lib.utc_now_iso()
+        if mapped:
+            result.note = (
+                f"Fetched {len(mapped)} Copilot interaction record(s). Supplementary usage "
+                "evidence; auditData field mapping is unverified against a live tenant."
+            )
+            result.finish("partial")
+        else:
+            result.note = "Query succeeded with no Copilot interaction records in range."
+            result.finish("succeeded")
     else:
-        result.note = f"Audit query status='{status}'."
+        # Non-terminal or failed query: persist the query metadata for provenance only.
+        result.extract_path = lib.write_raw_extract(
+            args.out_dir, lib.SURFACE_PURVIEW_AUDIT, args.snapshot_id, [{"query": query, "status": status}]
+        )
+        result.rows = 0
+        result.data_freshness_utc = lib.utc_now_iso()
+        result.note = f"Audit query status='{status}'; no records fetched."
         result.finish("partial")
-    logger.info("Purview audit query created (status=%s).", status)
+    logger.info("Purview audit query processed (status=%s, rows=%d).", status, result.rows)
     return 0
 
 

--- a/agent-cost-reporting/tests/test_purview_audit_collector.py
+++ b/agent-cost-reporting/tests/test_purview_audit_collector.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Offline unit tests for the Purview audit beta collector (records-fetch + mapping).
+
+No network access: @odata.nextLink pagination is exercised via an injected get_json
+callable, and CopilotInteraction field mapping is checked against mocked auditLogRecord
+payloads (dict and JSON-string auditData, case-insensitive keys, missing fields).
+
+Run with: python -m pytest tests/test_purview_audit_collector.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+
+SOLUTION_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPTS = os.path.join(SOLUTION_ROOT, "scripts")
+sys.path.insert(0, os.path.join(SCRIPTS, "shared"))
+
+
+def _load():
+    path = os.path.join(SCRIPTS, "collectors", "collect_purview_audit_queries_beta.py")
+    spec = importlib.util.spec_from_file_location("collect_purview_audit_queries_beta", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MOD = _load()
+
+
+def _sequential_pager(pages):
+    """Return (get_json, calls) that yields the given pages in order, ignoring the url."""
+    calls = {"n": 0}
+
+    def get_json(url, headers):
+        page = pages[calls["n"]]
+        calls["n"] += 1
+        return page
+
+    return get_json, calls
+
+
+def test_fetch_records_single_page():
+    get_json, calls = _sequential_pager([{"value": [{"id": "r1"}, {"id": "r2"}]}])
+    records = MOD.fetch_query_records("q1", "tok", get_json=get_json)
+    assert [r["id"] for r in records] == ["r1", "r2"]
+    assert calls["n"] == 1  # no nextLink -> exactly one request
+
+
+def test_fetch_records_multi_page():
+    pages = [
+        {"value": [{"id": "r1"}], "@odata.nextLink": "https://graph/next1"},
+        {"value": [{"id": "r2"}], "@odata.nextLink": "https://graph/next2"},
+        {"value": [{"id": "r3"}]},  # final page, no nextLink
+    ]
+    get_json, calls = _sequential_pager(pages)
+    records = MOD.fetch_query_records("q1", "tok", get_json=get_json)
+    assert [r["id"] for r in records] == ["r1", "r2", "r3"]
+    assert calls["n"] == 3
+
+
+def test_fetch_records_empty():
+    get_json, _ = _sequential_pager([{"value": []}])
+    assert MOD.fetch_query_records("q1", "tok", get_json=get_json) == []
+
+
+def test_fetch_records_missing_value_key():
+    get_json, _ = _sequential_pager([{}])  # neither value nor nextLink present
+    assert MOD.fetch_query_records("q1", "tok", get_json=get_json) == []
+
+
+def test_fetch_records_repeated_nextlink_guard():
+    # A server that echoes an identical nextLink must terminate, not loop forever.
+    # The base URL is fetched once, the echoed link once, then the repeat is detected
+    # and paging stops -- so exactly two pages are consumed and the call returns.
+    page = {"value": [{"id": "r1"}], "@odata.nextLink": "https://graph/same"}
+    records = MOD.fetch_query_records("q1", "tok", get_json=lambda url, headers: page)
+    assert [r["id"] for r in records] == ["r1", "r1"]
+
+
+def test_map_copilot_interaction_dict_auditdata():
+    record = {
+        "id": "40706737",
+        "createdDateTime": "2026-06-16T17:12:00Z",
+        "operation": "CopilotInteraction",
+        "auditLogRecordType": "copilotInteraction",
+        "organizationId": "org-1",
+        "service": "Copilot",
+        "userId": "user@contoso.com",
+        "userPrincipalName": "user@contoso.com",
+        "userType": "regular",
+        "clientIp": "10.0.0.1",
+        "auditData": {
+            "AppHost": "BizChat",
+            "AgentId": "agent-123",
+            "Contexts": [{"Id": "doc1"}],
+            "ThreadId": "thread-1",
+            "MessageIds": ["m1", "m2"],
+            "AccessedResources": [{"Name": "file.docx"}],
+            "AISystemPlugin": [{"Name": "plugin"}],
+        },
+    }
+    mapped = MOD.map_copilot_interaction(record)
+    assert mapped["source_surface"] == MOD.lib.SURFACE_PURVIEW_AUDIT
+    assert mapped["record_id"] == "40706737"
+    assert mapped["operation"] == "CopilotInteraction"
+    assert mapped["app_host"] == "BizChat"
+    assert mapped["agent_id"] == "agent-123"
+    assert mapped["thread_id"] == "thread-1"
+    assert mapped["message_ids"] == ["m1", "m2"]
+    assert mapped["user_principal_name"] == "user@contoso.com"
+
+
+def test_map_copilot_interaction_json_string_auditdata_and_casing():
+    # Some workloads deliver auditData as a JSON string, and casing may differ.
+    record = {
+        "id": "abc",
+        "createdDateTime": "2026-06-16T00:00:00Z",
+        "operation": "CopilotInteraction",
+        "auditData": json.dumps({"apphost": "Word", "threadID": "t9", "messageIDs": ["x"]}),
+    }
+    mapped = MOD.map_copilot_interaction(record)
+    assert mapped["app_host"] == "Word"
+    assert mapped["thread_id"] == "t9"
+    assert mapped["message_ids"] == ["x"]
+
+
+def test_map_copilot_interaction_missing_auditdata():
+    mapped = MOD.map_copilot_interaction({"id": "no-data", "operation": "CopilotInteraction"})
+    assert mapped["record_id"] == "no-data"
+    assert mapped["app_host"] is None
+    assert mapped["agent_id"] is None
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+    print("purview audit collector tests passed")


### PR DESCRIPTION
## Summary

Implements the **code-only, tenant-independent half** of JudeSquad issue **#1390** (agent-cost-reporting: Purview audit records-fetch, preview → GA) in the Purview beta collector.

Three items implemented in `agent-cost-reporting/scripts/collectors/collect_purview_audit_queries_beta.py`:

1. **Records-fetch** for completed audit queries via `GET /security/auditLog/queries/{queryId}/records` (Graph beta) — new `fetch_query_records()`.
2. **`@odata.nextLink` pagination** — loops until the link is absent; handles empty result set, single page, multi-page, and guards against a server that echoes an identical `nextLink` (hard `RECORDS_MAX_PAGES` cap as a backstop).
3. **`CopilotInteraction` field mapping** — new `map_copilot_interaction()` maps the `auditLogRecord` envelope + `auditData` blob into a supplementary reporting shape (`app_host`, `agent_id`, `contexts`, `thread_id`, `message_ids`, `accessed_resources`, `ai_system_plugin`, etc.). Defensive: handles `auditData` as either a nested object or a JSON-encoded string, with case-insensitive key lookup.

`_main()` now fetches + maps records when the query status is `succeeded` (writing mapped records as the raw extract), and still persists query metadata for provenance on non-terminal/failed queries. The surface remains **supplementary usage evidence** (`partial`), never folded into authoritative cost.

## API versions verified (public Microsoft docs)

| Surface | api-version | Status | Doc URL |
|---|---|---|---|
| Azure Cost Management — Query/Usage | `2025-03-01` | **GA** (confirmed) | https://learn.microsoft.com/en-us/rest/api/cost-management/query/usage?view=rest-cost-management-2025-03-01 |
| Power Platform API — Licensing / Billing Policy | `2024-10-01` | **GA** (confirmed) | https://learn.microsoft.com/en-us/rest/api/power-platform/licensing/billing-policy/get-billing-policy |
| Power Platform API — `capacityAllocations` | (shares `2024-10-01`) | **Preview** — "do not use in production" (no distinct GA confirmed) | see PP licensing reference above |
| Purview audit records endpoint (Graph) | `beta` | **Beta** (no v1.0); not in US Gov/China | https://learn.microsoft.com/en-us/graph/api/security-auditlogquery-list-records?view=graph-rest-beta |

Supporting schema docs relied on for the mapping:
- `auditLogRecord` resource (envelope fields): https://learn.microsoft.com/en-us/graph/api/resources/security-auditlogrecord?view=graph-rest-beta
- `copilotInteractionAuditRecord` (auditData subtype — documents **no explicit properties**): https://learn.microsoft.com/en-us/graph/api/resources/security-copilotinteractionauditrecord?view=graph-rest-beta
- CopilotInteraction `auditData` field names (AppHost, Contexts, ThreadId, MessageIds, AccessedResources, AgentId, AISystemPlugin, ModelTransparencyDetails): https://learn.microsoft.com/en-us/purview/audit-copilot and O365 Management API Copilot schema https://learn.microsoft.com/office/office-365-management-api/copilot-schema

The existing `COST_MANAGEMENT_API_VERSION = "2025-03-01"` and `POWERPLATFORM_API_VERSION = "2024-10-01"` constants in `cost_report_lib.py` are therefore **confirmed correct** against current GA references — no change required.

## Tests

Added `agent-cost-reporting/tests/test_purview_audit_collector.py` (offline, no network):
- pagination: single-page, multi-page, empty, missing `value` key, repeated-`nextLink` guard (via an injected `get_json` callable)
- mapping: dict `auditData`, JSON-string `auditData` with differing casing, missing `auditData`

```
$ python -m pytest agent-cost-reporting/tests/ -q
9 passed
```

Existing `test_pipeline_smoke.py` still passes (included in the 9).

## ⚠️ Unvalidated against a live tenant

**This code is complete but has NOT been run against a live Purview/Graph tenant.** I have no tenant access; everything was validated only via offline unit tests with mocked payloads. Specifically unverified:

- The exact **casing / presence** of `auditData` fields when surfaced through Graph beta (the `copilotInteractionAuditRecord` resource documents *no* properties, so field names are inferred from the O365 Management API schema). Mapping is deliberately case-insensitive + all-optional to tolerate drift.
- Whether Graph returns `auditData` as a nested object or a JSON string (both are handled).
- **Throttling / `Retry-After` (429)** is not specially handled — consistent with the sibling collectors, which also rely on `raise_for_status()`. Flag for follow-up if needed.

The **four live-data gap items remain Jude's tenant work** (unchanged by this PR — see `docs/known-gaps.md`):
1. Exact Azure meter names/IDs for Power Platform / Copilot Studio / Agent 365.
2. Whether `capacityAllocations` returns consumed vs allocated credits.
3. Agent 365 `skuPartNumber` values ($15 standalone / E7 bundle).
4. Whether Agent 365 ACU consumption is a distinct Azure meter.

Docs updated: `docs/api-surface-matrix.md` (new records-endpoint row), `docs/known-gaps.md` (records-fetch now implemented, mapping still pending live verification).

Refs: JudeSquad #1390.
