### PR TITLE
feat(early-release-validation): watch for MSCAT Part 2 to unblock ERV deliverables

### DIFF
--- a/.github/workflows/mscat-part2-watch.yml
+++ b/.github/workflows/mscat-part2-watch.yml
@@ -1,0 +1,66 @@
+name: MSCAT Part 2 Watch
+
+# Weekly poll of the MS Copilot Studio CAT blog (microsoft/mcscatblog) for the
+# "Building Enterprise AI Solutions" Part 2 post. Part 2 specifies the
+# early-release-ring environment-variable schema + ring URL that the deferred
+# early-release-validation deliverables depend on (create_erv_environment_variables.py
+# real schema + Check 4 EarlyReleaseReadinessCheck live probe), which currently ship
+# as fail-closed stubs. When Part 2 publishes, this opens an issue so the dependency
+# self-surfaces instead of relying on manual polling / nudges.
+# Tracking: JudeSquad #1266 / #1431.
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"   # Mondays 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Detect MSCAT Part 2
+        id: detect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # List the CAT blog post filenames; the matcher tests for a "Part 2" of
+          # the series. Treat any API hiccup (rate limit / outage) as not-found so
+          # the watch never fails the workflow on a transient error.
+          names="$(gh api repos/microsoft/mcscatblog/contents/_posts --jq '.[].name' 2>/dev/null || true)"
+          if [ -z "$names" ]; then
+            echo "Could not list mcscatblog _posts (API error / rate limit); treating as not-found."
+            echo "match=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          match="$(printf '%s\n' "$names" | python early-release-validation/scripts/watch_mscat_part2.py || true)"
+          echo "Matched: '${match:-<none>}'"
+          echo "match=$match" >> "$GITHUB_OUTPUT"
+
+      - name: Open issue when Part 2 is published
+        if: steps.detect.outputs.match != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATCH: ${{ steps.detect.outputs.match }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          title="MSCAT 'Building Enterprise AI Solutions' Part 2 published — implement early-release-validation deliverables"
+          body=$'MSCAT Part 2 appears to be published: **'"${MATCH}"$'**\n\nThis unblocks the deferred early-release-validation deliverables:\n\n- `early-release-validation/scripts/create_erv_environment_variables.py` — replace the fail-closed stub with the real early-release-ring environment-variable schema from Part 2.\n- Check 4 `EarlyReleaseReadinessCheck` live probe — implement the ring probe (currently reports Skipped).\n\nSee `early-release-validation/docs/` and the header of `create_erv_environment_variables.py`. Tracking: JudeSquad #1266 / #1431.\n\n**Verify** this is the correct post first, implement the two items, then close.\n\nDetected by: '"${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          existing="$(gh issue list -R "${GITHUB_REPOSITORY}" --search "$title in:title is:open" --json number --jq '.[0].number' 2>/dev/null || echo "")"
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            echo "Issue #$existing already open; not duplicating."
+          else
+            gh issue create -R "${GITHUB_REPOSITORY}" --title "$title" --body "$body"
+          fi

--- a/early-release-validation/CHANGELOG.md
+++ b/early-release-validation/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- MSCAT "Building Enterprise AI Solutions" Part 2 watch — `scripts/watch_mscat_part2.py`
+  (unit-tested in `tests/`) plus repo workflow `.github/workflows/mscat-part2-watch.yml`.
+  A weekly poll of the MS Copilot Studio CAT blog opens an issue when Part 2 publishes,
+  self-surfacing the deferred early-release-ring env-var schema
+  (`create_erv_environment_variables.py`) and Check 4 (`EarlyReleaseReadinessCheck`) live
+  probe instead of relying on manual polling. Tracking: JudeSquad #1266 / #1431.
+
 ## [0.1.0-preview] - 2026-06-30
 
 ### Added

--- a/early-release-validation/scripts/watch_mscat_part2.py
+++ b/early-release-validation/scripts/watch_mscat_part2.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Detect publication of MSCAT "Building Enterprise AI Solutions" Part 2.
+
+Part 2 specifies the early-release-ring environment-variable schema and ring URL
+that ``create_erv_environment_variables.py`` and Check 4
+(``EarlyReleaseReadinessCheck``) depend on. Until it publishes, those ship as
+fail-closed stubs. This helper lets ``.github/workflows/mscat-part2-watch.yml``
+self-surface the dependency instead of relying on manual polling / nudges.
+Tracking: JudeSquad #1266 / #1431.
+
+Reads MS Copilot Studio CAT blog ``_posts`` filenames (one per line) on stdin and
+prints the first filename that names Part 2 of the series, or nothing. The match
+logic is a pure function so it is unit-tested (``tests/test_watch_mscat_part2.py``)
+without any network access.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+# Series signal + a "part 2" token. Both are overridable via environment so the
+# watch can be tuned in one place if the published post's slug differs from the
+# expected wording (e.g. spelled "part two" or a different series phrasing).
+DEFAULT_SERIES_REGEX = r"enterprise[-_ ]?ai|building[-_ ]?enterprise"
+DEFAULT_PART2_REGEX = r"part[-_ ]?(2|two)\b"
+
+
+def find_part2(filenames, series_regex=DEFAULT_SERIES_REGEX,
+               part2_regex=DEFAULT_PART2_REGEX):
+    """Return the first filename that names Part 2 of the series, else ``None``.
+
+    A filename matches when it contains both the series signal and a whole-token
+    "part 2" marker. Part 1 (and false tokens like ``part-2024``) are excluded by
+    the word boundary in the part-2 pattern.
+    """
+    series = re.compile(series_regex, re.IGNORECASE)
+    part2 = re.compile(part2_regex, re.IGNORECASE)
+    for name in filenames:
+        if name and series.search(name) and part2.search(name):
+            return name.strip()
+    return None
+
+
+def main():
+    series_regex = os.environ.get("SERIES_REGEX", DEFAULT_SERIES_REGEX)
+    part2_regex = os.environ.get("PART2_REGEX", DEFAULT_PART2_REGEX)
+    names = [line.strip() for line in sys.stdin if line.strip()]
+    match = find_part2(names, series_regex, part2_regex)
+    if match:
+        print(match)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/early-release-validation/tests/test_watch_mscat_part2.py
+++ b/early-release-validation/tests/test_watch_mscat_part2.py
@@ -1,0 +1,57 @@
+"""Unit tests for the MSCAT Part 2 watch matcher (JudeSquad #1431).
+
+Loads the sibling ``scripts/watch_mscat_part2.py`` by path so the test works
+under the repo-wide ``pytest --import-mode=importlib`` run without packaging.
+"""
+import importlib.util
+import pathlib
+
+_SCRIPT = (
+    pathlib.Path(__file__).resolve().parents[1] / "scripts" / "watch_mscat_part2.py"
+)
+_spec = importlib.util.spec_from_file_location("watch_mscat_part2", _SCRIPT)
+watch = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(watch)
+
+
+def test_matches_part2_kebab():
+    posts = [
+        "2026-05-20-alm-copilot-studio-agents-foundation.md",
+        "2026-08-01-building-enterprise-ai-solutions-part-2.md",
+    ]
+    assert (
+        watch.find_part2(posts)
+        == "2026-08-01-building-enterprise-ai-solutions-part-2.md"
+    )
+
+
+def test_matches_part2_no_separator():
+    posts = ["2026-08-01-enterprise-ai-solutions-part2.md"]
+    assert watch.find_part2(posts) == posts[0]
+
+
+def test_matches_part_two_word():
+    posts = ["2026-09-01-building-enterprise-ai-solutions-part-two.md"]
+    assert watch.find_part2(posts) == posts[0]
+
+
+def test_ignores_part1():
+    posts = ["2026-07-01-building-enterprise-ai-solutions-part-1.md"]
+    assert watch.find_part2(posts) is None
+
+
+def test_ignores_unrelated_posts():
+    posts = [
+        "2026-05-20-alm-copilot-studio-agents-foundation.md",
+        "2026-06-15-modern-mcs-agent-skills.md",
+    ]
+    assert watch.find_part2(posts) is None
+
+
+def test_does_not_match_part_20_or_year():
+    posts = ["2026-01-01-enterprise-ai-solutions-part-2024-recap.md"]
+    assert watch.find_part2(posts) is None
+
+
+def test_empty_input():
+    assert watch.find_part2([]) is None


### PR DESCRIPTION
## TLDR
Adds a weekly GitHub Actions watch that self-surfaces the **MSCAT "Building Enterprise AI Solutions" Part 2** dependency. Part 2 (currently unpublished, no ETA) specifies the early-release-ring environment-variable schema + ring URL that the `early-release-validation` deliverables need; until it lands they ship as fail-closed stubs. This watch opens an issue when Part 2 publishes — replacing manual polling / per-round nudges. Tracking: JudeSquad #1266 / #1431.

## What
- **`.github/workflows/mscat-part2-watch.yml`** — weekly cron (Mon 08:00 UTC) + `workflow_dispatch`; lists `microsoft/mcscatblog` `_posts`, runs the matcher, and **idempotently** (search-by-title) opens an issue when Part 2 is detected. Transient API errors are treated as not-found (never fails the run).
- **`early-release-validation/scripts/watch_mscat_part2.py`** — pure, unit-tested matcher: series signal + whole-token "part 2" (matches `part-2` / `part2` / `part-two`), excludes `part 1` and false tokens like `part-2024`. Patterns overridable via `SERIES_REGEX` / `PART2_REGEX` env if the published slug differs.
- **`early-release-validation/tests/test_watch_mscat_part2.py`** — 7 pytest cases.
- CHANGELOG entry under `[Unreleased]`.

## Validation (local)
- ruff (E4/E7/E9/F/W) + `compileall` clean; **7 pytest green**; workflow YAML parses.
- **Live end-to-end:** piping the real `mcscatblog` `_posts` through the matcher returns **not-found** (Part 2 is not published yet); a synthetic `...-building-enterprise-ai-solutions-part-2.md` filename matches.

## Notes
- The two deferred deliverables (`create_erv_environment_variables.py` real schema, Check 4 live probe) remain correctly **fail-closed stubs** until Part 2 provides the schema — intentionally not implemented here (would require guessing an unpublished spec).
- No `Fixes` keyword: JudeSquad tracker #1431 stays open (blocked) until Part 2 actually publishes and the deliverables land — this PR just wires up the auto-detection.
