### PR TITLE
ci: add docs autonomy branch protection contract

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -1,0 +1,28 @@
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "Analyze csharp",
+      "Analyze python",
+      "commercial-scope",
+      "dependency-review",
+      "docs-autonomy",
+      "gitleaks",
+      "language-rules",
+      "lint",
+      "manifest-check",
+      "powershell",
+      "python"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": false,
+  "lock_branch": false,
+  "allow_fork_syncing": true
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -196,6 +196,18 @@ python scripts/build-manifest.py --check    # exits non-zero if drift exists
 python -m mkdocs build --strict             # fail on any broken link or missing nav file
 ```
 
+### Documentation autonomy protection
+
+- `.github/branch-protection.json` is the committed proposal for `main`; do not
+  apply live branch settings as part of documentation work.
+- The stable required context is `docs-autonomy`. It runs for every pull
+  request, validates manifest/schema determinism, language, commercial scope,
+  and the strict MkDocs build for relevant changes, and shim-succeeds for
+  non-documentation changes.
+- External network link checks remain non-required.
+- Run `python -m pytest scripts/tests/test_docs_autonomy_protection.py` after
+  changing the policy, workflow triggers, or documentation classifier.
+
 ## Validation
 
 ```bash

--- a/.github/workflows/agent-intake-ci.yml
+++ b/.github/workflows/agent-intake-ci.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 jobs:
-  python:
+  agent-intake-python:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -108,7 +108,7 @@ jobs:
         # see source drift without blocking unrelated CI fixes in this branch.
         run: python -m pytest agent-intake/tests/validators/test_validators_smoke.py -v
 
-  powershell:
+  agent-intake-powershell:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -147,7 +147,7 @@ jobs:
             exit 1
           }
 
-  language-rules:
+  agent-intake-language-rules:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/commercial-scope.yml
+++ b/.github/workflows/commercial-scope.yml
@@ -7,16 +7,9 @@ name: commercial-scope
 
 on:
   pull_request:
-    paths:
-      - "**/*.md"
-      - "**/*.json"
-      - "scripts/verify_commercial_scope.py"
-      - ".github/workflows/commercial-scope.yml"
+    branches: [main]
   push:
     branches: [main]
-    paths:
-      - "**/*.md"
-      - "**/*.json"
 
 permissions:
   contents: read

--- a/.github/workflows/docs-autonomy.yml
+++ b/.github/workflows/docs-autonomy.yml
@@ -1,0 +1,79 @@
+name: Docs Autonomy
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docs-autonomy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout solutions
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: solutions
+
+      - name: Classify changed paths
+        id: changes
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
+            BASE_SHA=$(git -C solutions rev-list --max-parents=0 "$HEAD_SHA")
+          fi
+          git -C solutions diff --name-only --diff-filter=ACDMRT \
+            "$BASE_SHA" "$HEAD_SHA" > changed-files.txt
+          python solutions/scripts/docs_autonomy.py \
+            --changed-files changed-files.txt \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Non-doc shim
+        if: steps.changes.outputs.docs != 'true'
+        run: echo "No documentation-relevant changes; docs-autonomy succeeds."
+
+      - name: Checkout framework controls
+        if: steps.changes.outputs.docs == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: judeper/FSI-AgentGov
+          ref: ${{ vars.FRAMEWORK_REF || 'v1.4.0' }}
+          path: fsi-agentgov
+
+      - name: Set up Python
+        if: steps.changes.outputs.docs == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: solutions/requirements-docs.txt
+
+      - name: Install documentation validators
+        if: steps.changes.outputs.docs == 'true'
+        working-directory: solutions
+        run: pip install -r requirements-docs.txt jsonschema pyyaml
+
+      - name: Validate documentation, manifests, and language
+        if: steps.changes.outputs.docs == 'true'
+        working-directory: solutions
+        env:
+          FRAMEWORK_CONTROLS: ${{ github.workspace }}/fsi-agentgov/assessment/manifest/controls.json
+        run: |
+          python scripts/validate-language-rules.py
+          python scripts/verify_commercial_scope.py
+          python scripts/build-manifest.py
+          python scripts/build-manifest.py --check
+          python scripts/sync-agent-md-versions.py --check
+          python scripts/lint-version-drift.py --strict
+          python scripts/lint-optionset-values.py --strict
+          python -m mkdocs build --strict

--- a/.github/workflows/language-rules.yml
+++ b/.github/workflows/language-rules.yml
@@ -25,69 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Banned compliance phrases
-        # Excludes files that DOCUMENT the rule (instruction files contain
-        # the banned phrases as examples), CHANGELOG history, and any
-        # `research/` subdirectory (preserved LLM outputs and meta-discussions
-        # of the rule itself).
-        run: |
-          set +e
-          patterns='ensures compliance|guarantees compliance|guarantee compliance|will prevent|eliminates risk'
-          hits=$(grep -rEn --include='*.md' \
-                   --exclude-dir='.git' \
-                   --exclude-dir='site' \
-                   --exclude-dir='site-docs' \
-                   --exclude-dir='.github' \
-                   --exclude-dir='research' \
-                   --exclude='AGENTS.md' \
-                   --exclude='CLAUDE.md' \
-                   --exclude='SECURITY.md' \
-                   --exclude='THREAT-MODEL.md' \
-                   --exclude='CHANGELOG.md' \
-                   --exclude='*/CHANGELOG.md' \
-                   "$patterns" . || true)
-          if [ -n "$hits" ]; then
-            echo "::error::Banned compliance phrases found:"
-            echo "$hits"
-            exit 1
-          fi
-          echo "OK: no banned compliance phrases."
-
-      - name: Banned product naming (Azure AD outside CHANGELOG/instructions)
-        run: |
-          set +e
-          hits=$(grep -rEn \
-                   --include='*.md' \
-                   --include='*.ps1' \
-                   --include='*.psm1' \
-                   --include='*.py' \
-                   --include='*.json' \
-                   --include='*.yaml' \
-                   --include='*.yml' \
-                   --include='*.kql' \
-                   --exclude-dir='.git' \
-                   --exclude-dir='site' \
-                   --exclude-dir='site-docs' \
-                   --exclude-dir='.github' \
-                   --exclude-dir='research' \
-                   --exclude-dir='files' \
-                   --exclude='AGENTS.md' \
-                   --exclude='CLAUDE.md' \
-                   --exclude='SECURITY.md' \
-                   --exclude='THREAT-MODEL.md' \
-                   --exclude='CHANGELOG.md' \
-                   --exclude='*/CHANGELOG.md' \
-                   '\bAzure AD\b' . || true)
-          # Path-based exclusion: ALG ralph-config intentionally preserves the legacy
-          # connector name as a runtime hint to agents. grep's --exclude only matches
-          # basename so we filter the full path here.
-          if [ -n "$hits" ]; then
-            hits=$(echo "$hits" | grep -vE 'agent-365-lifecycle-governance/\.ralph-config\.json' || true)
-          fi
-          if [ -n "$hits" ]; then
-            echo "::error::'Azure AD' found outside CHANGELOG/instruction files (use 'Microsoft Entra ID'):"
-            echo "$hits"
-            exit 1
-          fi
-          echo "OK: no 'Azure AD' references outside CHANGELOG/instructions."
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate language rules
+        run: python scripts/validate-language-rules.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,23 @@ python scripts/build-manifest.py --check    # exits non-zero if drift exists
 python -m mkdocs build --strict             # fail on any broken link or missing nav file
 ```
 
+### Documentation autonomy protection
+
+`.github/branch-protection.json` is the committed source of truth for the
+proposed `main` protection policy. Do not apply it implicitly from repository
+automation. The required `docs-autonomy` context runs on every pull request:
+documentation-relevant changes receive manifest/schema and generator
+determinism checks, language and commercial-scope validation, and a strict
+MkDocs build; non-documentation changes receive an explicit shim-success so
+the context cannot deadlock a PR. External network link checks are
+intentionally not required.
+
+Run the pinned contract tests with:
+
+```bash
+python -m pytest scripts/tests/test_docs_autonomy_protection.py
+```
+
 ## Validation Commands
 
 ```bash

--- a/scripts/docs_autonomy.py
+++ b/scripts/docs_autonomy.py
@@ -1,0 +1,85 @@
+"""Classify whether a change requires the documentation autonomy gate."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import PurePosixPath
+
+
+DOC_EXTENSIONS = {".json", ".md", ".mdx", ".yaml", ".yml"}
+DOC_PREFIXES = (
+    ".github/instructions/",
+    ".github/workflows/",
+    "site-docs/",
+)
+DOC_FILES = {
+    ".github/branch-protection.json",
+    "mkdocs.yml",
+    "requirements-docs.txt",
+    "solutions.json",
+    "scripts/build-manifest.py",
+    "scripts/docs_autonomy.py",
+    "scripts/lint-optionset-values.py",
+    "scripts/lint-version-drift.py",
+    "scripts/manifest.schema.json",
+    "scripts/sync-agent-md-versions.py",
+    "scripts/validate-language-rules.py",
+    "scripts/verify_commercial_scope.py",
+}
+
+
+def normalize_path(value: str) -> str:
+    """Return a repository-relative POSIX path."""
+    return value.strip().replace("\\", "/").removeprefix("./")
+
+
+def is_docs_relevant(value: str) -> bool:
+    """Return whether a changed path affects documentation validation."""
+    path = normalize_path(value)
+    if not path:
+        return False
+    if path in DOC_FILES or path.startswith(DOC_PREFIXES):
+        return True
+    pure_path = PurePosixPath(path)
+    return pure_path.suffix.lower() in DOC_EXTENSIONS or "docs" in pure_path.parts
+
+
+def classify_paths(paths: list[str]) -> list[str]:
+    """Return normalized documentation-relevant paths."""
+    return sorted({normalize_path(path) for path in paths if is_docs_relevant(path)})
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--changed-files",
+        required=True,
+        help="Newline-delimited repository-relative changed paths.",
+    )
+    parser.add_argument(
+        "--github-output",
+        help="Optional GitHub Actions output file.",
+    )
+    args = parser.parse_args()
+
+    with open(args.changed_files, encoding="utf-8") as handle:
+        matches = classify_paths(handle.read().splitlines())
+
+    docs = "true" if matches else "false"
+    print(f"docs={docs}")
+    if matches:
+        print("Documentation-relevant changes:")
+        for path in matches:
+            print(f"  {path}")
+    else:
+        print("No documentation-relevant changes; required context will shim-success.")
+
+    if args.github_output:
+        with open(args.github_output, "a", encoding="utf-8") as handle:
+            handle.write(f"docs={docs}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_docs_autonomy_protection.py
+++ b/scripts/tests/test_docs_autonomy_protection.py
@@ -1,0 +1,130 @@
+"""Pin the proposed branch protection and docs-autonomy trigger contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "docs-autonomy.yml"
+PROTECTION = ROOT / ".github" / "branch-protection.json"
+EXPECTED_CONTEXTS = [
+    "Analyze csharp",
+    "Analyze python",
+    "commercial-scope",
+    "dependency-review",
+    "docs-autonomy",
+    "gitleaks",
+    "language-rules",
+    "lint",
+    "manifest-check",
+    "powershell",
+    "python",
+]
+REQUIRED_WORKFLOWS = {
+    "Analyze csharp": ("codeql.yml", "name: Analyze ${{ matrix.language }}"),
+    "Analyze python": ("codeql.yml", "name: Analyze ${{ matrix.language }}"),
+    "commercial-scope": ("commercial-scope.yml", "  commercial-scope:"),
+    "dependency-review": ("dependency-review.yml", "  dependency-review:"),
+    "docs-autonomy": ("docs-autonomy.yml", "  docs-autonomy:"),
+    "gitleaks": ("gitleaks.yml", "  gitleaks:"),
+    "language-rules": ("language-rules.yml", "  language-rules:"),
+    "lint": ("odata-lint.yml", "  lint:"),
+    "manifest-check": ("manifest-check.yml", "  manifest-check:"),
+    "powershell": ("ci-powershell.yml", "  powershell:"),
+    "python": ("ci-python.yml", "  python:"),
+}
+
+
+def load_docs_autonomy_module():
+    """Load the path classifier without requiring scripts to be a package."""
+    path = ROOT / "scripts" / "docs_autonomy.py"
+    spec = importlib.util.spec_from_file_location("docs_autonomy", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def pull_request_block(workflow: str) -> str:
+    """Return the pull_request trigger block."""
+    match = re.search(r"(?m)^  pull_request:\n((?:^    .*\n|^\s*$)*)", workflow)
+    assert match, "workflow must declare a pull_request trigger"
+    return match.group(1)
+
+
+def test_branch_protection_is_strict_without_human_review_or_destructive_writes():
+    policy = json.loads(PROTECTION.read_text(encoding="utf-8"))
+
+    assert policy["required_status_checks"] == {
+        "strict": True,
+        "contexts": EXPECTED_CONTEXTS,
+    }
+    assert policy["enforce_admins"] is True
+    assert policy["required_pull_request_reviews"] is None
+    assert policy["restrictions"] is None
+    assert policy["allow_force_pushes"] is False
+    assert policy["allow_deletions"] is False
+
+
+def test_required_docs_context_runs_on_every_pull_request_without_path_filters():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    trigger = pull_request_block(workflow)
+
+    assert "  docs-autonomy:\n" in workflow
+    assert "paths:" not in trigger
+    assert "paths-ignore:" not in trigger
+    assert "Non-doc shim" in workflow
+    assert "steps.changes.outputs.docs != 'true'" in workflow
+    assert "--diff-filter=ACDMRT" in workflow
+
+
+def test_every_required_context_runs_on_every_pull_request_without_path_filters():
+    assert set(REQUIRED_WORKFLOWS) == set(EXPECTED_CONTEXTS)
+    for context, (filename, job_marker) in REQUIRED_WORKFLOWS.items():
+        workflow = (
+            ROOT / ".github" / "workflows" / filename
+        ).read_text(encoding="utf-8")
+        trigger = pull_request_block(workflow)
+        assert job_marker in workflow, f"{context} job marker changed"
+        assert "paths:" not in trigger, f"{context} is path-filtered"
+        assert "paths-ignore:" not in trigger, f"{context} is path-filtered"
+
+
+def test_classifier_selects_docs_and_manifest_changes_but_shims_code_only_changes():
+    classifier = load_docs_autonomy_module()
+
+    assert classifier.classify_paths(
+        [
+            "README.md",
+            "agent-intake/docs/setup.md",
+            "agent-intake/manifest.yaml",
+            "site-docs/removed-page.md",
+            "site-docs/stylesheets/extra.css",
+        ]
+    ) == [
+        "README.md",
+        "agent-intake/docs/setup.md",
+        "agent-intake/manifest.yaml",
+        "site-docs/removed-page.md",
+        "site-docs/stylesheets/extra.css",
+    ]
+    assert classifier.classify_paths(
+        [
+            "agent-intake/scripts/deploy.py",
+            "message-center-monitor/scripts/Invoke-Monitor.ps1",
+        ]
+    ) == []
+
+
+def test_path_filtered_optional_jobs_are_not_required():
+    policy = json.loads(PROTECTION.read_text(encoding="utf-8"))
+    contexts = policy["required_status_checks"]["contexts"]
+
+    assert "dotnet build (Debug)" not in contexts
+    assert "dotnet build (Release)" not in contexts
+    assert "agent-intake-python" not in contexts
+    assert "heartbeat" not in contexts

--- a/scripts/validate-language-rules.py
+++ b/scripts/validate-language-rules.py
@@ -1,0 +1,98 @@
+"""Validate repository content against the FSI language rules."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path, PurePosixPath
+
+
+COMPLIANCE_PATTERNS = re.compile(
+    r"ensures compliance|guarantees compliance|guarantee compliance|"
+    r"will prevent|eliminates risk"
+)
+LEGACY_PRODUCT_NAME = re.compile(r"\bAzure" + r" AD\b")
+COMPLIANCE_SUFFIXES = {".md"}
+PRODUCT_SUFFIXES = {".json", ".kql", ".md", ".ps1", ".psm1", ".py", ".yaml", ".yml"}
+EXCLUDED_DIRS = {".git", ".github", "research", "site", "site-docs"}
+EXCLUDED_PRODUCT_DIRS = EXCLUDED_DIRS | {"files"}
+EXCLUDED_NAMES = {
+    "AGENTS.md",
+    "CHANGELOG.md",
+    "CLAUDE.md",
+    "SECURITY.md",
+    "THREAT-MODEL.md",
+}
+LEGACY_NAME_EXCEPTION = "agent-365-lifecycle-governance/.ralph-config.json"
+
+
+def tracked_files(root: Path) -> list[Path]:
+    """Return tracked repository files."""
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    )
+    names = result.stdout.decode("utf-8", "replace").split("\0")
+    return [root / name for name in names if name]
+
+
+def is_excluded(relative: PurePosixPath, product_rule: bool = False) -> bool:
+    """Return whether a path is exempt from a language rule."""
+    excluded_dirs = EXCLUDED_PRODUCT_DIRS if product_rule else EXCLUDED_DIRS
+    return relative.name in EXCLUDED_NAMES or any(
+        part in excluded_dirs for part in relative.parts
+    )
+
+
+def scan(root: Path) -> list[str]:
+    """Return formatted language-rule violations."""
+    violations: list[str] = []
+    for path in tracked_files(root):
+        if not path.is_file():
+            continue
+        relative = PurePosixPath(path.relative_to(root).as_posix())
+        suffix = path.suffix.lower()
+        if suffix not in COMPLIANCE_SUFFIXES | PRODUCT_SUFFIXES:
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        if suffix in COMPLIANCE_SUFFIXES and not is_excluded(relative):
+            for line_number, line in enumerate(lines, start=1):
+                if COMPLIANCE_PATTERNS.search(line):
+                    violations.append(
+                        f"{relative}:{line_number}: prohibited compliance phrase: "
+                        f"{line.strip()[:160]}"
+                    )
+
+        if (
+            suffix in PRODUCT_SUFFIXES
+            and relative.as_posix() != LEGACY_NAME_EXCEPTION
+            and not is_excluded(relative, product_rule=True)
+        ):
+            for line_number, line in enumerate(lines, start=1):
+                if LEGACY_PRODUCT_NAME.search(line):
+                    violations.append(
+                        f"{relative}:{line_number}: use 'Microsoft Entra ID': "
+                        f"{line.strip()[:160]}"
+                    )
+    return violations
+
+
+def main() -> int:
+    root = Path.cwd().resolve()
+    violations = scan(root)
+    if violations:
+        print("Language rule violations found:")
+        for violation in violations:
+            print(f"  {violation}")
+        return 1
+    print("OK: repository content satisfies the FSI language rules.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- commit a strict, admin-enforced branch-protection source of truth without human review or destructive branch operations
- add an always-running docs-autonomy context that validates docs/manifests/language and shim-succeeds for non-doc PRs
- remove required-context path deadlocks and duplicate agent-intake check names
- pin policy and trigger behavior with tests

## Validation
- 757 pytest passed, 2 skipped
- docs autonomy validation passed against FSI-AgentGov v1.4.0 controls
- strict MkDocs build passed
- independent code review found no remaining significant issues

No live branch protection settings are changed by this PR.