### PR TITLE
feat: add lab-harness public foundation

### DIFF
--- a/.github/workflows/lab-harness-ci.yml
+++ b/.github/workflows/lab-harness-ci.yml
@@ -1,0 +1,124 @@
+name: Lab Harness CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'lab-harness/**'
+      - '.github/workflows/lab-harness-ci.yml'
+      - '.gitignore'
+  push:
+    branches: [main]
+    paths:
+      - 'lab-harness/**'
+      - '.github/workflows/lab-harness-ci.yml'
+      - '.gitignore'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lab-harness:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.16.0'
+          cache: 'npm'
+          cache-dependency-path: 'lab-harness/playwright/package-lock.json'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PowerShell modules
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force
+          Install-Module -Name Pester -Scope CurrentUser -Force -SkipPublisherCheck
+
+      - name: Install Playwright package dependencies
+        run: npm ci --prefix lab-harness/playwright
+
+      - name: Run Node tests
+        run: npm --prefix lab-harness/playwright run test:node
+
+      - name: Parse-check lab harness PowerShell
+        shell: pwsh
+        run: |
+          $errors = 0
+          Get-ChildItem -Path lab-harness -Recurse -Include *.ps1,*.psm1 | ForEach-Object {
+            $tokens = $null
+            $parseErrors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$parseErrors) | Out-Null
+            if ($parseErrors.Count -gt 0) {
+              Write-Host "PARSE FAIL: $($_.FullName)"
+              $parseErrors | ForEach-Object { Write-Host "  $_" }
+              $errors++
+            }
+          }
+          if ($errors -gt 0) { exit 1 }
+
+      - name: PSScriptAnalyzer (lab-harness only)
+        shell: pwsh
+        run: |
+          $targets = @(
+            'lab-harness/runtime',
+            'lab-harness/evidence',
+            'lab-harness/tests'
+          )
+          $results = @()
+          foreach ($target in $targets) {
+            $results += Invoke-ScriptAnalyzer -Path $target -Recurse -Severity Error,Warning -Settings ./PSScriptAnalyzerSettings.psd1
+          }
+          $results | Format-Table -AutoSize
+          if ($results.Count -gt 0) {
+            Write-Host "::error::PSScriptAnalyzer reported $($results.Count) finding(s) in lab-harness."
+            exit 1
+          }
+
+      - name: Run Pester tests (lab-harness only)
+        shell: pwsh
+        run: |
+          $cfg = New-PesterConfiguration
+          $cfg.Run.Path = @('lab-harness/tests')
+          $cfg.Run.Exit = $true
+          $cfg.Output.Verbosity = 'Detailed'
+          Invoke-Pester -Configuration $cfg
+
+      - name: Validate plan and evidence schemas/templates
+        run: |
+          python -m pip install --upgrade pip
+          pip install jsonschema pyyaml
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from jsonschema import validate
+          import yaml
+
+          root = Path('lab-harness')
+          schemas = {
+              "plan": json.loads((root / 'schema' / 'solution-validation-plan.schema.json').read_text(encoding='utf-8')),
+              "ownership": json.loads((root / 'schema' / 'ownership-cleanup.schema.json').read_text(encoding='utf-8')),
+              "summary": json.loads((root / 'schema' / 'evidence-summary.schema.json').read_text(encoding='utf-8')),
+          }
+          plan = json.loads((root / 'templates' / 'audit-compliance-manager.plan.json').read_text(encoding='utf-8'))
+          ownership = json.loads((root / 'templates' / 'audit-compliance-manager.ownership.json').read_text(encoding='utf-8'))
+          summary = json.loads((root / 'templates' / 'evidence-summary.example.json').read_text(encoding='utf-8'))
+
+          validate(instance=plan, schema=schemas["plan"])
+          validate(instance=ownership, schema=schemas["ownership"])
+          validate(instance=summary, schema=schemas["summary"])
+
+          workflow_path = Path('.github/workflows/lab-harness-ci.yml')
+          yaml.safe_load(workflow_path.read_text(encoding='utf-8'))
+
+          print('Schema/template validation passed.')
+          PY

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,18 @@ GAP_ANALYSIS_REPORT.md
 **/lab/.deploy-runtime/
 **/lab/*.log
 
+# Lab harness local runtime artifacts
+lab-harness/playwright/.auth/
+lab-harness/playwright/playwright-report/
+lab-harness/playwright/test-results/
+lab-harness/playwright/downloads/
+lab-harness/playwright/screenshots/
+lab-harness/playwright/traces/
+lab-harness/evidence/raw/
+lab-harness/evidence/redacted/
+lab-harness/evidence/manifests/*.generated.json
+lab-harness/tests/.tmp-*/
+
 # MkDocs build output
 site/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased] - 2026-Q3 — Lab harness foundation
+
+### Added
+- Added `lab-harness/` one-time shared foundation for typed validation planning, runtime orchestration, Playwright portal smoke scaffolding, and evidence redaction/manifest tooling.
+- Added schemas and templates for plan validation (`solution-validation-plan.schema.json`), ownership/cleanup (`ownership-cleanup.schema.json`), and summary metadata (`evidence-summary.schema.json`) plus static `audit-compliance-manager` PlanOnly example manifests.
+- Added isolated Playwright package (`lab-harness/playwright`) with pinned dependencies, environment-driven `storageState`, fail-fast auth/account-picker helpers, and Node-based unit tests for config/helper behavior.
+- Added Pester tests for path confinement, adapter allow-list enforcement, PlanOnly semantics, redaction coverage, manifest hashing, and gitignore protections.
+- Added GitHub-hosted-only CI workflow `.github/workflows/lab-harness-ci.yml` scoped to harness files with no secret usage.
+
+### Changed
+- Hardened root `.gitignore` for lab harness auth state, transient Playwright outputs, and local evidence artifact folders while preserving tracked templates/schemas.
+
+### Notes
+- This foundation is public code only and does not provision tenant resources by itself.
+- Live `workflow_dispatch` and persistent self-hosted runner execution remain in private follow-up work under `judep_microsoft/FSI-AgentGov-Lab`.
+
+---
+
 ## [v1.7.2] - 2026-Q3 — CI fix (no functional change)
 
 Patch release ensuring the Release pipeline (CycloneDX SBOM + Sigstore signing + Dataverse plugin DLL) ships with the v1.7.0 H-item wave content. Tag v1.7.0 and v1.7.1 are unchanged but their Release pipeline runs failed with `MSB1008: Only one project can be specified` due to Git Bash on Windows runners stripping the leading `/` from `/p:TreatWarningsAsErrors=true` (MSYS path conversion). v1.7.2 ships the same content as v1.7.1 plus the workflow fix (`-p:` form), so the Release pipeline now succeeds and attaches signed plugin + SBOM artifacts.

--- a/lab-harness/README.md
+++ b/lab-harness/README.md
@@ -1,0 +1,76 @@
+# Lab Harness Foundation (Public Surface Only)
+
+This directory provides a reusable validation harness foundation for US commercial-cloud Microsoft 365 solution testing in `judeper/FSI-AgentGov-Solutions`.
+
+## Public-code / private-execution boundary
+
+- **Public repository scope:** reusable harness code, schemas, templates, docs, and GitHub-hosted CI checks.
+- **Private execution scope:** live tenant execution, persistent lab runner registration, and dispatch workflows in `judep_microsoft/FSI-AgentGov-Lab`.
+- **Hard boundary:** this public repository must not target self-hosted runners.
+
+## Threat model and design assumptions
+
+Primary risks addressed by this foundation:
+
+1. **Unsafe execution inputs** (path traversal, arbitrary command execution).
+2. **Cross-channel confusion** (runtime checks and portal/UI checks mixed without controls).
+3. **Evidence leakage** (UPNs, GUIDs, webhook tokens, tenant URLs in committed artifacts).
+4. **Overstated assurance** (claiming live success when only static validation ran).
+
+Countermeasures implemented:
+
+- Typed plan schema plus adapter allow-list.
+- Explicit repo/evidence-root path confinement.
+- Separate `runtime` and `playwright` channels.
+- PlanOnly mode with explicit non-live outcome.
+- Redaction and SHA-256 manifest tooling for sanitized evidence handling.
+
+## What Playwright can and cannot prove
+
+Playwright in this harness is intentionally limited to **portal/UI state**:
+
+- Can prove page reachability, visible auth prompts, account-picker interruption, and basic portal rendering checks.
+- Cannot prove API behavior, backend policy enforcement, Dataverse correctness, or runtime control outcomes.
+- Runtime/API validation remains PowerShell/Pester/Python/pytest/direct REST in the `runtime` channel.
+
+## Usage model
+
+### Local foundation validation
+
+Run the harness validation entry point in PlanOnly mode:
+
+```powershell
+pwsh .\lab-harness\runtime\Invoke-LabValidation.ps1 `
+  -Solution audit-compliance-manager `
+  -PlanPath .\lab-harness\templates\audit-compliance-manager.plan.json `
+  -PlanOnly `
+  -EvidenceRoot C:\FSI-Lab-Evidence
+```
+
+### Private-runner/live dispatch
+
+- Live `workflow_dispatch` execution belongs in the private lab repository.
+- This public repository intentionally excludes self-hosted runner workflows.
+- The persistent lab runner must remain registered only to the private lab repository.
+
+## Evidence lifecycle
+
+1. Generate raw artifacts outside Git (for example, `C:\FSI-Lab-Evidence`).
+2. Redact sensitive content via `lab-harness/evidence/Invoke-LabEvidenceRedaction.ps1`.
+3. Generate a SHA-256 manifest via `lab-harness/evidence/New-LabEvidenceManifest.ps1`.
+4. Publish only sanitized summary metadata and approved report outputs.
+5. Clean up raw artifacts per ownership/cleanup manifest guidance.
+
+Raw evidence is never committed to this repository.
+
+## Redaction and rollback guidance
+
+- Redaction targets: UPNs, tenant names/domains, GUIDs, environment URLs, webhook signatures, token-shaped values.
+- Rollback/deletion: remove `lab-harness/` files from git history through normal revert if needed; this foundation does not provision tenant resources by itself.
+- Optional `studio-video-factory` integration is evidence capture only and is not a runtime dependency.
+
+## Scope and assurance language
+
+- This content targets **US commercial-cloud Microsoft 365**.
+- Any non-commercial cloud applicability should be validated independently with Microsoft.
+- This harness **supports compliance with** evidence and validation workflows but does not guarantee legal or regulatory outcomes.

--- a/lab-harness/evidence/Invoke-LabEvidenceRedaction.ps1
+++ b/lab-harness/evidence/Invoke-LabEvidenceRedaction.ps1
@@ -1,0 +1,40 @@
+#Requires -Version 7.2
+<#
+.SYNOPSIS
+Redacts sensitive identifiers from a text evidence artifact.
+
+.DESCRIPTION
+Applies deterministic regex-based redaction for common sensitive patterns including
+UPNs, tenant domains, GUIDs, Dynamics environment URLs, webhook URLs, and token-like
+query parameter values.
+
+.PARAMETER InputPath
+Path to a source evidence file to redact.
+
+.PARAMETER OutputPath
+Path where the redacted output file is written.
+
+.EXAMPLE
+pwsh .\lab-harness\evidence\Invoke-LabEvidenceRedaction.ps1 `
+  -InputPath .\lab-harness\evidence\raw\sample.txt `
+  -OutputPath .\lab-harness\evidence\redacted\sample.redacted.txt
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$InputPath,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$OutputPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$modulePath = Join-Path -Path $PSScriptRoot -ChildPath 'LabHarness.Evidence.psm1'
+Import-Module -Name $modulePath -Force
+
+$result = Invoke-LabEvidenceRedaction -InputPath $InputPath -OutputPath $OutputPath
+Write-Output ($result | ConvertTo-Json -Depth 6)

--- a/lab-harness/evidence/LabHarness.Evidence.psm1
+++ b/lab-harness/evidence/LabHarness.Evidence.psm1
@@ -10,7 +10,11 @@ function Get-LabRedactionPatterns {
         @{ Name = 'tenant-domain'; Pattern = '(?i)\b[a-z0-9\-]+\.onmicrosoft\.com\b'; Replacement = '<redacted:tenant-domain>' },
         @{ Name = 'guid'; Pattern = '(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b'; Replacement = '<redacted:guid>' },
         @{ Name = 'dynamics-url'; Pattern = '(?i)https:\/\/[a-z0-9\-]+\.crm\d*\.dynamics\.com'; Replacement = '<redacted:dynamics-url>' },
+        @{ Name = 'sharepoint-url'; Pattern = '(?i)https:\/\/[a-z0-9\-]+\.sharepoint\.com(?:\/[^\s"''<>]*)?'; Replacement = '<redacted:sharepoint-url>' },
         @{ Name = 'webhook-url'; Pattern = '(?i)https:\/\/[^ \r\n]*webhook[^ \r\n]*'; Replacement = '<redacted:webhook-url>' },
+        @{ Name = 'authorization-bearer'; Pattern = '(?im)(authorization\s*[:=]\s*bearer\s+)[a-z0-9._~+\/=\-]+'; Replacement = '$1<redacted:token>' },
+        @{ Name = 'jwt'; Pattern = '(?i)\beyJ[a-z0-9_-]{5,}\.[a-z0-9_-]{5,}\.[a-z0-9_-]{5,}\b'; Replacement = '<redacted:jwt>' },
+        @{ Name = 'connection-secret'; Pattern = '(?i)(AccountKey|SharedAccessSignature)\s*=\s*[^;\s]+'; Replacement = '$1=<redacted:token>' },
         @{ Name = 'token-parameter'; Pattern = '(?i)(sig|code|token|access_token|client_secret)=([^&\s]+)'; Replacement = '$1=<redacted:token>' }
     )
 }

--- a/lab-harness/evidence/LabHarness.Evidence.psm1
+++ b/lab-harness/evidence/LabHarness.Evidence.psm1
@@ -1,0 +1,116 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-LabRedactionPatterns {
+    [CmdletBinding()]
+    param()
+
+    @(
+        @{ Name = 'upn'; Pattern = '(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b'; Replacement = '<redacted:upn>' },
+        @{ Name = 'tenant-domain'; Pattern = '(?i)\b[a-z0-9\-]+\.onmicrosoft\.com\b'; Replacement = '<redacted:tenant-domain>' },
+        @{ Name = 'guid'; Pattern = '(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b'; Replacement = '<redacted:guid>' },
+        @{ Name = 'dynamics-url'; Pattern = '(?i)https:\/\/[a-z0-9\-]+\.crm\d*\.dynamics\.com'; Replacement = '<redacted:dynamics-url>' },
+        @{ Name = 'webhook-url'; Pattern = '(?i)https:\/\/[^ \r\n]*webhook[^ \r\n]*'; Replacement = '<redacted:webhook-url>' },
+        @{ Name = 'token-parameter'; Pattern = '(?i)(sig|code|token|access_token|client_secret)=([^&\s]+)'; Replacement = '$1=<redacted:token>' }
+    )
+}
+
+function Invoke-LabEvidenceRedaction {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$InputPath,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$OutputPath
+    )
+
+    $source = Get-Content -LiteralPath $InputPath -Raw
+    $redacted = $source
+    $counts = @{}
+
+    foreach ($definition in (Get-LabRedactionPatterns)) {
+        $before = $redacted
+        $redacted = [System.Text.RegularExpressions.Regex]::Replace($redacted, $definition.Pattern, $definition.Replacement)
+        $matchCount = [System.Text.RegularExpressions.Regex]::Matches($before, $definition.Pattern).Count
+        $counts[$definition.Name] = $matchCount
+    }
+
+    $outputDirectory = Split-Path -Path $OutputPath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($outputDirectory)) {
+        New-Item -Path $outputDirectory -ItemType Directory -Force | Out-Null
+    }
+
+    Set-Content -LiteralPath $OutputPath -Value $redacted -Encoding utf8NoBOM
+
+    return @{
+        InputPath   = $InputPath
+        OutputPath  = $OutputPath
+        Replacements = $counts
+    }
+}
+
+function New-LabEvidenceManifest {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ArtifactRoot,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ManifestPath
+    )
+
+    $resolvedArtifactRoot = [System.IO.Path]::GetFullPath($ArtifactRoot)
+    $resolvedManifestPath = [System.IO.Path]::GetFullPath($ManifestPath)
+
+    if (-not (Test-Path -LiteralPath $resolvedArtifactRoot)) {
+        throw [System.IO.DirectoryNotFoundException]::new("Artifact root '$resolvedArtifactRoot' was not found.")
+    }
+
+    $manifestDirectory = Split-Path -Path $resolvedManifestPath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($manifestDirectory)) {
+        New-Item -Path $manifestDirectory -ItemType Directory -Force | Out-Null
+    }
+
+    $files = Get-ChildItem -Path $resolvedArtifactRoot -Recurse -File | Where-Object {
+        $_.FullName -ne $resolvedManifestPath
+    }
+
+    $entries = @(
+        foreach ($file in $files) {
+            $hash = Get-FileHash -Path $file.FullName -Algorithm SHA256
+            @{
+                path      = [System.IO.Path]::GetRelativePath($resolvedArtifactRoot, $file.FullName)
+                sizeBytes = [int64]$file.Length
+                sha256    = $hash.Hash.ToLowerInvariant()
+            }
+        }
+    )
+
+    $manifest = @{
+        schemaVersion = '1.0.0'
+        generatedAtUtc = [System.DateTimeOffset]::UtcNow.ToString('o')
+        artifactRoot = $resolvedArtifactRoot
+        files = $entries
+    }
+
+    $manifestJson = $manifest | ConvertTo-Json -Depth 8
+    if ($PSCmdlet.ShouldProcess($resolvedManifestPath, 'Write SHA-256 evidence manifest')) {
+        Set-Content -LiteralPath $resolvedManifestPath -Value $manifestJson -Encoding utf8NoBOM
+    }
+
+    return @{
+        ManifestPath = $resolvedManifestPath
+        FileCount = $entries.Count
+    }
+}
+
+Export-ModuleMember -Function @(
+    'Get-LabRedactionPatterns',
+    'Invoke-LabEvidenceRedaction',
+    'New-LabEvidenceManifest'
+)

--- a/lab-harness/evidence/New-LabEvidenceManifest.ps1
+++ b/lab-harness/evidence/New-LabEvidenceManifest.ps1
@@ -1,0 +1,39 @@
+#Requires -Version 7.2
+<#
+.SYNOPSIS
+Generates a SHA-256 manifest for redacted evidence artifacts.
+
+.DESCRIPTION
+Enumerates files under the provided artifact root and writes a JSON manifest with
+relative paths, byte lengths, and SHA-256 digests.
+
+.PARAMETER ArtifactRoot
+Root directory containing redacted artifacts.
+
+.PARAMETER ManifestPath
+Output path for the generated manifest JSON document.
+
+.EXAMPLE
+pwsh .\lab-harness\evidence\New-LabEvidenceManifest.ps1 `
+  -ArtifactRoot .\lab-harness\evidence\redacted `
+  -ManifestPath .\lab-harness\evidence\manifests\redacted.manifest.json
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ArtifactRoot,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ManifestPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$modulePath = Join-Path -Path $PSScriptRoot -ChildPath 'LabHarness.Evidence.psm1'
+Import-Module -Name $modulePath -Force
+
+$result = New-LabEvidenceManifest -ArtifactRoot $ArtifactRoot -ManifestPath $ManifestPath
+Write-Output ($result | ConvertTo-Json -Depth 6)

--- a/lab-harness/playwright/.gitignore
+++ b/lab-harness/playwright/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+.auth/
+playwright-report/
+test-results/
+downloads/
+screenshots/
+traces/
+*.har

--- a/lab-harness/playwright/package-lock.json
+++ b/lab-harness/playwright/package-lock.json
@@ -1,0 +1,622 @@
+{
+  "name": "@fsi/lab-harness-playwright",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@fsi/lab-harness-playwright",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "1.54.2",
+        "tsx": "4.20.4"
+      },
+      "engines": {
+        "node": ">=20 <23"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha1-gPy+NhMOWLdnBRHoiLjoiiWe12w=",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha1-MAcSEB9/UPHSYnoWLm4JsQm2dno=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha1-iqSWX40KeYLcIXNL9mATI6Ztp1I=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha1-h9+ycWEgK9yVjvSLthsJx1j67hY=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha1-eRl4mOwf90XSHAceHHzDyALwwf0=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha1-FGQAqFYhM/RcTS6tzzfd0JcYB54=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha1-HF+bpyBuFY/SskxZ+i0si7R8oP4=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha1-6mMfSja+qsS5J5+g/MbKKerusrM=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha1-RSzWayCTLQi9xTqLYcDjC69DSLk=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha1-4QZrzlg5TxsRQd7shVel8KIvWXc=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha1-sk+KzEW89UGSx/LzvhtT5lUer+A=",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha1-+c//p/yDIlcfvEyLMmjK8VvYGtA=",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha1-V1oUvXRkT/q4ka3H1+YNJ1KW8s0=",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha1-dbmccKlfvV93OddpK+/mBgFZGGk=",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha1-LjJZRAMhpE553fdTXDJQV9qHXNY=",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha1-F2dsq7/lko2lsqDW311YzQjbJmM=",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha1-BYN3VoXKggZtBMNQfwlSTTzXowY=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha1-8ExAScsuJS/paxb+2Q9wdGsT9KQ=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha1-d9oNCg2CbXySHuo9QCklSLJYoHY=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha1-Ypb1hnrt7yioGyKrIAnHhqlS3M0=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha1-+NIzAzYOJ7Fs8GWyO7/0PBQUJnk=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha1-SeC3aHRKOSS+DX/ZfdbOmykj2I0=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha1-pu19Z3jWflKMgfsWWyP0kRubE9Y=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha1-msFMN44bZTrxfQjn0840yu9YcyM=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha1-kYlC3LuzXMFPyjmvuRteaj0Scmc=",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha1-m9rYF2vngRrRSNH4dyNZBB9GxsU=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha1-/w0eXY4m8yWK5lNk4tTRAXaSawc=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha1-l6HQQfSrAML84vg40rmWmi0ql6U=",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha1-mF2FxSqZA4ZCgMzCRI1BP78e/tg=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha1-4kNauy2zqWonb4rMOtoahbWH3/M=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha1-c8xRBvGexrk3GQhgPWGn8XHr2PA=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha1-YWs9wsVwVrVYjDHN9LPWTbEzcg8=",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.4",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tsx/-/tsx-4.20.4.tgz",
+      "integrity": "sha1-P88lXbyIJr3eKCDxz/R+MQdcHTA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    }
+  }
+}

--- a/lab-harness/playwright/package.json
+++ b/lab-harness/playwright/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@fsi/lab-harness-playwright",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20 <23"
+  },
+  "scripts": {
+    "test:node": "tsx --test tests/node/**/*.test.ts",
+    "test:smoke": "playwright test tests/portal-smoke.spec.ts"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.54.2",
+    "tsx": "4.20.4"
+  }
+}

--- a/lab-harness/playwright/playwright.config.ts
+++ b/lab-harness/playwright/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@playwright/test';
+import { resolveStorageStatePath } from './src/config-helpers';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 45_000,
+  fullyParallel: false,
+  retries: 0,
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: 'playwright-report' }]
+  ],
+  outputDir: 'test-results',
+  use: {
+    baseURL: process.env.LAB_PORTAL_BASE_URL?.trim(),
+    storageState: resolveStorageStatePath(process.env),
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure'
+  }
+});

--- a/lab-harness/playwright/src/config-helpers.ts
+++ b/lab-harness/playwright/src/config-helpers.ts
@@ -1,0 +1,9 @@
+export function resolveStorageStatePath(environment: NodeJS.ProcessEnv): string | undefined {
+  const candidate = environment.PW_STORAGE_STATE_PATH?.trim();
+  return candidate ? candidate : undefined;
+}
+
+export function resolvePortalBaseUrl(environment: NodeJS.ProcessEnv): string | undefined {
+  const candidate = environment.LAB_PORTAL_BASE_URL?.trim();
+  return candidate ? candidate : undefined;
+}

--- a/lab-harness/playwright/src/portal-helpers.ts
+++ b/lab-harness/playwright/src/portal-helpers.ts
@@ -12,7 +12,26 @@ export function detectInteractiveAuthSignal(content: string): string | undefined
   return interactiveSignals.find((signal) => normalized.includes(signal));
 }
 
+export function detectInteractiveAuthUrl(url: string): string | undefined {
+  const parsed = new URL(url);
+  const host = parsed.hostname.toLowerCase();
+  if (host === 'login.microsoftonline.com' || host === 'login.live.com') {
+    return host;
+  }
+  if (parsed.pathname.toLowerCase().includes('/oauth2/authorize')) {
+    return parsed.pathname;
+  }
+  return undefined;
+}
+
 export async function assertNoInteractiveAuth(page: Page): Promise<void> {
+  const authUrl = detectInteractiveAuthUrl(page.url());
+  if (authUrl) {
+    throw new Error(
+      `Interactive authentication URL detected (${authUrl}). Refresh auth storage state before running smoke checks.`
+    );
+  }
+
   const title = await page.title();
   const bodyText = await page.locator('body').innerText();
   const signal = detectInteractiveAuthSignal(`${title}\n${bodyText}`);

--- a/lab-harness/playwright/src/portal-helpers.ts
+++ b/lab-harness/playwright/src/portal-helpers.ts
@@ -1,0 +1,24 @@
+import type { Page } from '@playwright/test';
+
+const interactiveSignals = [
+  'pick an account',
+  'use another account',
+  'sign in to your account',
+  'enter password'
+];
+
+export function detectInteractiveAuthSignal(content: string): string | undefined {
+  const normalized = content.toLowerCase();
+  return interactiveSignals.find((signal) => normalized.includes(signal));
+}
+
+export async function assertNoInteractiveAuth(page: Page): Promise<void> {
+  const title = await page.title();
+  const bodyText = await page.locator('body').innerText();
+  const signal = detectInteractiveAuthSignal(`${title}\n${bodyText}`);
+  if (signal) {
+    throw new Error(
+      `Interactive authentication prompt detected (${signal}). Update LAB_PORTAL_BASE_URL or refresh auth storage state before running smoke checks.`
+    );
+  }
+}

--- a/lab-harness/playwright/tests/node/config-and-helpers.test.ts
+++ b/lab-harness/playwright/tests/node/config-and-helpers.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+import { pathToFileURL } from 'node:url';
+import { detectInteractiveAuthSignal } from '../../src/portal-helpers';
+import { resolvePortalBaseUrl, resolveStorageStatePath } from '../../src/config-helpers';
+
+test('resolveStorageStatePath returns undefined when not configured', () => {
+  const result = resolveStorageStatePath({});
+  assert.equal(result, undefined);
+});
+
+test('resolveStorageStatePath trims configured value', () => {
+  const result = resolveStorageStatePath({ PW_STORAGE_STATE_PATH: '  .auth/state.json  ' });
+  assert.equal(result, '.auth/state.json');
+});
+
+test('resolvePortalBaseUrl trims configured value', () => {
+  const result = resolvePortalBaseUrl({ LAB_PORTAL_BASE_URL: '  https://contoso.crm.dynamics.com  ' });
+  assert.equal(result, 'https://contoso.crm.dynamics.com');
+});
+
+test('detectInteractiveAuthSignal identifies account picker and sign-in prompts', () => {
+  assert.equal(detectInteractiveAuthSignal('Pick an account to continue'), 'pick an account');
+  assert.equal(detectInteractiveAuthSignal('Please Sign in to your account now'), 'sign in to your account');
+  assert.equal(detectInteractiveAuthSignal('Portal dashboard ready'), undefined);
+});
+
+test('playwright config reads storage state from environment', async () => {
+  process.env.PW_STORAGE_STATE_PATH = '.auth/state.json';
+  const configPath = pathToFileURL(path.resolve('playwright.config.ts')).href + `?cacheBust=${Date.now()}`;
+  const loaded = await import(configPath);
+  assert.equal(loaded.default.use.storageState, '.auth/state.json');
+  delete process.env.PW_STORAGE_STATE_PATH;
+});

--- a/lab-harness/playwright/tests/node/config-and-helpers.test.ts
+++ b/lab-harness/playwright/tests/node/config-and-helpers.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import path from 'node:path';
 import test from 'node:test';
 import { pathToFileURL } from 'node:url';
-import { detectInteractiveAuthSignal } from '../../src/portal-helpers';
+import { detectInteractiveAuthSignal, detectInteractiveAuthUrl } from '../../src/portal-helpers';
 import { resolvePortalBaseUrl, resolveStorageStatePath } from '../../src/config-helpers';
 
 test('resolveStorageStatePath returns undefined when not configured', () => {
@@ -24,6 +24,18 @@ test('detectInteractiveAuthSignal identifies account picker and sign-in prompts'
   assert.equal(detectInteractiveAuthSignal('Pick an account to continue'), 'pick an account');
   assert.equal(detectInteractiveAuthSignal('Please Sign in to your account now'), 'sign in to your account');
   assert.equal(detectInteractiveAuthSignal('Portal dashboard ready'), undefined);
+});
+
+test('detectInteractiveAuthUrl identifies Microsoft sign-in hosts and authorize paths', () => {
+  assert.equal(
+    detectInteractiveAuthUrl('https://login.microsoftonline.com/common/oauth2/v2.0/authorize'),
+    'login.microsoftonline.com'
+  );
+  assert.equal(
+    detectInteractiveAuthUrl('https://portal.example.com/oauth2/authorize?client_id=test'),
+    '/oauth2/authorize'
+  );
+  assert.equal(detectInteractiveAuthUrl('https://make.powerapps.com/environments/test'), undefined);
 });
 
 test('playwright config reads storage state from environment', async () => {

--- a/lab-harness/playwright/tests/portal-smoke.spec.ts
+++ b/lab-harness/playwright/tests/portal-smoke.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@playwright/test';
+import { resolvePortalBaseUrl } from '../src/config-helpers';
+import { assertNoInteractiveAuth } from '../src/portal-helpers';
+
+test('portal smoke template fails fast on interactive auth', async ({ page }) => {
+  const baseUrl = resolvePortalBaseUrl(process.env);
+  test.skip(!baseUrl, 'Set LAB_PORTAL_BASE_URL to run portal smoke checks.');
+
+  await page.goto(baseUrl!, { waitUntil: 'domcontentloaded' });
+  await assertNoInteractiveAuth(page);
+  await expect(page.locator('body')).toBeVisible();
+});

--- a/lab-harness/runtime/Invoke-LabValidation.ps1
+++ b/lab-harness/runtime/Invoke-LabValidation.ps1
@@ -1,0 +1,87 @@
+#Requires -Version 7.2
+<#
+.SYNOPSIS
+Validates and optionally executes a typed lab harness plan.
+
+.DESCRIPTION
+Loads a typed validation plan, validates it against schema and ownership manifest contracts,
+confines all referenced paths to approved roots, and executes only allow-listed adapters.
+When -PlanOnly is set, no runtime or Playwright checks are executed.
+
+.PARAMETER Solution
+Canonical solution slug matching the plan and ownership manifest.
+
+.PARAMETER PlanPath
+Path to the solution validation plan JSON document.
+
+.PARAMETER PlanOnly
+Validates all plan artifacts without executing runtime or Playwright steps.
+
+.PARAMETER EvidenceRoot
+Root path for sanitized summary output. Defaults to C:\FSI-Lab-Evidence.
+
+.EXAMPLE
+pwsh .\lab-harness\runtime\Invoke-LabValidation.ps1 `
+  -Solution audit-compliance-manager `
+  -PlanPath .\lab-harness\templates\audit-compliance-manager.plan.json `
+  -PlanOnly `
+  -EvidenceRoot C:\FSI-Lab-Evidence
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[a-z0-9-]+$')]
+    [string]$Solution,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$PlanPath,
+
+    [Parameter()]
+    [switch]$PlanOnly,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]$EvidenceRoot = 'C:\FSI-Lab-Evidence'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$modulePath = Join-Path -Path $PSScriptRoot -ChildPath 'LabHarness.Runtime.psm1'
+Import-Module -Name $modulePath -Force
+
+try {
+    $result = Invoke-LabValidation -Solution $Solution -PlanPath $PlanPath -PlanOnly:$PlanOnly -EvidenceRoot $EvidenceRoot
+    if ($result.Result -eq 'PlanValidatedNotExecuted') {
+        Write-Output ("Plan validated for solution '{0}'. No runtime checks executed. Summary: {1}" -f $Solution, $result.SummaryPath)
+    }
+    elseif ($result.Result -eq 'Failed') {
+        Write-Output ("Validation failed for solution '{0}'. Review sanitized summary: {1}" -f $Solution, $result.SummaryPath)
+    }
+    else {
+        Write-Output ("Validation completed for solution '{0}'. Summary: {1}" -f $Solution, $result.SummaryPath)
+    }
+
+    exit $result.ExitCode
+}
+catch [System.UnauthorizedAccessException] {
+    Write-Error $_
+    exit 11
+}
+catch [System.IO.InvalidDataException] {
+    Write-Error $_
+    exit 10
+}
+catch [System.IO.FileNotFoundException] {
+    Write-Error $_
+    exit 10
+}
+catch [System.InvalidOperationException] {
+    Write-Error $_
+    exit 20
+}
+catch {
+    Write-Error $_
+    exit 30
+}

--- a/lab-harness/runtime/LabHarness.Runtime.psm1
+++ b/lab-harness/runtime/LabHarness.Runtime.psm1
@@ -1,0 +1,431 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-LabValidationAdapterCatalog {
+    [CmdletBinding()]
+    param()
+
+    @{
+        'runtime.powershell.pester' = @{
+            channel           = 'runtime'
+            requiredFields    = @('testPaths')
+            allowedProperties = @('id', 'channel', 'adapter', 'description', 'testPaths')
+        }
+        'runtime.python.pytest'     = @{
+            channel           = 'runtime'
+            requiredFields    = @('testPaths')
+            allowedProperties = @('id', 'channel', 'adapter', 'description', 'testPaths')
+        }
+        'runtime.powershell.script' = @{
+            channel           = 'runtime'
+            requiredFields    = @('scriptPath')
+            allowedProperties = @('id', 'channel', 'adapter', 'description', 'scriptPath', 'parameters')
+        }
+        'playwright.portal-smoke'   = @{
+            channel           = 'playwright'
+            requiredFields    = @('packagePath', 'specPath')
+            allowedProperties = @('id', 'channel', 'adapter', 'description', 'packagePath', 'specPath')
+        }
+    }
+}
+
+function Get-LabHarnessRepoRoot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$StartPath
+    )
+
+    $current = [System.IO.Path]::GetFullPath($StartPath)
+    while ($true) {
+        if (Test-Path -LiteralPath (Join-Path -Path $current -ChildPath '.git')) {
+            return $current
+        }
+
+        $parent = [System.IO.Directory]::GetParent($current)
+        if ($null -eq $parent) {
+            throw [System.IO.InvalidDataException]::new("Could not locate repository root from '$StartPath'.")
+        }
+
+        $current = $parent.FullName
+    }
+}
+
+function Resolve-LabConstrainedPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$BasePath,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]$AllowedRoots,
+
+        [Parameter()]
+        [switch]$MustExist
+    )
+
+    $candidate = $Path
+    if (-not [System.IO.Path]::IsPathRooted($candidate)) {
+        $candidate = Join-Path -Path $BasePath -ChildPath $candidate
+    }
+
+    $resolvedPath = [System.IO.Path]::GetFullPath($candidate)
+    $isAllowed = $false
+
+    foreach ($root in $AllowedRoots) {
+        $resolvedRoot = [System.IO.Path]::GetFullPath($root)
+        $rootWithSeparator = $resolvedRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+        if ($resolvedPath.Equals($resolvedRoot, [System.StringComparison]::OrdinalIgnoreCase) -or
+            $resolvedPath.StartsWith($rootWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $isAllowed = $true
+            break
+        }
+    }
+
+    if (-not $isAllowed) {
+        throw [System.UnauthorizedAccessException]::new("Path '$Path' resolves outside allowed roots.")
+    }
+
+    if ($MustExist -and -not (Test-Path -LiteralPath $resolvedPath)) {
+        throw [System.IO.FileNotFoundException]::new("Path '$resolvedPath' does not exist.")
+    }
+
+    return $resolvedPath
+}
+
+function Assert-LabValidationStepModel {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$Step,
+
+        [Parameter(Mandatory)]
+        [hashtable]$Catalog
+    )
+
+    if (-not $Catalog.ContainsKey($Step.adapter)) {
+        throw [System.IO.InvalidDataException]::new("Adapter '$($Step.adapter)' is not in the allow-list.")
+    }
+
+    $adapterConfig = $Catalog[$Step.adapter]
+    if ($Step.channel -ne $adapterConfig.channel) {
+        throw [System.IO.InvalidDataException]::new("Step '$($Step.id)' channel '$($Step.channel)' does not match adapter '$($Step.adapter)'.")
+    }
+
+    $stepProperties = @($Step.Keys)
+    foreach ($requiredField in $adapterConfig.requiredFields) {
+        if (-not $Step.ContainsKey($requiredField)) {
+            throw [System.IO.InvalidDataException]::new("Step '$($Step.id)' missing required field '$requiredField'.")
+        }
+    }
+
+    foreach ($property in $stepProperties) {
+        if ($property -notin $adapterConfig.allowedProperties) {
+            throw [System.IO.InvalidDataException]::new("Step '$($Step.id)' contains unsupported property '$property'.")
+        }
+    }
+}
+
+function Test-LabValidationPlan {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Solution,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$PlanPath,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$RepoRoot,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$EvidenceRoot
+    )
+
+    $schemaRoot = Join-Path -Path $RepoRoot -ChildPath 'lab-harness\schema'
+    $planSchemaPath = Join-Path -Path $schemaRoot -ChildPath 'solution-validation-plan.schema.json'
+    $ownershipSchemaPath = Join-Path -Path $schemaRoot -ChildPath 'ownership-cleanup.schema.json'
+
+    $resolvedPlanPath = Resolve-LabConstrainedPath -Path $PlanPath -BasePath $RepoRoot -AllowedRoots @($RepoRoot, $EvidenceRoot) -MustExist
+    $planJson = Get-Content -LiteralPath $resolvedPlanPath -Raw
+
+    if (-not ($planJson | Test-Json -SchemaFile $planSchemaPath)) {
+        throw [System.IO.InvalidDataException]::new("Plan file '$resolvedPlanPath' failed schema validation.")
+    }
+
+    $plan = ConvertFrom-Json -InputObject $planJson -AsHashtable
+    if ($plan.solution -ne $Solution) {
+        throw [System.IO.InvalidDataException]::new("Plan solution '$($plan.solution)' does not match requested solution '$Solution'.")
+    }
+
+    $resolvedOwnershipPath = Resolve-LabConstrainedPath -Path $plan.ownershipManifestPath -BasePath $RepoRoot -AllowedRoots @($RepoRoot, $EvidenceRoot) -MustExist
+    $ownershipJson = Get-Content -LiteralPath $resolvedOwnershipPath -Raw
+    if (-not ($ownershipJson | Test-Json -SchemaFile $ownershipSchemaPath)) {
+        throw [System.IO.InvalidDataException]::new("Ownership manifest '$resolvedOwnershipPath' failed schema validation.")
+    }
+
+    $ownership = ConvertFrom-Json -InputObject $ownershipJson -AsHashtable
+    if ($ownership.solution -ne $Solution) {
+        throw [System.IO.InvalidDataException]::new("Ownership manifest solution '$($ownership.solution)' does not match requested solution '$Solution'.")
+    }
+
+    $catalog = Get-LabValidationAdapterCatalog
+    $normalizedSteps = @()
+    foreach ($step in $plan.steps) {
+        Assert-LabValidationStepModel -Step $step -Catalog $catalog
+
+        $normalizedStep = @{}
+        foreach ($key in $step.Keys) {
+            $normalizedStep[$key] = $step[$key]
+        }
+
+        switch ($step.adapter) {
+            'runtime.powershell.pester' {
+                $normalizedStep.testPaths = @(
+                    foreach ($pathValue in $step.testPaths) {
+                        Resolve-LabConstrainedPath -Path $pathValue -BasePath $RepoRoot -AllowedRoots @($RepoRoot) -MustExist
+                    }
+                )
+            }
+            'runtime.python.pytest' {
+                $normalizedStep.testPaths = @(
+                    foreach ($pathValue in $step.testPaths) {
+                        Resolve-LabConstrainedPath -Path $pathValue -BasePath $RepoRoot -AllowedRoots @($RepoRoot) -MustExist
+                    }
+                )
+            }
+            'runtime.powershell.script' {
+                $normalizedStep.scriptPath = Resolve-LabConstrainedPath -Path $step.scriptPath -BasePath $RepoRoot -AllowedRoots @($RepoRoot) -MustExist
+            }
+            'playwright.portal-smoke' {
+                $normalizedStep.packagePath = Resolve-LabConstrainedPath -Path $step.packagePath -BasePath $RepoRoot -AllowedRoots @($RepoRoot) -MustExist
+                $normalizedStep.specPath = Resolve-LabConstrainedPath -Path $step.specPath -BasePath $RepoRoot -AllowedRoots @($RepoRoot) -MustExist
+            }
+        }
+
+        $normalizedSteps += $normalizedStep
+    }
+
+    return @{
+        planPath      = $resolvedPlanPath
+        ownershipPath = $resolvedOwnershipPath
+        plan          = $plan
+        ownership     = $ownership
+        steps         = $normalizedSteps
+    }
+}
+
+function Invoke-LabValidationStep {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$Step,
+
+        [Parameter()]
+        [switch]$PlanOnly
+    )
+
+    $start = [System.DateTimeOffset]::UtcNow
+    if ($PlanOnly) {
+        return @{
+            id              = $Step.id
+            channel         = $Step.channel
+            adapter         = $Step.adapter
+            status          = 'not-run-planonly'
+            startedAtUtc    = $start.ToString('o')
+            durationSeconds = 0
+        }
+    }
+
+    switch ($Step.adapter) {
+        'runtime.powershell.pester' {
+            Import-Module -Name Pester -ErrorAction Stop
+            $config = New-PesterConfiguration
+            $config.Run.Path = @($Step.testPaths)
+            $config.Run.Exit = $false
+            $config.Output.Verbosity = 'Detailed'
+            $result = Invoke-Pester -Configuration $config
+            if ($result.FailedCount -gt 0) {
+                throw [System.InvalidOperationException]::new("Pester failed for step '$($Step.id)'.")
+            }
+        }
+        'runtime.python.pytest' {
+            $arguments = @('-m', 'pytest') + @($Step.testPaths)
+            & python @arguments
+            if ($LASTEXITCODE -ne 0) {
+                throw [System.InvalidOperationException]::new("pytest failed for step '$($Step.id)' with exit code $LASTEXITCODE.")
+            }
+        }
+        'runtime.powershell.script' {
+            $arguments = @('-NoProfile', '-File', $Step.scriptPath)
+            if ($Step.ContainsKey('parameters') -and $null -ne $Step.parameters) {
+                foreach ($parameterName in $Step.parameters.Keys) {
+                    $parameterValue = [string]$Step.parameters[$parameterName]
+                    $arguments += @("-$parameterName", $parameterValue)
+                }
+            }
+
+            & pwsh @arguments
+            if ($LASTEXITCODE -ne 0) {
+                throw [System.InvalidOperationException]::new("PowerShell script step '$($Step.id)' failed with exit code $LASTEXITCODE.")
+            }
+        }
+        'playwright.portal-smoke' {
+            $relativeSpecPath = [System.IO.Path]::GetRelativePath($Step.packagePath, $Step.specPath)
+            & npm --prefix $Step.packagePath run test:smoke -- $relativeSpecPath
+            if ($LASTEXITCODE -ne 0) {
+                throw [System.InvalidOperationException]::new("Playwright smoke step '$($Step.id)' failed with exit code $LASTEXITCODE.")
+            }
+        }
+        default {
+            throw [System.IO.InvalidDataException]::new("Unsupported adapter '$($Step.adapter)'.")
+        }
+    }
+
+    $finish = [System.DateTimeOffset]::UtcNow
+    return @{
+        id              = $Step.id
+        channel         = $Step.channel
+        adapter         = $Step.adapter
+        status          = 'succeeded'
+        startedAtUtc    = $start.ToString('o')
+        durationSeconds = [System.Math]::Round(($finish - $start).TotalSeconds, 3)
+    }
+}
+
+function New-LabValidationSummary {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Solution,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$PlanPath,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$OwnershipPath,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$EvidenceRoot,
+
+        [Parameter(Mandatory)]
+        [hashtable[]]$StepResults,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('PlanValidatedNotExecuted', 'Succeeded', 'Failed')]
+        [string]$Result,
+
+        [Parameter(Mandatory)]
+        [int]$ExitCode
+    )
+
+    $summaryDirectory = Join-Path -Path $EvidenceRoot -ChildPath 'summary'
+    New-Item -Path $summaryDirectory -ItemType Directory -Force | Out-Null
+    $summaryPath = Join-Path -Path $summaryDirectory -ChildPath ("{0}-summary.json" -f $Solution)
+
+    $summary = @{
+        schemaVersion      = '1.0.0'
+        generatedAtUtc     = [System.DateTimeOffset]::UtcNow.ToString('o')
+        solution           = $Solution
+        planPath           = $PlanPath
+        ownershipManifest  = $OwnershipPath
+        executionMode      = if ($Result -eq 'PlanValidatedNotExecuted') { 'PlanOnly' } else { 'Execute' }
+        result             = $Result
+        exitCode           = $ExitCode
+        steps              = $StepResults
+    }
+
+    $summaryJson = $summary | ConvertTo-Json -Depth 8
+    if ($PSCmdlet.ShouldProcess($summaryPath, 'Write sanitized validation summary')) {
+        Set-Content -LiteralPath $summaryPath -Value $summaryJson -Encoding utf8NoBOM
+    }
+    return $summaryPath
+}
+
+function Invoke-LabValidation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Solution,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$PlanPath,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$EvidenceRoot,
+
+        [Parameter()]
+        [switch]$PlanOnly
+    )
+
+    $repoRoot = Get-LabHarnessRepoRoot -StartPath (Join-Path -Path $PSScriptRoot -ChildPath '..')
+    $resolvedEvidenceRoot = Resolve-LabConstrainedPath -Path $EvidenceRoot -BasePath $repoRoot -AllowedRoots @($repoRoot, $EvidenceRoot)
+    New-Item -Path $resolvedEvidenceRoot -ItemType Directory -Force | Out-Null
+
+    $validated = Test-LabValidationPlan -Solution $Solution -PlanPath $PlanPath -RepoRoot $repoRoot -EvidenceRoot $resolvedEvidenceRoot
+    $stepResults = @()
+
+    $resultName = if ($PlanOnly) { 'PlanValidatedNotExecuted' } else { 'Succeeded' }
+    $exitCode = if ($PlanOnly) { 2 } else { 0 }
+
+    foreach ($step in $validated.steps) {
+        try {
+            $stepResults += Invoke-LabValidationStep -Step $step -PlanOnly:$PlanOnly
+        }
+        catch [System.Exception] {
+            $stepResults += @{
+                id              = $step.id
+                channel         = $step.channel
+                adapter         = $step.adapter
+                status          = 'failed'
+                startedAtUtc    = [System.DateTimeOffset]::UtcNow.ToString('o')
+                durationSeconds = 0
+            }
+            $resultName = 'Failed'
+            $exitCode = 20
+            break
+        }
+    }
+
+    $summaryPath = New-LabValidationSummary `
+        -Solution $Solution `
+        -PlanPath $validated.planPath `
+        -OwnershipPath $validated.ownershipPath `
+        -EvidenceRoot $resolvedEvidenceRoot `
+        -StepResults $stepResults `
+        -Result $resultName `
+        -ExitCode $exitCode
+
+    return @{
+        ExitCode    = $exitCode
+        Result      = $resultName
+        SummaryPath = $summaryPath
+        StepResults = $stepResults
+    }
+}
+
+Export-ModuleMember -Function @(
+    'Get-LabValidationAdapterCatalog',
+    'Get-LabHarnessRepoRoot',
+    'Resolve-LabConstrainedPath',
+    'Test-LabValidationPlan',
+    'Invoke-LabValidation'
+)

--- a/lab-harness/schema/evidence-summary.schema.json
+++ b/lab-harness/schema/evidence-summary.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://judeper.github.io/FSI-AgentGov-Solutions/lab-harness/schema/evidence-summary.schema.json",
+  "title": "Lab Harness Evidence Summary",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "generatedAtUtc",
+    "solution",
+    "executionMode",
+    "result",
+    "exitCode",
+    "steps"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "generatedAtUtc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "solution": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "executionMode": {
+      "type": "string",
+      "enum": [
+        "PlanOnly",
+        "Execute"
+      ]
+    },
+    "result": {
+      "type": "string",
+      "enum": [
+        "PlanValidatedNotExecuted",
+        "Succeeded",
+        "Failed"
+      ]
+    },
+    "exitCode": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "planPath": {
+      "type": "string"
+    },
+    "ownershipManifest": {
+      "type": "string"
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "channel",
+          "adapter",
+          "status",
+          "startedAtUtc",
+          "durationSeconds"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string" },
+          "channel": { "type": "string", "enum": [ "runtime", "playwright" ] },
+          "adapter": { "type": "string" },
+          "status": { "type": "string" },
+          "startedAtUtc": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "durationSeconds": {
+            "type": "number",
+            "minimum": 0
+          }
+        }
+      }
+    }
+  }
+}

--- a/lab-harness/schema/ownership-cleanup.schema.json
+++ b/lab-harness/schema/ownership-cleanup.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://judeper.github.io/FSI-AgentGov-Solutions/lab-harness/schema/ownership-cleanup.schema.json",
+  "title": "Resource Ownership and Cleanup Manifest",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "solution",
+    "resourceOwner",
+    "cleanupActions",
+    "rollbackActions"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "solution": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "resourceOwner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "cleanupActions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "resourceType",
+          "location",
+          "cleanupAdapter"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "resourceType": {
+            "type": "string",
+            "enum": [
+              "filesystem",
+              "service-config",
+              "human-review"
+            ]
+          },
+          "location": {
+            "type": "string",
+            "minLength": 1
+          },
+          "cleanupAdapter": {
+            "type": "string",
+            "enum": [
+              "manual-review-then-delete",
+              "scripted-delete",
+              "retention-policy"
+            ]
+          },
+          "notes": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "rollbackActions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "description"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "description": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/lab-harness/schema/solution-validation-plan.schema.json
+++ b/lab-harness/schema/solution-validation-plan.schema.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://judeper.github.io/FSI-AgentGov-Solutions/lab-harness/schema/solution-validation-plan.schema.json",
+  "title": "Solution Validation Plan",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "solution",
+    "ownershipManifestPath",
+    "steps"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "solution": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "ownershipManifestPath": {
+      "type": "string",
+      "minLength": 1
+    },
+    "notes": {
+      "type": "string"
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "title": "Runtime PowerShell Pester Step",
+            "type": "object",
+            "required": [
+              "id",
+              "channel",
+              "adapter",
+              "testPaths"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "description": { "type": "string" },
+              "channel": { "type": "string", "const": "runtime" },
+              "adapter": { "type": "string", "const": "runtime.powershell.pester" },
+              "testPaths": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 1 }
+              }
+            }
+          },
+          {
+            "title": "Runtime Python Pytest Step",
+            "type": "object",
+            "required": [
+              "id",
+              "channel",
+              "adapter",
+              "testPaths"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "description": { "type": "string" },
+              "channel": { "type": "string", "const": "runtime" },
+              "adapter": { "type": "string", "const": "runtime.python.pytest" },
+              "testPaths": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 1 }
+              }
+            }
+          },
+          {
+            "title": "Runtime PowerShell Script Step",
+            "type": "object",
+            "required": [
+              "id",
+              "channel",
+              "adapter",
+              "scriptPath"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "description": { "type": "string" },
+              "channel": { "type": "string", "const": "runtime" },
+              "adapter": { "type": "string", "const": "runtime.powershell.script" },
+              "scriptPath": { "type": "string", "minLength": 1 },
+              "parameters": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": [
+                    "string",
+                    "number",
+                    "integer",
+                    "boolean"
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "title": "Playwright Portal Smoke Step",
+            "type": "object",
+            "required": [
+              "id",
+              "channel",
+              "adapter",
+              "packagePath",
+              "specPath"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "description": { "type": "string" },
+              "channel": { "type": "string", "const": "playwright" },
+              "adapter": { "type": "string", "const": "playwright.portal-smoke" },
+              "packagePath": { "type": "string", "minLength": 1 },
+              "specPath": { "type": "string", "minLength": 1 }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/lab-harness/templates/audit-compliance-manager.ownership.json
+++ b/lab-harness/templates/audit-compliance-manager.ownership.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "1.0.0",
+  "solution": "audit-compliance-manager",
+  "resourceOwner": "Power Platform Admin",
+  "cleanupActions": [
+    {
+      "id": "delete-redacted-artifacts-after-retention-window",
+      "resourceType": "filesystem",
+      "location": "lab-harness/evidence/redacted",
+      "cleanupAdapter": "manual-review-then-delete",
+      "notes": "Review and retain only approved sanitized artifacts before deletion."
+    },
+    {
+      "id": "delete-generated-summary-metadata",
+      "resourceType": "filesystem",
+      "location": "lab-harness/evidence/summary",
+      "cleanupAdapter": "scripted-delete",
+      "notes": "Delete generated run summaries as part of lab cleanup."
+    }
+  ],
+  "rollbackActions": [
+    {
+      "id": "revert-lab-harness-foundation-commit",
+      "description": "Use git revert for the foundation commit if rollback is required."
+    },
+    {
+      "id": "remove-local-evidence-root",
+      "description": "Delete non-git evidence folders (for example C:\\FSI-Lab-Evidence) through local runbook steps."
+    }
+  ]
+}

--- a/lab-harness/templates/audit-compliance-manager.plan.json
+++ b/lab-harness/templates/audit-compliance-manager.plan.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "1.0.0",
+  "solution": "audit-compliance-manager",
+  "ownershipManifestPath": "lab-harness/templates/audit-compliance-manager.ownership.json",
+  "notes": "Static PlanOnly example for foundation validation. Contains no private tenant values.",
+  "steps": [
+    {
+      "id": "acm-runtime-pester-validators",
+      "channel": "runtime",
+      "adapter": "runtime.powershell.pester",
+      "description": "Validate ACM PowerShell unit coverage via existing Pester tests.",
+      "testPaths": [
+        "audit-compliance-manager/scripts/Validators.Tests.ps1"
+      ]
+    },
+    {
+      "id": "acm-playwright-portal-smoke-template",
+      "channel": "playwright",
+      "adapter": "playwright.portal-smoke",
+      "description": "Template smoke step. Runtime values come from environment variables only.",
+      "packagePath": "lab-harness/playwright",
+      "specPath": "lab-harness/playwright/tests/portal-smoke.spec.ts"
+    }
+  ]
+}

--- a/lab-harness/templates/evidence-summary.example.json
+++ b/lab-harness/templates/evidence-summary.example.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "1.0.0",
+  "generatedAtUtc": "2026-07-13T00:00:00Z",
+  "solution": "audit-compliance-manager",
+  "executionMode": "PlanOnly",
+  "result": "PlanValidatedNotExecuted",
+  "exitCode": 2,
+  "planPath": "lab-harness/templates/audit-compliance-manager.plan.json",
+  "ownershipManifest": "lab-harness/templates/audit-compliance-manager.ownership.json",
+  "steps": [
+    {
+      "id": "acm-runtime-pester-validators",
+      "channel": "runtime",
+      "adapter": "runtime.powershell.pester",
+      "status": "not-run-planonly",
+      "startedAtUtc": "2026-07-13T00:00:00Z",
+      "durationSeconds": 0
+    }
+  ]
+}

--- a/lab-harness/templates/evidence-summary.template.md
+++ b/lab-harness/templates/evidence-summary.template.md
@@ -1,0 +1,21 @@
+# Lab Validation Summary
+
+- **Solution:** {{solution}}
+- **Execution mode:** {{executionMode}}
+- **Result:** {{result}}
+- **Exit code:** {{exitCode}}
+- **Generated (UTC):** {{generatedAtUtc}}
+- **Plan path:** {{planPath}}
+- **Ownership manifest:** {{ownershipManifest}}
+
+## Steps
+
+{{#steps}}
+- `{{id}}` · channel=`{{channel}}` · adapter=`{{adapter}}` · status=`{{status}}` · duration={{durationSeconds}}s
+{{/steps}}
+
+## Notes
+
+- This summary is metadata-only and should not include raw tenant evidence.
+- Runtime/API validation and portal/UI validation are separate channels by design.
+- PlanOnly runs validate structure without claiming live execution success.

--- a/lab-harness/tests/Evidence.Tests.ps1
+++ b/lab-harness/tests/Evidence.Tests.ps1
@@ -28,6 +28,10 @@ Tenant: contoso.onmicrosoft.com
 Environment: https://contoso.crm.dynamics.com
 RecordId: 123e4567-e89b-12d3-a456-426614174000
 Webhook: https://workflow.contoso.com/webhook/endpoint?sig=abc123
+SharePoint: https://contoso.sharepoint.com/sites/AgentGov/Shared%20Documents
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signaturevalue
+Storage: AccountKey=topsecretvalue;EndpointSuffix=core.windows.net
+EvidenceHash: bb90e859a61d8e65f77b3092bc74e29d38581a785c2847980c7fe9c68dbe84d3
 '@ | Set-Content -LiteralPath $inputPath -Encoding utf8NoBOM
 
         $result = Invoke-LabEvidenceRedaction -InputPath $inputPath -OutputPath $outputPath
@@ -36,8 +40,15 @@ Webhook: https://workflow.contoso.com/webhook/endpoint?sig=abc123
         $content | Should -Not -Match 'alex\.smith@contoso\.com'
         $content | Should -Not -Match 'contoso\.onmicrosoft\.com'
         $content | Should -Not -Match '123e4567-e89b-12d3-a456-426614174000'
+        $content | Should -Not -Match 'contoso\.sharepoint\.com'
+        $content | Should -Not -Match 'eyJhbGci'
+        $content | Should -Not -Match 'topsecretvalue'
         $content | Should -Match '<redacted:upn>'
         $content | Should -Match '<redacted:webhook-url>'
+        $content | Should -Match '<redacted:sharepoint-url>'
+        $content | Should -Match 'Authorization: Bearer <redacted:token>'
+        $content | Should -Match 'AccountKey=<redacted:token>'
+        $content | Should -Match 'bb90e859a61d8e65f77b3092bc74e29d38581a785c2847980c7fe9c68dbe84d3'
         $result.Replacements.upn | Should -BeGreaterThan 0
     }
 

--- a/lab-harness/tests/Evidence.Tests.ps1
+++ b/lab-harness/tests/Evidence.Tests.ps1
@@ -1,0 +1,64 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\evidence\LabHarness.Evidence.psm1'
+Import-Module -Name $modulePath -Force
+
+Describe 'Lab evidence tooling' {
+    BeforeAll {
+        $workspace = Join-Path -Path $PSScriptRoot -ChildPath '.tmp-evidence-tests'
+        if (Test-Path -LiteralPath $workspace) {
+            Remove-Item -LiteralPath $workspace -Recurse -Force
+        }
+        New-Item -Path $workspace -ItemType Directory | Out-Null
+    }
+
+    AfterAll {
+        if (Test-Path -LiteralPath $workspace) {
+            Remove-Item -LiteralPath $workspace -Recurse -Force
+        }
+    }
+
+    It 'redacts sensitive values from evidence content' {
+        $inputPath = Join-Path -Path $workspace -ChildPath 'sample.txt'
+        $outputPath = Join-Path -Path $workspace -ChildPath 'sample.redacted.txt'
+        @'
+User: alex.smith@contoso.com
+Tenant: contoso.onmicrosoft.com
+Environment: https://contoso.crm.dynamics.com
+RecordId: 123e4567-e89b-12d3-a456-426614174000
+Webhook: https://workflow.contoso.com/webhook/endpoint?sig=abc123
+'@ | Set-Content -LiteralPath $inputPath -Encoding utf8NoBOM
+
+        $result = Invoke-LabEvidenceRedaction -InputPath $inputPath -OutputPath $outputPath
+        $content = Get-Content -LiteralPath $outputPath -Raw
+
+        $content | Should -Not -Match 'alex\.smith@contoso\.com'
+        $content | Should -Not -Match 'contoso\.onmicrosoft\.com'
+        $content | Should -Not -Match '123e4567-e89b-12d3-a456-426614174000'
+        $content | Should -Match '<redacted:upn>'
+        $content | Should -Match '<redacted:webhook-url>'
+        $result.Replacements.upn | Should -BeGreaterThan 0
+    }
+
+    It 'generates deterministic sha256 manifest entries' {
+        $artifactRoot = Join-Path -Path $workspace -ChildPath 'artifacts'
+        $manifestPath = Join-Path -Path $workspace -ChildPath 'manifest.json'
+        New-Item -Path $artifactRoot -ItemType Directory | Out-Null
+        Set-Content -LiteralPath (Join-Path -Path $artifactRoot -ChildPath 'a.txt') -Value 'alpha' -Encoding utf8NoBOM
+        Set-Content -LiteralPath (Join-Path -Path $artifactRoot -ChildPath 'b.txt') -Value 'beta' -Encoding utf8NoBOM
+
+        $result = New-LabEvidenceManifest -ArtifactRoot $artifactRoot -ManifestPath $manifestPath
+        $result.FileCount | Should -Be 2
+        $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json -AsHashtable
+
+        $entryA = $manifest.files | Where-Object { $_.path -eq 'a.txt' } | Select-Object -First 1
+        $entryB = $manifest.files | Where-Object { $_.path -eq 'b.txt' } | Select-Object -First 1
+
+        $expectedA = (Get-FileHash -Path (Join-Path -Path $artifactRoot -ChildPath 'a.txt') -Algorithm SHA256).Hash.ToLowerInvariant()
+        $expectedB = (Get-FileHash -Path (Join-Path -Path $artifactRoot -ChildPath 'b.txt') -Algorithm SHA256).Hash.ToLowerInvariant()
+
+        $entryA.sha256 | Should -Be $expectedA
+        $entryB.sha256 | Should -Be $expectedB
+    }
+}

--- a/lab-harness/tests/GitIgnore.Tests.ps1
+++ b/lab-harness/tests/GitIgnore.Tests.ps1
@@ -1,0 +1,35 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Lab harness gitignore protections' {
+    BeforeAll {
+        $script:repoRoot = [System.IO.Path]::GetFullPath((Join-Path -Path $PSScriptRoot -ChildPath '..\..'))
+    }
+
+    It 'ignores auth and runtime artifact paths' {
+        $ignoredPaths = @(
+            'lab-harness/playwright/.auth/storageState.json',
+            'lab-harness/playwright/playwright-report/index.html',
+            'lab-harness/playwright/test-results/result.json',
+            'lab-harness/playwright/downloads/file.txt',
+            'lab-harness/evidence/raw/artifact.json'
+        )
+
+        foreach ($pathValue in $ignoredPaths) {
+            & git -C $script:repoRoot check-ignore -q $pathValue
+            $LASTEXITCODE | Should -Be 0
+        }
+    }
+
+    It 'does not ignore committed templates and schemas' {
+        $trackedPaths = @(
+            'lab-harness/templates/audit-compliance-manager.plan.json',
+            'lab-harness/schema/solution-validation-plan.schema.json'
+        )
+
+        foreach ($pathValue in $trackedPaths) {
+            & git -C $script:repoRoot check-ignore -q $pathValue
+            $LASTEXITCODE | Should -Be 1
+        }
+    }
+}

--- a/lab-harness/tests/Runtime.Tests.ps1
+++ b/lab-harness/tests/Runtime.Tests.ps1
@@ -1,0 +1,90 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\runtime\LabHarness.Runtime.psm1'
+Import-Module -Name $modulePath -Force
+
+Describe 'Lab harness runtime foundation' {
+    BeforeAll {
+        $script:repoRoot = (Get-LabHarnessRepoRoot -StartPath (Join-Path -Path $PSScriptRoot -ChildPath '..\runtime'))
+        $script:workspace = Join-Path -Path $PSScriptRoot -ChildPath '.tmp-runtime-tests'
+        if (Test-Path -LiteralPath $script:workspace) {
+            Remove-Item -LiteralPath $script:workspace -Recurse -Force
+        }
+        New-Item -Path $script:workspace -ItemType Directory | Out-Null
+        $script:evidenceRoot = Join-Path -Path $script:workspace -ChildPath 'evidence'
+        New-Item -Path $script:evidenceRoot -ItemType Directory | Out-Null
+    }
+
+    AfterAll {
+        if (Test-Path -LiteralPath $script:workspace) {
+            Remove-Item -LiteralPath $script:workspace -Recurse -Force
+        }
+    }
+
+    It 'rejects path traversal outside allowed roots' {
+        { Resolve-LabConstrainedPath -Path '..\..\Windows\System32' -BasePath $script:repoRoot -AllowedRoots @($script:repoRoot, $script:evidenceRoot) } | Should -Throw
+    }
+
+    It 'enforces typed adapter allow-list during plan validation' {
+        $planPath = Join-Path -Path $script:workspace -ChildPath 'invalid.plan.json'
+        $ownershipPath = Join-Path -Path $script:workspace -ChildPath 'ownership.json'
+        @'
+{
+  "schemaVersion": "1.0.0",
+  "solution": "audit-compliance-manager",
+  "resourceOwner": "Power Platform Admin",
+  "cleanupActions": [
+    {
+      "id": "cleanup",
+      "resourceType": "filesystem",
+      "location": "lab-harness/evidence/redacted",
+      "cleanupAdapter": "manual-review-then-delete"
+    }
+  ],
+  "rollbackActions": [
+    {
+      "id": "rollback",
+      "description": "Rollback action."
+    }
+  ]
+}
+'@ | Set-Content -LiteralPath $ownershipPath -Encoding utf8NoBOM
+
+        @"
+{
+  "schemaVersion": "1.0.0",
+  "solution": "audit-compliance-manager",
+  "ownershipManifestPath": "$([System.IO.Path]::GetRelativePath($script:repoRoot, $ownershipPath).Replace('\','/'))",
+  "steps": [
+    {
+      "id": "invalid",
+      "channel": "runtime",
+      "adapter": "runtime.shell.command",
+      "testPaths": [
+        "audit-compliance-manager/scripts/Validators.Tests.ps1"
+      ]
+    }
+  ]
+}
+"@ | Set-Content -LiteralPath $planPath -Encoding utf8NoBOM
+
+        { Test-LabValidationPlan -Solution 'audit-compliance-manager' -PlanPath $planPath -RepoRoot $script:repoRoot -EvidenceRoot $script:evidenceRoot } | Should -Throw
+    }
+
+    It 'returns plan-only result without executing steps' {
+        $planPath = Join-Path -Path $script:repoRoot -ChildPath 'lab-harness\templates\audit-compliance-manager.plan.json'
+        $result = Invoke-LabValidation -Solution 'audit-compliance-manager' -PlanPath $planPath -PlanOnly -EvidenceRoot $script:evidenceRoot
+
+        $result.ExitCode | Should -Be 2
+        $result.Result | Should -Be 'PlanValidatedNotExecuted'
+        $result.StepResults.Count | Should -BeGreaterThan 0
+        foreach ($step in $result.StepResults) {
+            $step.status | Should -Be 'not-run-planonly'
+        }
+
+        $summary = Get-Content -LiteralPath $result.SummaryPath -Raw | ConvertFrom-Json -AsHashtable
+        $summary.result | Should -Be 'PlanValidatedNotExecuted'
+        $summary.executionMode | Should -Be 'PlanOnly'
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds the one-time **public** lab-harness foundation in `lab-harness/` for reusable validation orchestration, Playwright portal smoke scaffolding, and evidence tooling.

## Public/private boundary
- Public repo scope: typed harness code, schemas, templates, docs, and GitHub-hosted CI only.
- No self-hosted runner workflow is introduced in this public repository.
- Live `workflow_dispatch` execution and persistent runner registration stay in private `judep_microsoft/FSI-AgentGov-Lab` (follow-up wiring after this interface baseline).

## Threat model coverage
- Rejects path traversal and constrains paths to repo/evidence roots.
- Uses allow-listed typed adapters (no arbitrary shell string execution).
- Separates runtime and Playwright channels.
- Adds redaction and SHA-256 evidence-manifest tooling.
- PlanOnly mode explicitly validates structure without claiming live success.

## Tests and validation run
- `npm ci && npm run test:node` in `lab-harness/playwright`
- Pester: `lab-harness/tests` (path confinement, adapter allow-list, PlanOnly semantics, redaction, manifest hashing, gitignore protections)
- PSScriptAnalyzer + parser validation for `lab-harness/runtime`, `lab-harness/evidence`, and `lab-harness/tests`
- Schema/template checks for plan/ownership/summary contracts plus workflow YAML parse
- Repo checks: `python scripts/validate-language-rules.py`, `python scripts/verify_commercial_scope.py`
- `python scripts/build-manifest.py --check` currently reports pre-existing generator drift in unrelated generated docs (not changed by this PR).

## Rollback/deletion behavior
The foundation is revertible by git commit rollback and creates no tenant resources by itself.
