### PR TITLE
docs(coi-testing): sync prerequisites licensing table with corrected README (#339)

### DIFF
--- a/coi-testing/docs/prerequisites.md
+++ b/coi-testing/docs/prerequisites.md
@@ -92,9 +92,9 @@ Dataverse authorization for this runner is based on Dataverse application users 
 
 | Requirement | Purpose |
 |-------------|---------|
-| **Power Platform Premium** | Planned Power Automate or pipeline-driven scheduled test execution |
+| **Power Automate Premium** | Planned Power Automate cloud flows using premium connectors, or pipeline-driven scheduled test execution |
 | **Dataverse capacity** | Storage for test results (`fsi_coitestresults` table) |
-| **Copilot Studio** | Agent API access via Direct Line or Microsoft 365 Agents SDK in a future release |
+| **Copilot Studio (standalone subscription)** | Agent API access over the Direct Line channel or Microsoft 365 Agents SDK in a future release. The Copilot Studio for Teams plan included in select Microsoft 365 subscriptions publishes only to Teams and cannot generate web channel security secrets. |
 
 ## Dataverse Requirements
 


### PR DESCRIPTION
Closes judeper/OceanSquad#339

## Summary

`coi-testing/README.md` and `coi-testing/docs/prerequisites.md` carry the same licensing table. PR #354 corrected only the README, leaving the linked prerequisites doc contradicting it. This brings `prerequisites.md` into agreement.

Both claims were **independently verified against Microsoft Learn before writing** rather than copied from the README. Learn confirms the README on both points.

## Changes

| Line | Before | After |
|------|--------|-------|
| 95 | `Power Platform Premium` | `Power Automate Premium` |
| 97 | `Copilot Studio` | `Copilot Studio (standalone subscription)` + Teams plan limitation |

## Verification against Microsoft Learn

**1. "Power Platform Premium" is not a real SKU — confirmed.**

[Types of Power Automate licenses](https://learn.microsoft.com/en-us/power-platform/admin/power-automate-licensing/types) enumerates the actual SKUs: Power Automate **Premium** (user), **Process**, **Hosted Process** (capacity), **Free**, and **trial**. There is no "Power Platform Premium". Learn states:

> "With a Power Automate Premium user license, users gain the full set of capabilities for cloud and desktop automation including **premium connectors** [...]"

This supports the README's replacement term and its "cloud flows using premium connectors" purpose text.

**2. Copilot Studio Teams plan limitation — confirmed, both halves.**

[Copilot Studio overview](https://learn.microsoft.com/en-us/microsoft-copilot-studio/fundamentals-what-is-copilot-studio) on the Teams plan:

> "If you have the Teams plan, **available in select Microsoft 365 subscriptions**, you can use the Copilot Studio web app to create agents that use classic orchestration and **publish them to Microsoft Teams only**."

[Configure web and Direct Line channel security](https://learn.microsoft.com/en-us/microsoft-copilot-studio/configure-web-security) on the secret limitation:

> "If you have a **Teams-only license, you can't generate secrets to enable secure access**. Secure access tokens are created automatically for you and secure access is enabled by default."

This matters operationally for this solution: the planned Direct Line runner obtains a secret and exchanges it for a token, so a Teams-only license cannot supply what the runner needs.

**Learn does not contradict the README.** No correction was propagated in the other direction.

## Notes for reviewers

- **Non-blocking observation (deliberately out of scope):** for a *service-owned scheduled* flow, Learn describes **Power Automate Process** as the capacity license that permits premium/custom connectors "regardless of the owning or triggering user's license." That may be the more precise fit for an unattended runner than the per-user Premium license. Raising it rather than acting on it, since the issue scoped this to matching the README. Worth a follow-up on both files together if maintainers agree.
- The retirement note that the Copilot Studio **for Teams app** stops creating classic chatbots after June 2026 does not affect this wording — the change describes the Teams **plan**, which Learn still documents in present tense.
- prerequisites.md has no `Last Verified` header, so no date bump applied. Document structure is unchanged, per issue scope.

## Validation

- `python scripts/validate-language-rules.py` → `OK: repository content satisfies the FSI language rules.`
- `python scripts/build-manifest.py --check` → 281 drift, **pre-existing**. Verified identical with the change stashed; `site-docs/solutions/*/` is gitignored and regenerated at build time. This change introduces no drift.
