### PR TITLE
docs(rag-source-validator): re-verify claims, fix Graph permission order [ocean/issue-389]

### DIFF
--- a/rag-source-validator/README.md
+++ b/rag-source-validator/README.md
@@ -11,7 +11,7 @@ coe_function: govern
 > **Version:** v1.3.1
 > **Status:** Live
 > **Validated against framework version:** v1.6.0
-> **Last Verified:** 2026-05-25
+> **Last Verified:** 2026-08-02
 
 Integrity validation for Retrieval-Augmented Generation (RAG) knowledge sources with change detection and audit capabilities.
 
@@ -97,11 +97,11 @@ The recommended production path is a system- or user-assigned managed identity. 
 
 | Identity grant | Scope | Required for |
 |----------------|-------|--------------|
-| **Microsoft Graph application permission `Sites.Read.All`** (or `Files.Read.All`) | Tenant, admin-consented | Reading SharePoint / OneDrive `driveItem` content for hash validation |
+| **Microsoft Graph application permission `Files.Read.All`** (or `Sites.Read.All`) | Tenant, admin-consented | Reading SharePoint / OneDrive `driveItem` content for hash validation |
 | **Dataverse application user with a security role** granting create/read/write on `fsi_knowledgesource`, `fsi_validationresult`, and `fsi_sourcechange` | Target environment | Reading the source registry and writing validation results, source changes, and status updates |
 | **Storage Blob Data Reader** | Target storage account | Azure Blob source access (optional; planned source type) |
 
-> **Permission references:** Downloading `driveItem` content requires a Graph permission such as `Sites.Read.All` or `Files.Read.All` ([Get driveItem content](https://learn.microsoft.com/graph/api/driveitem-get-content)). The managed identity must be registered as a Dataverse [application user associated with a security role](https://learn.microsoft.com/power-apps/developer/data-platform/use-multi-tenant-server-server-authentication#create-an-application-user-associated-with-the-registered-application-in-dataverse) before it can read or write the registry tables.
+> **Permission references:** Downloading `driveItem` content requires a Graph permission such as `Files.Read.All` (least privileged for application permissions) or `Sites.Read.All` ([Get driveItem content](https://learn.microsoft.com/graph/api/driveitem-get-content)). The managed identity must be registered as a Dataverse [application user associated with a security role](https://learn.microsoft.com/power-apps/developer/data-platform/use-multi-tenant-server-server-authentication#create-an-application-user-associated-with-the-registered-application-in-dataverse) before it can read or write the registry tables.
 >
 > The legacy client-secret development fallback uses the same Entra app registration and Dataverse application-user role; it is for local development only (see [Deployment](#deployment)).
 
@@ -131,7 +131,7 @@ The script automatically captures baselines on first run for sources without an 
 ## Deployment
 
 1. Create the Dataverse schema manually in your Power Platform environment (see [Quick Start](#1-deploy-dataverse-schema-manual) for current status)
-2. Grant the Azure-hosted job's managed identity Dataverse access to `fsi_knowledgesource`, `fsi_validationresult`, and `fsi_sourcechange` (via a Dataverse application user and security role), plus the Microsoft Graph application permission `Sites.Read.All` (or `Files.Read.All`) for SharePoint or OneDrive content retrieval
+2. Grant the Azure-hosted job's managed identity Dataverse access to `fsi_knowledgesource`, `fsi_validationresult`, and `fsi_sourcechange` (via a Dataverse application user and security role), plus the Microsoft Graph application permission `Files.Read.All` (or `Sites.Read.All`) for SharePoint or OneDrive content retrieval
 3. Register knowledge sources via the model-driven app or Dataverse API
 4. Run `Invoke-SourceValidation.ps1 -UseManagedIdentity` to capture baselines and validate
 5. Configure scheduled execution via Azure Automation, Azure Functions, or a VM-hosted scheduled job with managed identity enabled


### PR DESCRIPTION
## Summary

Re-verification of `rag-source-validator/README.md` per OceanSquad issue #389 ([judeper/OceanSquad#389](https://github.com/judeper/OceanSquad/issues/389)).

## Claims Re-checked

All Microsoft product/technical claims verified against live Microsoft Learn documentation as of 2026-08-02:

| Claim | Status | Source |
|-------|--------|--------|
| Graph `driveItem` content download API and applicable permissions | ✅ Accurate (ordering corrected — see below) | [Download driveItem content](https://learn.microsoft.com/graph/api/driveitem-get-content) |
| `Files.Read.All` vs `Sites.Read.All` permission scope for Application type | ⚠️ **Drift corrected** | [Download driveItem content — Permissions table](https://learn.microsoft.com/graph/api/driveitem-get-content) |
| Dataverse application user + custom security role pattern | ✅ Accurate | [Use multi-tenant S2S authentication](https://learn.microsoft.com/power-apps/developer/data-platform/use-multi-tenant-server-server-authentication) |
| Copilot Studio knowledge source types (SharePoint, OneDrive, uploaded docs, Dataverse, Copilot connectors, public websites) | ✅ Accurate | [Add unstructured data as knowledge source](https://learn.microsoft.com/microsoft-copilot-studio/knowledge-add-unstructured-data) |
| Copilot Studio OneDrive/SharePoint files stored in Dataverse | ✅ Accurate | [Add unstructured data as knowledge source](https://learn.microsoft.com/microsoft-copilot-studio/knowledge-add-unstructured-data) |
| Microsoft 365 Copilot connectors / `externalItem` schema / ACLs / Microsoft Search grounding | ✅ Accurate (synced connector model) | [Microsoft 365 Copilot connectors overview](https://learn.microsoft.com/graph/connecting-external-content-connectors-overview) |
| Azure AI Search vectorSearch profiles, hybrid query, semantic ranking | ✅ Accurate | [Vector search in Azure AI Search](https://learn.microsoft.com/azure/search/vector-search-overview) |
| Graph delta queries, eTag, cTag for OneDrive/SharePoint change tracking | ✅ Accurate | [Use delta query to track changes](https://learn.microsoft.com/graph/delta-query-overview) |

## Explicit Discrepancies Corrected

**Graph application permission ordering** (3 occurrences):

- **Before:** `Sites.Read.All` (or `Files.Read.All`) — leading with the higher-privileged permission
- **After:** `Files.Read.All` (or `Sites.Read.All`) — correctly leading with the least-privileged application permission

Per current Microsoft Learn docs ([driveItem content permissions table](https://learn.microsoft.com/graph/api/driveitem-get-content)), for **Application** permission type:
- **Least privileged:** `Files.Read.All`
- **Higher privileged:** `Files.ReadWrite.All`, `Sites.Read.All`, `Sites.ReadWrite.All`

The README was incorrectly presenting `Sites.Read.All` as the primary/recommended choice, which violates least-privilege principle. Fixed in: permissions table row, `Permission references` callout, and Deployment step 2.

`Last Verified` updated from `2026-05-25` to `2026-08-02`.

## Validation

| Check | Result |
|-------|--------|
| `python scripts/validate-language-rules.py` | ✅ Pass |
| `python scripts/lint-odata-columns.py` | ✅ Pass (0 violations across 43 solutions) |
| `python scripts/verify_commercial_scope.py` | ✅ Pass |
| `python -m pytest scripts/tests/ -q` | ✅ 106 passed |
| `python scripts/build-manifest.py --check` | ⚠️ Pre-existing failure (gitignored `site-docs/` requires regeneration — unrelated to this change) |

## Sources

- https://learn.microsoft.com/graph/api/driveitem-get-content
- https://learn.microsoft.com/power-apps/developer/data-platform/use-multi-tenant-server-server-authentication
- https://learn.microsoft.com/microsoft-copilot-studio/knowledge-add-unstructured-data
- https://learn.microsoft.com/graph/connecting-external-content-connectors-overview
- https://learn.microsoft.com/azure/search/vector-search-overview
- https://learn.microsoft.com/graph/delta-query-overview