### PR TITLE
docs(copilot-billing-governance): re-verify README technical claims vs Microsoft Learn (issue #411)

### DIFF
--- a/copilot-billing-governance/README.md
+++ b/copilot-billing-governance/README.md
@@ -12,7 +12,7 @@ coe_function: optimize
 > **Status:** Preview
 > **Validated against framework version:** v1.6.0
 > **Upstream Microsoft dependency:** Mixed — Copilot Credits consumption billing from June 16 2026; credit policies Chat-only today
-> **Last Verified:** 2026-06-09
+> **Last Verified:** 2026-08-09
 
 Governance for **Copilot consumption billing** — the two policy objects
 (pay-as-you-go and prepaid credits), a switch-on-pathway entitlement engine,
@@ -39,7 +39,7 @@ CBG reads — rather than re-discovers — the agent dimension from
 
 A focused application of this engine is the **FNF People-Sweep lens**
 (`scripts/Get-FnfPeopleSweepReport.ps1`): it identifies declarative agents with the
-"Reference org chart and profile info" (declarative-manifest `People`) capability that are
+"Reference people in organization" (declarative-manifest `People`) capability that are
 shared with users who hold **no paid Microsoft 365 Copilot license and no PAYG coverage**,
 and reports the blocked users per agent with an explicit coverage-scope statement. For the
 agents whose manifest is not readable by any supported API, the **owner-attestation


### PR DESCRIPTION
## Summary
Re-verifies every Microsoft product/technical claim in `copilot-billing-governance/README.md` against **live** official Microsoft Learn documentation, per OceanSquad issue judeper/OceanSquad#411 (drift scanner flagged the control as 61 days stale, threshold 60).

Technical correctness only — no regulatory/compliance mapping or wording was added, removed, or reinterpreted.

## Claims re-checked
- Pay-as-you-go (PAYG) billing policy: Azure-subscription-backed, two-step (create policy → connect policy) setup, **tenant ceiling of 50** billing policies, budget alerts only (**not a hard stop** — reaching 100% of budget doesn't stop billing; only disconnecting the service does).
- Copilot credit policy: prepaid capacity-pack credits, **tenant ceiling of 10** credit policies, **standalone hard-stop** (Copilot Chat becomes unavailable when a standalone credit policy's prepaid credits are exhausted, until replenishment or pairing with PAYG), currently **Chat-only** (SharePoint agents continue to use PAYG billing).
- Declarative-agent `People` capability: manifest capability name `People` (still correct, confirmed against the declarative-agent manifest schema and knowledge-sources doc).
- Declarative-agent `People` capability **UI label** used by the FNF People-Sweep lens description — **found and corrected** (see Discrepancies).
- Microsoft Graph permissions `User.Read.All` / `Group.Read.All` for reading another user's license/group membership.
- Zero-rating: a Microsoft 365 Copilot–licensed user incurs no extra usage-based-billing charge for extensibility features (Copilot connectors, agents, plugins) — confirmed against the current Copilot extensibility cost-considerations page.
- Work IQ API general availability / consumption-based (Copilot Credits) billing switch date — June 16, 2026.
- `Bing_Chat_Enterprise` service plan name (used as an excluded/confusable plan in entitlement resolution).
- Azure Resource Graph `PowerPlatformResources` table (used by the upstream `copilot-agent-inventory` dependency description).

## Discrepancies found
- **`docs/architecture.md` cross-reference not in scope, but the README's FNF People-Sweep lens description quoted a stale UI label.** The README quoted the Configure-tab toggle for the People knowledge source as `"Reference org chart and profile info"`. Current Microsoft Learn documentation (Add knowledge sources to your declarative agent in Microsoft 365 Copilot) shows the live toggle label is **`"Reference people in organization"`**. Corrected the quoted label in the README; the underlying declarative-manifest capability name (`People`) was already correct and is unchanged.
- No other technical claims had drifted — all other checked items above (PAYG/credit-policy tenant ceilings, hard-stop/budget-alert behavior, Chat-only scope, Graph permissions, zero-rating, Work IQ GA date, service plan name, ARG table name) remain accurate against current Microsoft Learn content.

## Sources
- https://learn.microsoft.com/microsoft-365/copilot/pay-as-you-go/setup
- https://learn.microsoft.com/microsoft-365/commerce/services/pay-as-you-go-budget
- https://learn.microsoft.com/microsoft-365/copilot/pay-as-you-go/copilot-capacity-packs
- https://learn.microsoft.com/microsoft-365/copilot/extensibility/cost-considerations
- https://learn.microsoft.com/microsoft-365/copilot/extensibility/agent-builder-add-knowledge#people-data
- https://learn.microsoft.com/microsoft-365/copilot/extensibility/knowledge-sources#people
- https://learn.microsoft.com/graph/api/user-list-transitivememberof?view=graph-rest-1.0
- https://learn.microsoft.com/entra/identity/users/licensing-service-plan-reference
- https://learn.microsoft.com/partner-center/announcements/2026-june#work-iq-api-and-consumptive-pricing-update
- https://learn.microsoft.com/power-platform/admin/pay-as-you-go-overview
- https://aka.ms/CopilotCredits/LicensingGuide (Microsoft Copilot Credits Guide, August 2026 — used to corroborate the Copilot Studio/Copilot Chat credit-billing relationship)

## Validation performed
- `python scripts/verify_commercial_scope.py` → PASS (no gov/sovereign-cloud content)
- `python scripts/validate-language-rules.py` → PASS (no prohibited compliance-language phrases)
- `python scripts/build-manifest.py` → regenerated derived artifacts; confirmed the only diff from my change was the intended `copilot-billing-governance/README.md` content (no `Last Verified` mirror exists elsewhere for this solution)
- `python scripts/build-manifest.py --check` → **pre-existing, unrelated drift** in `site-docs/index.md` and `site-docs/reference/control-mapping.md` caused by the companion `fsi-agentgov` framework repo's local `controls.json` having moved from 78→79 controls (new control 2.27, renamed 2.6). Verified this drift exists identically with my change stashed out, confirming it is **not caused by this PR**. Those two files were reverted and are not part of this change.
- `python -m pytest copilot-billing-governance/tests/test_cbg_dataverse_logical_names.py -q` → 117 passed

## Task reference
- OceanSquad issue: judeper/OceanSquad#411